### PR TITLE
Per-user theme preference

### DIFF
--- a/chimera/prepareDatabase.js
+++ b/chimera/prepareDatabase.js
@@ -18,7 +18,7 @@ const creationTasks = [
 		description: "frame deletions table"
 	},
 	{
-		query: "CREATE TABLE auth(ID SERIAL PRIMARY KEY, username VARCHAR(50) UNIQUE, hash VARCHAR, role VARCHAR(10) NOT NULL DEFAULT 'user', last_login TIMESTAMP, force_password_change BOOLEAN NOT NULL DEFAULT FALSE, temp_password_expires TIMESTAMP, theme VARCHAR(10) DEFAULT 'dark');",
+		query: "CREATE TABLE auth(ID SERIAL PRIMARY KEY, username VARCHAR(50) UNIQUE, hash VARCHAR, role VARCHAR(10) NOT NULL DEFAULT 'user', last_login TIMESTAMP, force_password_change BOOLEAN NOT NULL DEFAULT FALSE, temp_password_expires TIMESTAMP, theme VARCHAR(10) DEFAULT 'system');",
 		description: "authorization table"
 	},
 	{

--- a/chimera/prepareDatabase.js
+++ b/chimera/prepareDatabase.js
@@ -18,7 +18,7 @@ const creationTasks = [
 		description: "frame deletions table"
 	},
 	{
-		query: "CREATE TABLE auth(ID SERIAL PRIMARY KEY, username VARCHAR(50) UNIQUE, hash VARCHAR, role VARCHAR(10) NOT NULL DEFAULT 'user', last_login TIMESTAMP, force_password_change BOOLEAN NOT NULL DEFAULT FALSE, temp_password_expires TIMESTAMP);",
+		query: "CREATE TABLE auth(ID SERIAL PRIMARY KEY, username VARCHAR(50) UNIQUE, hash VARCHAR, role VARCHAR(10) NOT NULL DEFAULT 'user', last_login TIMESTAMP, force_password_change BOOLEAN NOT NULL DEFAULT FALSE, temp_password_expires TIMESTAMP, theme VARCHAR(10) DEFAULT 'dark');",
 		description: "authorization table"
 	},
 	{

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -82,9 +82,20 @@ app.post("/setup", loginLimiter, validateBody, async (req, res) => {
 app.post("/login", loginLimiter, validateBody, passwordCheck, login)
 app.post("/verify", authorize, async (req, res) => {
 	try {
-		const result = await pool.query("SELECT force_password_change FROM auth WHERE username = $1", [req.decoded.username])
-		const forcePasswordChange = result.rows[0]?.force_password_change ?? false
-		res.json({ error: false, role: req.decoded.role, forcePasswordChange })
+		const result = await pool.query("SELECT force_password_change, theme FROM auth WHERE username = $1", [req.decoded.username])
+		const row = result.rows[0] ?? {}
+		res.json({ error: false, role: req.decoded.role, forcePasswordChange: row.force_password_change ?? false, theme: row.theme ?? "dark" })
+	} catch (e) {
+		res.status(500).json({ error: true })
+	}
+})
+
+app.put("/theme", authorize, validateBody, async (req, res) => {
+	const { theme } = req.body
+	if (!["light", "dark"].includes(theme)) return res.status(400).json({ error: true })
+	try {
+		await pool.query("UPDATE auth SET theme = $1 WHERE username = $2", [theme, req.decoded.username])
+		res.json({ error: false })
 	} catch (e) {
 		res.status(500).json({ error: true })
 	}

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -84,7 +84,7 @@ app.post("/verify", authorize, async (req, res) => {
 	try {
 		const result = await pool.query("SELECT force_password_change, theme FROM auth WHERE username = $1", [req.decoded.username])
 		const row = result.rows[0] ?? {}
-		res.json({ error: false, role: req.decoded.role, forcePasswordChange: row.force_password_change ?? false, theme: row.theme ?? "dark" })
+		res.json({ error: false, role: req.decoded.role, forcePasswordChange: row.force_password_change ?? false, theme: row.theme ?? "system" })
 	} catch (e) {
 		res.status(500).json({ error: true })
 	}
@@ -92,7 +92,7 @@ app.post("/verify", authorize, async (req, res) => {
 
 app.put("/theme", authorize, validateBody, async (req, res) => {
 	const { theme } = req.body
-	if (!["light", "dark"].includes(theme)) return res.status(400).json({ error: true })
+	if (!["light", "dark", "system"].includes(theme)) return res.status(400).json({ error: true })
 	try {
 		await pool.query("UPDATE auth SET theme = $1 WHERE username = $2", [theme, req.decoded.username])
 		res.json({ error: false })

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -20,7 +20,7 @@ module.exports = {
 		const { username, password } = req.body
 		const deny = () => res.status(400).json({ error: true, errors: "Invalid username or password" })
 
-		pool.query("SELECT hash, role, force_password_change, temp_password_expires FROM auth WHERE username = $1", [username], (err, values) => {
+		pool.query("SELECT hash, role, force_password_change, temp_password_expires, theme FROM auth WHERE username = $1", [username], (err, values) => {
 			if (err) return deny()
 			const row = values.rows[0]
 			bcrypt.compare(password == undefined ? "" : password, row && row.hash ? row.hash : DUMMY_HASH, (err, success) => {
@@ -28,6 +28,7 @@ module.exports = {
 				if (row.force_password_change && row.temp_password_expires && new Date(row.temp_password_expires) < new Date()) return deny()
 				req.userRole = row.role
 				req.forcePasswordChange = row.force_password_change
+				req.userTheme = row.theme ?? "dark"
 				next()
 			})
 		})
@@ -52,7 +53,7 @@ module.exports = {
 					secure: process.env.NODE_ENV !== "development",
 					sameSite: "lax"
 				})
-				res.send({ error: false, role: req.userRole, forcePasswordChange: req.forcePasswordChange })
+				res.send({ error: false, role: req.userRole, forcePasswordChange: req.forcePasswordChange, theme: req.userTheme })
 			}
 		)
 	}

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -28,7 +28,7 @@ module.exports = {
 				if (row.force_password_change && row.temp_password_expires && new Date(row.temp_password_expires) < new Date()) return deny()
 				req.userRole = row.role
 				req.forcePasswordChange = row.force_password_change
-				req.userTheme = row.theme ?? "dark"
+				req.userTheme = row.theme ?? "system"
 				next()
 			})
 		})

--- a/command/e2e/api.js
+++ b/command/e2e/api.js
@@ -7,7 +7,8 @@ const json = (body, status = 200) => ({
 const defaultRoutes = {
 	"GET /authorization/status": json({ setup: true, tokenRequired: false }),
 	"POST /authorization/verify": json({ error: true }),
-	"POST /authorization/login": json({ error: false, role: "admin" }),
+	"POST /authorization/login": json({ error: false, role: "admin", theme: "system" }),
+	"PUT /authorization/theme": json({ error: false }),
 	"POST /authorization/logout": json({ error: false }),
 	"POST /authorization/setup": json({ error: false }),
 	"POST /authorization/password": json({ error: false }),

--- a/command/e2e/auth.spec.js
+++ b/command/e2e/auth.spec.js
@@ -90,14 +90,14 @@ test.describe("authentication", () => {
 		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
 	})
 
-	test("sign out returns to the login page", async ({ page }) => {
+	test("log out returns to the login page", async ({ page }) => {
 		await mockApi(page)
 		await page.goto("/")
 		await page.getByPlaceholder("username").fill("admin")
 		await page.getByPlaceholder("password").fill("password123")
 		await page.getByRole("button", { name: "Sign In" }).click()
-		await page.getByRole("button", { name: "Sign Out" }).click()
-		await page.getByRole("dialog").getByRole("button", { name: "Sign Out" }).click()
+		await page.getByRole("button", { name: "Log Out" }).click()
+		await page.getByRole("dialog").getByRole("button", { name: "Log Out" }).click()
 		await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible()
 	})
 })

--- a/command/e2e/theme.spec.js
+++ b/command/e2e/theme.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require("@playwright/test")
-const { mockApi, login } = require("./api")
+const { mockApi, login, json } = require("./api")
 
 test.describe("theme", () => {
 	test("toggling the theme switch updates the document and persists", async ({ page }) => {
@@ -12,5 +12,18 @@ test.describe("theme", () => {
 		await page.getByRole("switch").click()
 		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(!wasDark)
 		await expect.poll(() => page.evaluate(() => localStorage.getItem("theme"))).toBe(wasDark ? "light" : "dark")
+	})
+
+	test("server theme on login overrides the local default", async ({ page }) => {
+		await mockApi(page, {
+			"POST /authorization/login": json({ error: false, role: "admin", theme: "light" })
+		})
+		await page.goto("/")
+		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(true)
+
+		await login(page)
+		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
+		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(false)
+		await expect.poll(() => page.evaluate(() => localStorage.getItem("theme"))).toBe("light")
 	})
 })

--- a/command/e2e/theme.spec.js
+++ b/command/e2e/theme.spec.js
@@ -2,16 +2,93 @@ const { test, expect } = require("@playwright/test")
 const { mockApi, login, json } = require("./api")
 
 test.describe("theme", () => {
-	test("toggling the theme switch updates the document and persists", async ({ page }) => {
+	test("clicking a theme button updates the document, persists, and fires PUT", async ({ page }) => {
+		const themePuts = []
 		await mockApi(page)
+		await page.route("**/authorization/theme", (route) => {
+			if (route.request().method() === "PUT") {
+				themePuts.push(JSON.parse(route.request().postData()))
+				route.fulfill(json({ error: false }))
+			} else {
+				route.fallback()
+			}
+		})
 		await page.goto("/")
 		await login(page)
 		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
 
-		const wasDark = await page.evaluate(() => document.documentElement.classList.contains("dark"))
-		await page.getByRole("switch").click()
-		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(!wasDark)
-		await expect.poll(() => page.evaluate(() => localStorage.getItem("theme"))).toBe(wasDark ? "light" : "dark")
+		await page.getByRole("button", { name: "light" }).click()
+		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(false)
+		await expect.poll(() => page.evaluate(() => localStorage.getItem("theme"))).toBe("light")
+		await expect.poll(() => themePuts.at(-1)).toEqual({ theme: "light" })
+
+		await page.getByRole("button", { name: "dark" }).click()
+		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(true)
+		await expect.poll(() => themePuts.at(-1)).toEqual({ theme: "dark" })
+	})
+
+	test("shows a toast when saving the theme fails", async ({ page }) => {
+		await mockApi(page)
+		await page.route("**/authorization/theme", (route) => {
+			if (route.request().method() === "PUT") {
+				route.fulfill(json({ error: true }, 500))
+			} else {
+				route.fallback()
+			}
+		})
+		await page.goto("/")
+		await login(page)
+		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
+
+		await page.getByRole("button", { name: "light" }).click()
+		await expect(page.getByText("Couldn't save theme")).toBeVisible()
+	})
+
+	test("system theme follows the OS preference and reacts to changes", async ({ page }) => {
+		await mockApi(page)
+		await page.emulateMedia({ colorScheme: "dark" })
+		await page.goto("/")
+		await login(page)
+		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
+
+		await page.getByRole("button", { name: "system" }).click()
+		await expect.poll(() => page.evaluate(() => localStorage.getItem("theme"))).toBe("system")
+		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(true)
+
+		await page.emulateMedia({ colorScheme: "light" })
+		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(false)
+	})
+
+	test("a saved theme survives logout and is restored from the server on next login", async ({ page }) => {
+		let savedTheme = "system"
+		await mockApi(page)
+		await page.route("**/authorization/theme", (route) => {
+			if (route.request().method() === "PUT") {
+				savedTheme = JSON.parse(route.request().postData()).theme
+				route.fulfill(json({ error: false }))
+			} else {
+				route.fallback()
+			}
+		})
+		await page.route("**/authorization/login", (route) =>
+			route.fulfill(json({ error: false, role: "admin", theme: savedTheme })))
+
+		await page.goto("/")
+		await login(page)
+		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
+
+		await page.getByRole("button", { name: "dark" }).click()
+		await expect.poll(() => savedTheme).toBe("dark")
+
+		await page.getByRole("button", { name: "Log Out" }).click()
+		await page.getByRole("dialog").getByRole("button", { name: "Log Out" }).click()
+		await expect(page.getByPlaceholder("username")).toBeVisible()
+
+		await page.evaluate(() => localStorage.clear())
+		await login(page)
+		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
+		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(true)
+		await expect.poll(() => page.evaluate(() => localStorage.getItem("theme"))).toBe("dark")
 	})
 
 	test("server theme on login overrides the local default", async ({ page }) => {
@@ -19,7 +96,6 @@ test.describe("theme", () => {
 			"POST /authorization/login": json({ error: false, role: "admin", theme: "light" })
 		})
 		await page.goto("/")
-		await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark"))).toBe(true)
 
 		await login(page)
 		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()

--- a/command/frontend/App.jsx
+++ b/command/frontend/App.jsx
@@ -15,14 +15,7 @@ import AuthContext from "./app/AuthContext.jsx"
 import { ThemeProvider } from "./app/ThemeContext.jsx"
 import useAuth from "./hooks/useAuth.js"
 
-const AppInner = () => {
-	const [loaded, setup, tokenRequired, loggedIn, role, forcePasswordChange, tryLogin, trySetup, signOut, changePassword] = useAuth()
-	const [key, setKey] = useState(0)
-
-	useEffect(() => {
-		setKey((k) => k + 1)
-	}, [loggedIn])
-
+const AppInner = ({ loaded, setup, tokenRequired, loggedIn, role, forcePasswordChange, tryLogin, trySetup, signOut, changePassword, routerKey }) => {
 	if (!loaded) return <LoadingIcon />
 
 	if (setup === false) return <SetupForm trySetup={trySetup} tokenRequired={tokenRequired} />
@@ -31,20 +24,20 @@ const AppInner = () => {
 
 	return (
 		<AuthContext.Provider value={{ role, signOut }}>
-			<Router key={`ROUTER-${key}`}>
+			<Router key={`ROUTER-${routerKey}`}>
 				<Routes>
 					<Route
-						key={`ROUTE-${key}-1`}
+						key={`ROUTE-${routerKey}-1`}
 						path="/login"
 						element={loggedIn ? <Navigate to="/" /> : <LoginPage tryLogin={tryLogin} />}
 					/>
 					<Route
-						key={`ROUTE-${key}-2`}
+						key={`ROUTE-${routerKey}-2`}
 						path="/:route"
 						element={loggedIn ? <ResponsiveMain /> : <Navigate to="/login" />}
 					/>
 					<Route
-						key={`ROUTE-${key}-3`}
+						key={`ROUTE-${routerKey}-3`}
 						path="/"
 						element={loggedIn ? <ResponsiveMain /> : <Navigate to="/login" />}
 					/>
@@ -54,10 +47,31 @@ const AppInner = () => {
 	)
 }
 
-const App = () => (
-	<ThemeProvider>
-		<AppInner />
-	</ThemeProvider>
-)
+const App = () => {
+	const [loaded, setup, tokenRequired, loggedIn, role, forcePasswordChange, tryLogin, trySetup, signOut, changePassword, serverTheme] = useAuth()
+	const [key, setKey] = useState(0)
+
+	useEffect(() => {
+		setKey((k) => k + 1)
+	}, [loggedIn])
+
+	return (
+		<ThemeProvider serverTheme={serverTheme}>
+			<AppInner
+				loaded={loaded}
+				setup={setup}
+				tokenRequired={tokenRequired}
+				loggedIn={loggedIn}
+				role={role}
+				forcePasswordChange={forcePasswordChange}
+				tryLogin={tryLogin}
+				trySetup={trySetup}
+				signOut={signOut}
+				changePassword={changePassword}
+				routerKey={key}
+			/>
+		</ThemeProvider>
+	)
+}
 
 export default App

--- a/command/frontend/app/MobileView.jsx
+++ b/command/frontend/app/MobileView.jsx
@@ -52,14 +52,14 @@ const MobileView = ({ index }) => {
 			{role === "admin" && <StorageWidget />}
 			<ScheduleDashboard mini withButton />
 			<div className="flex items-center rounded-md border border-border text-muted">
-				<div className="flex flex-1 items-center justify-center gap-1 py-2">
+				<div className="flex flex-1">
 					{themeOptions.map(({ value, icon: Icon }) => (
 						<button
 							key={value}
 							aria-label={value}
 							onClick={() => applyTheme(value)}
 							className={cn(
-								"flex items-center justify-center px-2 py-1 rounded-md transition-colors",
+								"flex flex-1 items-center justify-center py-2 rounded-md transition-colors",
 								theme === value ? "bg-accent/15 text-accent" : "hover:text-primary"
 							)}
 						>

--- a/command/frontend/app/MobileView.jsx
+++ b/command/frontend/app/MobileView.jsx
@@ -1,9 +1,9 @@
 import React from "react"
 import { Navigate } from "react-router-dom"
-import { Sun, Moon } from "lucide-react"
+import { Sun, Moon, Monitor } from "lucide-react"
 import { useRole } from "./AuthContext"
 import { useTheme } from "./ThemeContext.jsx"
-import { Switch } from "../components/ui/switch"
+import { cn } from "../lib/utils"
 
 import LiveVideo from "./LiveVideo"
 import ClipMaker from "./ClipMaker"
@@ -19,7 +19,12 @@ import ProcessList from "./ProcessList.jsx"
 
 const MobileView = ({ index }) => {
 	const role = useRole()
-	const { dark, toggle } = useTheme()
+	const { theme, applyTheme } = useTheme()
+	const themeOptions = [
+		{ value: "light", icon: Sun },
+		{ value: "dark", icon: Moon },
+		{ value: "system", icon: Monitor },
+	]
 
 	if (index === "route-1") return <ClipMaker />
 
@@ -47,10 +52,20 @@ const MobileView = ({ index }) => {
 			{role === "admin" && <StorageWidget />}
 			<ScheduleDashboard mini withButton />
 			<div className="flex items-center rounded-md border border-border text-muted">
-				<div className="flex flex-1 items-center justify-center gap-2 py-2">
-					<Moon className="size-4" />
-					<Switch checked={!dark} onCheckedChange={toggle} />
-					<Sun className="size-4" />
+				<div className="flex flex-1 items-center justify-center gap-1 py-2">
+					{themeOptions.map(({ value, icon: Icon }) => (
+						<button
+							key={value}
+							aria-label={value}
+							onClick={() => applyTheme(value)}
+							className={cn(
+								"flex items-center justify-center px-2 py-1 rounded-md transition-colors",
+								theme === value ? "bg-accent/15 text-accent" : "hover:text-primary"
+							)}
+						>
+							<Icon className="size-4" />
+						</button>
+					))}
 				</div>
 				<div className="w-px self-stretch bg-border" />
 				<SignOutButton className="flex flex-1 items-center justify-center gap-2 py-2 text-sm font-medium transition-colors hover:bg-surface-raised hover:text-primary" iconOnly={false} />

--- a/command/frontend/app/SideMenu.jsx
+++ b/command/frontend/app/SideMenu.jsx
@@ -70,7 +70,7 @@ const SideMenu = ({ index, mobile }) => {
 	}
 
 	return (
-		<aside className="sticky top-0 flex h-screen w-60 shrink-0 flex-col border-r border-border bg-surface">
+		<aside className="sticky top-0 flex h-screen w-48 shrink-0 flex-col border-r border-border bg-surface">
 			<div className="flex items-center gap-2 px-4 py-4">
 				<img src="/res/logo.png" alt="Chimera" className="h-8 w-8 object-contain" />
 				<span className="text-lg font-semibold tracking-tight">Chimera</span>
@@ -93,25 +93,22 @@ const SideMenu = ({ index, mobile }) => {
 					)
 				})}
 			</nav>
-			<div className="px-2 py-3">
-				<div className="flex items-center gap-2 rounded-md px-3 py-2 text-muted">
-					<div className="flex rounded-md border border-border">
-						{themeOptions.map(({ value, icon: Icon }) => (
-							<button
-								key={value}
-								aria-label={value}
-								onClick={() => applyTheme(value)}
-								className={cn(
-									"flex items-center justify-center px-2 py-1 transition-colors first:rounded-l-md last:rounded-r-md",
-									theme === value ? "bg-accent/15 text-accent" : "hover:text-primary"
-								)}
-							>
-								<Icon className="size-4" />
-							</button>
-						))}
-					</div>
-					<div className="mx-1 h-4 w-px bg-border" />
-					<SignOutButton className="flex items-center gap-2 text-sm font-medium transition-colors hover:text-primary" iconOnly={false} />
+			<div className="space-y-1 px-2 py-2">
+				<SignOutButton className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted transition-colors hover:bg-surface-raised hover:text-primary" iconOnly={false} />
+				<div className="flex w-full rounded-md border border-border">
+					{themeOptions.map(({ value, icon: Icon }) => (
+						<button
+							key={value}
+							aria-label={value}
+							onClick={() => applyTheme(value)}
+							className={cn(
+								"flex flex-1 items-center justify-center px-2 py-2 transition-colors first:rounded-l-md last:rounded-r-md",
+								theme === value ? "bg-accent/15 text-accent" : "hover:text-primary text-muted"
+							)}
+						>
+							<Icon className="size-5" />
+						</button>
+					))}
 				</div>
 			</div>
 		</aside>

--- a/command/frontend/app/SideMenu.jsx
+++ b/command/frontend/app/SideMenu.jsx
@@ -1,18 +1,22 @@
 import React from "react"
 import { useNavigate } from "react-router-dom"
-import { Home, Video, Scissors, Rewind, Activity, CalendarClock, Users, ScanEye, Sun, Moon } from "lucide-react"
+import { Home, Video, Scissors, Rewind, Activity, CalendarClock, Users, ScanEye, Sun, Moon, Monitor } from "lucide-react"
 
 import { indexToRoute } from "../js/routeIndexMapping"
 import { useRole } from "./AuthContext.jsx"
 import { useTheme } from "./ThemeContext.jsx"
 import SignOutButton from "./SignOutButton.jsx"
-import { Switch } from "../components/ui/switch"
 import { cn } from "../lib/utils"
 
 const SideMenu = ({ index, mobile }) => {
 	const role = useRole()
 	const navigate = useNavigate()
-	const { dark, toggle } = useTheme()
+	const { theme, applyTheme } = useTheme()
+	const themeOptions = [
+		{ value: "light", icon: Sun },
+		{ value: "dark", icon: Moon },
+		{ value: "system", icon: Monitor },
+	]
 
 	const mobileTabs = [
 		{ key: "route-1", icon: Scissors, title: "Clip" },
@@ -91,9 +95,21 @@ const SideMenu = ({ index, mobile }) => {
 			</nav>
 			<div className="px-2 py-3">
 				<div className="flex items-center gap-2 rounded-md px-3 py-2 text-muted">
-					<Moon className="size-4 shrink-0" />
-					<Switch checked={!dark} onCheckedChange={toggle} />
-					<Sun className="size-4 shrink-0" />
+					<div className="flex rounded-md border border-border">
+						{themeOptions.map(({ value, icon: Icon }) => (
+							<button
+								key={value}
+								aria-label={value}
+								onClick={() => applyTheme(value)}
+								className={cn(
+									"flex items-center justify-center px-2 py-1 transition-colors first:rounded-l-md last:rounded-r-md",
+									theme === value ? "bg-accent/15 text-accent" : "hover:text-primary"
+								)}
+							>
+								<Icon className="size-4" />
+							</button>
+						))}
+					</div>
 					<div className="mx-1 h-4 w-px bg-border" />
 					<SignOutButton className="flex items-center gap-2 text-sm font-medium transition-colors hover:text-primary" iconOnly={false} />
 				</div>

--- a/command/frontend/app/SignOutButton.jsx
+++ b/command/frontend/app/SignOutButton.jsx
@@ -12,19 +12,19 @@ const SignOutButton = ({ className, iconOnly }) => {
 		<>
 			<button onClick={() => setOpen(true)} className={className}>
 				<LogOut className="size-5 shrink-0" />
-				{!iconOnly && <span>Sign Out</span>}
+				{!iconOnly && <span>Log Out</span>}
 			</button>
 			<Dialog open={open} onOpenChange={setOpen}>
 				<DialogContent className="bg-surface-raised border-border text-primary">
 					<DialogHeader>
-						<DialogTitle className="text-primary">Sign Out</DialogTitle>
-						<DialogDescription className="text-muted">Are you sure you want to sign out?</DialogDescription>
+						<DialogTitle className="text-primary">Log Out</DialogTitle>
+						<DialogDescription className="text-muted">Are you sure you want to log out?</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
 						<DialogClose asChild>
 							<Button variant="ghost" className="text-muted hover:text-primary">Cancel</Button>
 						</DialogClose>
-						<Button onClick={signOut} className="bg-danger text-danger-foreground hover:bg-danger/80">Sign Out</Button>
+						<Button onClick={signOut} className="bg-danger text-danger-foreground hover:bg-danger/80">Log Out</Button>
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>

--- a/command/frontend/app/ThemeContext.jsx
+++ b/command/frontend/app/ThemeContext.jsx
@@ -1,20 +1,45 @@
 import React, { createContext, useContext, useEffect, useState } from "react"
+import { request } from "../js/request.js"
 
 const ThemeContext = createContext()
 
-export const ThemeProvider = ({ children }) => {
-	const [dark, setDark] = useState(() => {
+const resolveTheme = (theme) => theme === "dark"
+
+const saveTheme = (theme) =>
+	request("/authorization/theme", {
+		method: "PUT",
+		headers: { "Accept": "application/json", "Content-Type": "application/json" },
+		body: JSON.stringify({ theme })
+	}, (prom) => prom.catch(() => {}))
+
+export const ThemeProvider = ({ serverTheme, children }) => {
+	const [theme, setTheme] = useState(() => {
 		const saved = localStorage.getItem("theme")
-		return saved ? saved === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches
+		return saved ?? "dark"
 	})
 
 	useEffect(() => {
-		document.documentElement.classList.toggle("dark", dark)
-		localStorage.setItem("theme", dark ? "dark" : "light")
-	}, [dark])
+		if (serverTheme) {
+			setTheme(serverTheme)
+			localStorage.setItem("theme", serverTheme)
+		}
+	}, [serverTheme])
+
+	useEffect(() => {
+		document.documentElement.classList.toggle("dark", resolveTheme(theme))
+		localStorage.setItem("theme", theme)
+	}, [theme])
+
+	const toggle = () => {
+		setTheme(t => {
+			const next = t === "dark" ? "light" : "dark"
+			saveTheme(next)
+			return next
+		})
+	}
 
 	return (
-		<ThemeContext.Provider value={{ dark, toggle: () => setDark(d => !d) }}>
+		<ThemeContext.Provider value={{ dark: resolveTheme(theme), toggle }}>
 			{children}
 		</ThemeContext.Provider>
 	)

--- a/command/frontend/app/ThemeContext.jsx
+++ b/command/frontend/app/ThemeContext.jsx
@@ -1,22 +1,23 @@
 import React, { createContext, useContext, useEffect, useState } from "react"
 import { request } from "../js/request.js"
+import toast from "../js/toast.js"
 
 const ThemeContext = createContext()
 
-const resolveTheme = (theme) => theme === "dark"
+const isDark = (theme) =>
+	theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches)
 
 const saveTheme = (theme) =>
 	request("/authorization/theme", {
 		method: "PUT",
 		headers: { "Accept": "application/json", "Content-Type": "application/json" },
 		body: JSON.stringify({ theme })
-	}, (prom) => prom.catch(() => {}))
+	}, (prom) => prom
+		.then((res) => { if (!res.ok) throw new Error() })
+		.catch(() => toast("Couldn't save theme")))
 
 export const ThemeProvider = ({ serverTheme, children }) => {
-	const [theme, setTheme] = useState(() => {
-		const saved = localStorage.getItem("theme")
-		return saved ?? "dark"
-	})
+	const [theme, setTheme] = useState(() => localStorage.getItem("theme") ?? "system")
 
 	useEffect(() => {
 		if (serverTheme) {
@@ -26,20 +27,23 @@ export const ThemeProvider = ({ serverTheme, children }) => {
 	}, [serverTheme])
 
 	useEffect(() => {
-		document.documentElement.classList.toggle("dark", resolveTheme(theme))
+		document.documentElement.classList.toggle("dark", isDark(theme))
 		localStorage.setItem("theme", theme)
+
+		if (theme !== "system") return
+		const media = window.matchMedia("(prefers-color-scheme: dark)")
+		const onChange = () => document.documentElement.classList.toggle("dark", media.matches)
+		media.addEventListener("change", onChange)
+		return () => media.removeEventListener("change", onChange)
 	}, [theme])
 
-	const toggle = () => {
-		setTheme(t => {
-			const next = t === "dark" ? "light" : "dark"
-			saveTheme(next)
-			return next
-		})
+	const applyTheme = (next) => {
+		setTheme(next)
+		saveTheme(next)
 	}
 
 	return (
-		<ThemeContext.Provider value={{ dark: resolveTheme(theme), toggle }}>
+		<ThemeContext.Provider value={{ theme, applyTheme }}>
 			{children}
 		</ThemeContext.Provider>
 	)

--- a/command/frontend/hooks/useAuth.js
+++ b/command/frontend/hooks/useAuth.js
@@ -46,9 +46,9 @@ const attemptLogout = () =>
 		headers: { "Accept": "application/json", "Content-Type": "application/json" },
 	}, authPromiseHandler)
 
-const handleLoginAttempt = (verified, role, timestamp, setState, forcePasswordChange = false) => {
+const handleLoginAttempt = (verified, role, timestamp, setState, forcePasswordChange = false, theme = null) => {
 	setTimeout(() => {
-		setState(s => ({ ...s, loggedIn: verified, role: role || null, forcePasswordChange: verified ? forcePasswordChange : false }))
+		setState(s => ({ ...s, loggedIn: verified, role: role || null, forcePasswordChange: verified ? forcePasswordChange : false, theme: verified ? theme : null }))
 		setTimeout(() => {
 			setState(s => ({ ...s, loaded: true }))
 		}, Math.max(0, timeout - (new Date() - timestamp)))
@@ -63,6 +63,7 @@ const useAuth = () => {
 		loggedIn: false,
 		role: null,
 		forcePasswordChange: false,
+		theme: null,
 		timestamp: new Date()
 	})
 
@@ -79,7 +80,7 @@ const useAuth = () => {
 				return
 			}
 			attemptVerification().then(res => {
-				handleLoginAttempt(!res.error, res.role, state.timestamp, setState, res.forcePasswordChange)
+				handleLoginAttempt(!res.error, res.role, state.timestamp, setState, res.forcePasswordChange, res.theme)
 			})
 		})
 
@@ -97,7 +98,7 @@ const useAuth = () => {
 	const tryLogin = (username, password, callback) => {
 		attemptLogin(username, password).then(res => {
 			callback(!res.error, res.errors)
-			handleLoginAttempt(!res.error, res.role, state.timestamp, setState, res.forcePasswordChange)
+			handleLoginAttempt(!res.error, res.role, state.timestamp, setState, res.forcePasswordChange, res.theme)
 		})
 	}
 
@@ -117,11 +118,11 @@ const useAuth = () => {
 
 	const signOut = () => {
 		attemptLogout().finally(() => {
-			setState(s => ({ ...s, loggedIn: false, role: null, forcePasswordChange: false }))
+			setState(s => ({ ...s, loggedIn: false, role: null, forcePasswordChange: false, theme: null }))
 		})
 	}
 
-	return [state.loaded, state.setup, state.tokenRequired, state.loggedIn, state.role, state.forcePasswordChange, tryLogin, trySetup, signOut, changePassword]
+	return [state.loaded, state.setup, state.tokenRequired, state.loggedIn, state.role, state.forcePasswordChange, tryLogin, trySetup, signOut, changePassword, state.theme]
 }
 
 export default useAuth

--- a/command/frontend/index.html
+++ b/command/frontend/index.html
@@ -7,7 +7,7 @@
 		<title>Chimera</title>
 	</head>
 	<body>
-		<script>(function(){var s=localStorage.getItem("theme"),p=window.matchMedia("(prefers-color-scheme: dark)").matches;if(s==="dark"||(s===null&&p))document.documentElement.classList.add("dark")}())</script>
+		<script>(function(){var s=localStorage.getItem("theme"),p=window.matchMedia("(prefers-color-scheme: dark)").matches;if(s==="dark"||((s===null||s==="system")&&p))document.documentElement.classList.add("dark")}())</script>
 		<div id="root"></div>
 		<script type="module" src="/main.jsx"></script>
 	</body>

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -86,7 +86,7 @@ describe("Authorization Routes", () => {
 				.post("/authorization/login")
 				.send({ username: "admin", password: "mockedPassword" })
 			expect(res.status).toBe(200)
-			expect(res.body).toEqual({ error: false, role: "user" })
+			expect(res.body).toEqual({ error: false, role: "user", theme: "dark" })
 			expect(res.headers["set-cookie"]).toBeDefined()
 			expect(res.headers["set-cookie"][0]).toMatch(/^bearertoken=/)
 		})
@@ -131,7 +131,7 @@ describe("Authorization Routes", () => {
 				.post("/authorization/verify")
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
 			expect(res.status).toBe(200)
-			expect(res.body).toEqual({ error: false, role: "user", forcePasswordChange: false })
+			expect(res.body).toEqual({ error: false, role: "user", forcePasswordChange: false, theme: "dark" })
 		})
 
 		test("returns 401 for valid JWT of deleted user", async () => {
@@ -142,6 +142,33 @@ describe("Authorization Routes", () => {
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
 			expect(res.status).toBe(401)
 			expect(res.body).toEqual({ error: "unauthorized" })
+		})
+	})
+
+	describe("PUT /authorization/theme", () => {
+		test("returns 401 with no token", async () => {
+			const res = await supertest(app).put("/authorization/theme").send({ theme: "light" })
+			expect(res.status).toBe(401)
+		})
+
+		test("returns 400 for an invalid theme value", async () => {
+			const token = jwt.sign({ username: "bob", role: "user", jti: "jti-user" }, "test-secret")
+			const res = await supertest(app)
+				.put("/authorization/theme")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.send({ theme: "blue" })
+			expect(res.status).toBe(400)
+			expect(res.body).toEqual({ error: true })
+		})
+
+		test("returns 200 on successful theme update", async () => {
+			const token = jwt.sign({ username: "bob", role: "user", jti: "jti-user" }, "test-secret")
+			const res = await supertest(app)
+				.put("/authorization/theme")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.send({ theme: "light" })
+			expect(res.status).toBe(200)
+			expect(res.body).toEqual({ error: false })
 		})
 	})
 

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -86,7 +86,7 @@ describe("Authorization Routes", () => {
 				.post("/authorization/login")
 				.send({ username: "admin", password: "mockedPassword" })
 			expect(res.status).toBe(200)
-			expect(res.body).toEqual({ error: false, role: "user", theme: "dark" })
+			expect(res.body).toEqual({ error: false, role: "user", theme: "system" })
 			expect(res.headers["set-cookie"]).toBeDefined()
 			expect(res.headers["set-cookie"][0]).toMatch(/^bearertoken=/)
 		})
@@ -131,7 +131,7 @@ describe("Authorization Routes", () => {
 				.post("/authorization/verify")
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
 			expect(res.status).toBe(200)
-			expect(res.body).toEqual({ error: false, role: "user", forcePasswordChange: false, theme: "dark" })
+			expect(res.body).toEqual({ error: false, role: "user", forcePasswordChange: false, theme: "system" })
 		})
 
 		test("returns 401 for valid JWT of deleted user", async () => {
@@ -161,12 +161,12 @@ describe("Authorization Routes", () => {
 			expect(res.body).toEqual({ error: true })
 		})
 
-		test("returns 200 on successful theme update", async () => {
+		test.each(["light", "dark", "system"])("returns 200 on successful theme update (%s)", async (theme) => {
 			const token = jwt.sign({ username: "bob", role: "user", jti: "jti-user" }, "test-secret")
 			const res = await supertest(app)
 				.put("/authorization/theme")
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
-				.send({ theme: "light" })
+				.send({ theme })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 		})

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -27,7 +27,7 @@ if(process.env.gateway_HTTPS_Redirect == "true"){
 
 const services = require("./services.js")
 for(const apiService of services){
-	const {serviceOn, log, postPathRegex, getPathRegex, deletePathRegex, baseURL} = apiService
+	const {serviceOn, log, postPathRegex, getPathRegex, deletePathRegex, putPathRegex, baseURL} = apiService
 
 	if(serviceOn){
 		console.log(log)
@@ -35,12 +35,15 @@ for(const apiService of services){
 		const postRe = anchor(postPathRegex)
 		const getRe = anchor(getPathRegex)
 		const deleteRe = deletePathRegex && anchor(deletePathRegex)
+		const putRe = putPathRegex && anchor(putPathRegex)
 		const sources = [postRe.source, getRe.source]
 		if (deleteRe) sources.push(deleteRe.source)
+		if (putRe) sources.push(putRe.source)
 		app.use(new RegExp(sources.join("|")), createProxyMiddleware((pathname, req) => {
 			return (postRe.test(pathname) && req.method === "POST")
 				|| (getRe.test(pathname) && req.method === "GET")
 				|| (deleteRe && deleteRe.test(pathname) && req.method === "DELETE")
+				|| (putRe && putRe.test(pathname) && req.method === "PUT")
 		}, {
 			target: baseURL,
 			logLevel: "silent",

--- a/gateway/services.js
+++ b/gateway/services.js
@@ -29,5 +29,6 @@ module.exports = [{
 	baseURL: process.env.command_HOST,
 	postPathRegex: /\/.*/,
 	getPathRegex: /\/.*/,
-	deletePathRegex: /\/.*/
+	deletePathRegex: /\/.*/,
+	putPathRegex: /\/.*/
 }]

--- a/gateway/test/gateway.test.js
+++ b/gateway/test/gateway.test.js
@@ -30,4 +30,16 @@ describe("Gateway Tests", () => {
 				})
 		})
 	})
+
+	test("Gateway forwards PUT requests", (done) => {
+		const server = handleServerStart(command, process.env.command_PORT, () => {
+			supertest(gateway)
+				.put("/authorization/theme")
+				.send({ theme: "dark" })
+				.expect(401, (err) => {
+					server.close()
+					done(err)
+				})
+		})
+	})
 })


### PR DESCRIPTION
Persist a per-user light/dark theme. Adds `PUT /authorization/theme`, returns `theme` on login/verify, and tests.