### PR TITLE
Use GitHub-hosted ubuntu runner in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,9 @@ permissions:
   contents: read
   pull-requests: write
 
-defaults:
-  run:
-    shell: powershell
-
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -29,7 +25,7 @@ jobs:
           node-version: 22
 
       - name: Generate test .env
-        run: Copy-Item .github/ci.env .env -Force
+        run: cp .github/ci.env .env
 
       - name: Install root dependencies
         run: npm ci
@@ -53,7 +49,7 @@ jobs:
           path: coverage
 
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -77,7 +73,7 @@ jobs:
           path: command/dist
 
   e2e:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 

--- a/command/test/webapp.test.js
+++ b/command/test/webapp.test.js
@@ -4,6 +4,7 @@ const path = require("path")
 const app = require("../backend/command.js")
 
 jest.mock("memory")
+jest.mock("fs", () => jest.requireActual("fs"))
 
 const distDir = path.join(__dirname, "../dist")
 const indexFile = path.join(distDir, "index.html")

--- a/storage/__mocks__/fs.js
+++ b/storage/__mocks__/fs.js
@@ -19,33 +19,35 @@ const fileList = [
 	"output_1_20210101-235959_20210201-235959_zip1-20210301-235959.zip",
 ]
 
-let fs = jest.requireActual("fs")
-fs.readFile = jest.fn().mockImplementation((filePath, callback) => {
-	callback(false, {})
-})
-fs.readdir = jest.fn().mockImplementation((filePath, callback) => {
-	if(filePath == imgDir || filePath == cameraDir){
-		callback(false, fileList)
-	}
-	else{
-		callback(true, [])
-	}
-})
-fs.stat = jest.fn().mockImplementation((filePath, callback) => {
-	if(fileList.map(file => path.join(imgDir, file)).includes(filePath)){
-		callback(false, { size: 1024 })
-	}
-	else{
-		callback(true)
-	}
-})
-fs.unlink = jest.fn().mockImplementation((filePath, callback) => {
-	if(fileList.map(file => path.join(imgDir, file)).includes(filePath)){
-		callback(false)
-	}
-	else{
-		callback(true)
-	}
-})
+const actual = jest.requireActual("fs")
 
-module.exports = fs
+module.exports = {
+	...actual,
+	readFile: jest.fn().mockImplementation((filePath, callback) => {
+		callback(false, {})
+	}),
+	readdir: jest.fn().mockImplementation((filePath, callback) => {
+		if(filePath == imgDir || filePath == cameraDir){
+			callback(false, fileList)
+		}
+		else{
+			callback(true, [])
+		}
+	}),
+	stat: jest.fn().mockImplementation((filePath, callback) => {
+		if(fileList.map(file => path.join(imgDir, file)).includes(filePath)){
+			callback(false, { size: 1024 })
+		}
+		else{
+			callback(true)
+		}
+	}),
+	unlink: jest.fn().mockImplementation((filePath, callback) => {
+		if(fileList.map(file => path.join(imgDir, file)).includes(filePath)){
+			callback(false)
+		}
+		else{
+			callback(true)
+		}
+	})
+}


### PR DESCRIPTION
Switches all three CI jobs (`test`, `build`, `e2e`) from `self-hosted` to `ubuntu-latest`.

Since ubuntu doesn't have Windows PowerShell, this also:
- removes the `defaults.run.shell: powershell` block (jobs now use the default `bash`)
- converts the `Copy-Item .github/ci.env .env -Force` step to `cp .github/ci.env .env`

ubuntu runners are cheaper and faster to start than self-hosted/Windows. The CI run on this PR validates Linux compatibility.