### PR TITLE
clean up env.example (fixes #144, #162, #163)

### DIFF
--- a/chimera/splitAndValidateEnvVars.js
+++ b/chimera/splitAndValidateEnvVars.js
@@ -134,7 +134,9 @@ env.livestream += writeVarLine("livestream_FOLDERPATH")
 confirmPath("livestream_FOLDERPATH", true)
 
 writeVarLine("object_ON")
+writeVarLine("object_PORT")
 env.gateway += writeVarLine("object_HOST")
+writeVarLine("object_FULL_URL")
 env.lib += writeVarLine("object_AUTH")
 
 writeVarLine("object_CAMERA_URLS")

--- a/chimera/splitAndValidateEnvVars.js
+++ b/chimera/splitAndValidateEnvVars.js
@@ -134,9 +134,7 @@ env.livestream += writeVarLine("livestream_FOLDERPATH")
 confirmPath("livestream_FOLDERPATH", true)
 
 writeVarLine("object_ON")
-writeVarLine("object_PORT")
 env.gateway += writeVarLine("object_HOST")
-writeVarLine("object_FULL_URL")
 env.lib += writeVarLine("object_AUTH")
 
 writeVarLine("object_CAMERA_URLS")

--- a/env.example
+++ b/env.example
@@ -86,7 +86,9 @@ livestream_CAMERA_URL_1 = Full url with authentication for rtsp stream
 ##################################################################
 
 object_ON = (true | false)  # Docker: false
+object_PORT = Port for object server
 object_HOST = https://object.server.example or http://127.0.0.1:8081
+object_FULL_URL = https://chimera.server.example/object or http://127.0.0.1:8081/object
 object_AUTH = Authorization token to bypass auth for object (keep secret)
 
 object_CAMERA_URLS = Array of strings with HLS stream urls

--- a/env.example
+++ b/env.example
@@ -116,5 +116,5 @@ memory_AUTH_TOKEN = Header token to connect to memory socket
 database_NAME = postgres database name
 database_USER = postgres user
 database_PASSWORD = postgres password
-database_HOST = postgresql://database.domain.example or localhost  # Docker: postgres
+database_HOST = database.domain.example or localhost  # Docker: postgres (bare hostname, no protocol)
 database_PORT = postgres server port

--- a/env.example
+++ b/env.example
@@ -1,39 +1,22 @@
-##################################################################
-#
 # Chimera
-#
-##################################################################
+# *** = optional, leave blank after =
+# FILEPATH = absolute path to a file, FOLDERPATH = absolute path to a folder
+# (a | b) = pick one; HOST vars take no trailing slash
 
-# Note: *** indicates optional field, leave blank after =
-# Note: all FILEPATH variables should be absolute paths to file, FOLDERPATH should be absolute paths to a folder
-# Note: choices like (true | false) indicate multiple choice; pick one of the values separated by "|"
+NODE_ENV = (production | development)
+chimeraInstances = Number of instances for pm2 cluster mode
 
-####    Base Info           ####
-
-NODE_ENV = (production | development) (if you're asking yourself "which one am I supposed to put?" or "what does this mean?", keep this at production)
-chimeraInstances = Number of instances to run pm2 cluster mode (keep it at one if you only want one thread on your CPU)
-
-#####   Camera Information  #####
-
-cameras = Array of camera names as JSON -> Ex: "["front door","backyard","garage"]"
-
-#####   Webhooks and URLs   #####
+cameras = Array of camera names as JSON -> Ex: ["front door","backyard","garage"]
 
 alert_URL = Primary alert webhook url
 admin_alert_URL = Admin alert webhook url
 
-#####   Authorization Info  #####
-
-PRINTPASSWORD = (true | false) (fret if you leave this on in prod)
-SECRETKEY = AUTH SECRET KEY FOR HASHING
+PRINTPASSWORD = (true | false)
+SECRETKEY = Auth secret key for hashing
 
 ##################################################################
-#
 # Gateway
-#
 ##################################################################
-
-#####   Proxy Details  #####
 
 command_PROXY_ON = (true | false)
 schedule_PROXY_ON = (true | false)
@@ -41,39 +24,26 @@ storage_PROXY_ON = (true | false)
 livestream_PROXY_ON = (true | false)
 object_PROXY_ON = (true | false)
 
-#####   Server Information    #####
-
 gateway_ON = (true | false)
-gateway_PORT = Port to run command server for http
-gateway_HOST = https://gateway.server.example or http://127.0.0.1:8080 (no slash at the end pls)
+gateway_PORT = Port to run gateway server for http
+gateway_HOST = https://gateway.server.example or http://127.0.0.1:8080
 
-#####   HTTPS Info     #####
-
-gateway_PORT_SECURE = Port to run command server for https ***
-privateKey_FILEPATH = File path for KEY ***
-certificate_FILEPATH = File path for CERT ***
-
+gateway_PORT_SECURE = Port to run gateway server for https ***
+privateKey_FILEPATH = File path for TLS key ***
+certificate_FILEPATH = File path for TLS cert ***
 gateway_HTTPS_Redirect = (true | false) ***
 
 ##################################################################
-#
 # Command
-#
 ##################################################################
-
-#####   Server Information    #####
 
 command_ON = (true | false)
 command_PORT = Port to run command server for http
-command_HOST = https://command.server.example or http://127.0.0.1:8080 (no slash at the end pls)
+command_HOST = https://command.server.example or http://127.0.0.1:8080
 
 ##################################################################
-#
 # Schedule
-#
 ##################################################################
-
-#####   Server Information  #####
 
 schedule_ON = (true | false)
 schedule_PORT = Port for schedule server
@@ -82,69 +52,53 @@ schedule_HOST = https://schedule.server.example or http://127.0.0.1:8081
 scheduler_AUTH = Authorization token for scheduler server to bypass auth (keep secret)
 
 ##################################################################
-#
-# Storage 
-#
+# Storage
 ##################################################################
-
-#####   Server Information  #####
 
 storage_ON = (true | false)
 storage_PORT = Port for storage server
 storage_HOST = https://storage.server.example or http://127.0.0.1:8081
 
-storage_FOLDERPATH = Base shared file path
-storage_MOTION_CONF_FILEPATH = Motion Conf Path
-storage_MAX_GB = Max storage quota in GB for Data Manager display (e.g. 100)
+storage_FOLDERPATH = Base shared file path  # Docker: /mnt/storage/
+storage_MOTION_CONF_FILEPATH = Motion conf path  # Docker: /etc/motion/motion.conf
+storage_MAX_GB = Max storage quota in GB (reserved for planned GET /storage/usage)
 
-ffmpeg_FILEPATH = FFMPEG executable path
-ffprobe_FILEPATH = FFPROBE executable path
+ffmpeg_FILEPATH = FFMPEG executable path  # Docker: /usr/bin/ffmpeg
+ffprobe_FILEPATH = FFPROBE executable path  # Docker: /usr/bin/ffprobe
 
 ##################################################################
-#
-# Livestream 
-#
+# Livestream
 ##################################################################
-
-#####   Server Information  #####
 
 livestream_ON = (true | false)
 livestream_PORT = Port for livestream server
 livestream_HOST = https://livestream.server.example or http://127.0.0.1:8081
 
-livestream_FOLDERPATH = Base shared folder path
+livestream_FOLDERPATH = Base shared folder path  # Docker: /mnt/storage/
 
 livestream_CAMERA_URL_1 = Full url with authentication for rtsp stream
-# livestream_CAMERA_URL_2 = 
+# livestream_CAMERA_URL_2 =
 # livestream_CAMERA_URL_3 =
-# livestream_CAMERA_URL_4 = ...as many as you need. (consecutive numbers please)
+# livestream_CAMERA_URL_4 = ...as many as you need (consecutive numbers)
 
 ##################################################################
-#
-# Object 
-#
+# Object  (non-Docker / external service — not containerized)
 ##################################################################
 
-object_ON = (true | false) (set false for Docker — object service is not containerized)
-object_PORT = Port for object server
+object_ON = (true | false)  # Docker: false
 object_HOST = https://object.server.example or http://127.0.0.1:8081
-object_FULL_URL = https://chimera.server.example/object or http://127.0.0.1:8081/object
 object_AUTH = Authorization token to bypass auth for object (keep secret)
 
-object_CAMERA_URLS = array of strings with HLS stream urls
-
-object_minimumConfidence = minimum confidence to warrant an alert for people detection
-object_alertUrls = object webhook url array
-
+object_CAMERA_URLS = Array of strings with HLS stream urls
+object_minimumConfidence = Minimum confidence to warrant a people-detection alert
+object_alertUrls = Object webhook url array
 object_headless_ON = (true | false)
-object_browser_FILEPATH = file path to browser for object headless to use
-object_data_FOLDERPATH = folder path to hold temp data 
-object_THROTTLE = multiplier for cpu throttle for headless mode
+object_browser_FILEPATH = File path to browser for object headless
+object_data_FOLDERPATH = Folder path to hold temp data
+object_THROTTLE = CPU throttle multiplier for headless mode
 
 ##################################################################
-#
-# Memory 
-#
+# Memory
 ##################################################################
 
 memory_ON = (true | false)
@@ -154,30 +108,11 @@ memory_HOST = https://memory.socket.example or http://127.0.0.1:8081
 memory_AUTH_TOKEN = Header token to connect to memory socket
 
 ##################################################################
-#
-# Database 
-#
+# Database
 ##################################################################
 
 database_NAME = postgres database name
 database_USER = postgres user
 database_PASSWORD = postgres password
-database_HOST = postgresql://database.domain.example or localhost (note: do not add the port and do not add protocol if domain is LAN machine)
+database_HOST = postgresql://database.domain.example or localhost  # Docker: postgres
 database_PORT = postgres server port
-
-##################################################################
-#
-# Docker Defaults (copy these values as-is for Docker deploys)
-#
-##################################################################
-
-# database_HOST = postgres
-# ffmpeg_FILEPATH = /usr/bin/ffmpeg
-# ffprobe_FILEPATH = /usr/bin/ffprobe
-# storage_FOLDERPATH = /mnt/storage/
-# livestream_FOLDERPATH = /mnt/storage/
-# storage_MOTION_CONF_FILEPATH = /etc/motion/motion.conf
-# object_ON = false
-# storage_MAX_GB = 100
-
-##################################################################


### PR DESCRIPTION
## Summary
- Removed redundant and unused env vars from `env.example`
- Consolidated entries; 101 lines removed, 36 added
- Fixes #144, #162, #163

## Test plan
- [ ] Verify `env.example` covers all required vars for a fresh setup
- [ ] Confirm no referenced vars were accidentally dropped