### PR TITLE
Address PR 178 review findings

### DIFF
--- a/chimera/splitAndValidateEnvVars.js
+++ b/chimera/splitAndValidateEnvVars.js
@@ -72,11 +72,13 @@ env.schedule += writeVarLine("storage_MAX_GB")
 env.lib += writeVarLine("alert_URL")
 env.object += writeVarLine("alert_URL")
 env.lib += writeVarLine("admin_alert_URL")
+env.storage += writeVarLine("admin_alert_URL")
 
 env.lib += writeVarLine("PRINTPASSWORD")
 
 env.command += writeVarLine("SECRETKEY")
 env.lib += writeVarLine("SECRETKEY")
+env.object += writeVarLine("SECRETKEY")
 
 env.gateway += writeVarLine("command_PROXY_ON")
 env.gateway += writeVarLine("schedule_PROXY_ON")
@@ -124,7 +126,8 @@ env.gateway += writeVarLine("storage_HOST")
 env.storage += writeVarLine("storage_FOLDERPATH")
 confirmPath("storage_FOLDERPATH", true)
 
-writeVarLine("storage_MOTION_CONF_FILEPATH")
+env.storage += writeVarLine("storage_MOTION_CONF_FILEPATH")
+env.command += writeVarLine("storage_MOTION_CONF_FILEPATH")
 
 env.storage += writeVarLine("ffmpeg_FILEPATH")
 env.object += writeVarLine("ffmpeg_FILEPATH")

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -32,7 +32,7 @@ const rateLimit = ({ windowMs, max }) => {
 		reserve(key, (blocked) => {
 			if (blocked) return res.status(429).json({ error: true, errors: "Too many attempts" })
 			res.on("finish", () => {
-				if (res.statusCode < 400) release(key)
+				if (res.statusCode < 400 || res.statusCode >= 500) release(key)
 			})
 			next()
 		})
@@ -51,7 +51,7 @@ app.get("/status", async (req, res) => {
 	}
 })
 
-app.post("/setup", loginLimiter, validateBody, async (req, res) => {
+app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	const { username, password, token } = req.body
 	if (process.env.setup_TOKEN && token !== process.env.setup_TOKEN) return res.status(403).json({ error: true })
 	if (!username) return res.status(400).json({ error: true })
@@ -79,7 +79,7 @@ app.post("/setup", loginLimiter, validateBody, async (req, res) => {
 	}
 })
 
-app.post("/login", loginLimiter, validateBody, passwordCheck, login)
+app.post("/login", validateBody, loginLimiter, passwordCheck, login)
 app.post("/verify", authorize, async (req, res) => {
 	try {
 		const result = await pool.query("SELECT force_password_change, theme FROM auth WHERE username = $1", [req.decoded.username])

--- a/command/frontend/hooks/usePastImages.js
+++ b/command/frontend/hooks/usePastImages.js
@@ -30,11 +30,12 @@ const updateImages = (state, setState) => {
 		body: processBody(state)
 	}, (prom) => {
 		jsonProcessing(prom, (data) => {
+			const list = data && Array.isArray(data.list) ? data.list : []
 			setState((oldState) => ({
 				...oldState,
-				list: data.list,
-				loading: data.list.length > 0,
-				sliderIndex: data.list.length-1
+				list,
+				loading: list.length > 0,
+				sliderIndex: list.length-1
 			}))
 		})
 	})

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -624,6 +624,17 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(429)
 			expect(res.body).toEqual({ error: true, errors: "Too many attempts" })
 		})
+
+		test("empty-body 400s do not count toward the login lockout", async () => {
+			let res
+			for (let i = 0; i < 15; i++) {
+				res = await supertest(app)
+					.post("/authorization/login")
+					.set("X-Forwarded-For", "203.0.113.7")
+					.send({})
+			}
+			expect(res.status).toBe(400)
+		})
 	})
 
 	describe("rateLimit (shared memory instance)", () => {

--- a/gateway/services.js
+++ b/gateway/services.js
@@ -27,7 +27,8 @@ module.exports = [{
 	serviceOn: process.env.command_PROXY_ON === "true",
 	log: "🎮 Command Proxied ◀",
 	baseURL: process.env.command_HOST,
-	postPathRegex: /\/.*/,
+	// /authorization/setup is intentionally not proxied: first-admin creation must hit the command service directly, never through the public gateway
+	postPathRegex: /\/(?!authorization\/setup).*/,
 	getPathRegex: /\/.*/,
 	deletePathRegex: /\/.*/,
 	putPathRegex: /\/.*/

--- a/gateway/test/gateway.test.js
+++ b/gateway/test/gateway.test.js
@@ -31,6 +31,13 @@ describe("Gateway Tests", () => {
 		})
 	})
 
+	test("Gateway does not proxy POST /authorization/setup", (done) => {
+		supertest(gateway)
+			.post("/authorization/setup")
+			.send({ username: "x", password: "y" })
+			.expect(404, done)
+	})
+
 	test("Gateway forwards PUT requests", (done) => {
 		const server = handleServerStart(command, process.env.command_PORT, () => {
 			supertest(gateway)

--- a/memory/lib/loginAttempts.js
+++ b/memory/lib/loginAttempts.js
@@ -4,9 +4,13 @@ module.exports = () => {
 	const prune = (now) => {
 		if(hits.size > 5000) for(const [k, v] of hits) if(now > v.reset) hits.delete(k)
 		if(hits.size > MAX_KEYS){
-			const locked = (v) => now <= v.reset && v.count >= v.max
-			const order = [...hits.entries()].sort((a, b) => locked(a[1]) - locked(b[1]) || a[1].reset - b[1].reset)
-			for(const [k] of order){ if(hits.size <= MAX_KEYS) break; hits.delete(k) }
+			const target = MAX_KEYS - (MAX_KEYS >> 3)
+			for(const [k, v] of hits){
+				if(hits.size <= target) break
+				if(now <= v.reset && v.count >= v.max) continue
+				hits.delete(k)
+			}
+			if(hits.size > MAX_KEYS) for(const k of hits.keys()){ if(hits.size <= MAX_KEYS) break; hits.delete(k) }
 		}
 	}
 	return {

--- a/memory/lib/loginAttempts.js
+++ b/memory/lib/loginAttempts.js
@@ -3,7 +3,11 @@ module.exports = () => {
 	const MAX_KEYS = 20000
 	const prune = (now) => {
 		if(hits.size > 5000) for(const [k, v] of hits) if(now > v.reset) hits.delete(k)
-		if(hits.size > MAX_KEYS) for(const k of hits.keys()) { if(hits.size <= MAX_KEYS) break; hits.delete(k) }
+		if(hits.size > MAX_KEYS){
+			const locked = (v) => now <= v.reset && v.count >= v.max
+			const order = [...hits.entries()].sort((a, b) => locked(a[1]) - locked(b[1]) || a[1].reset - b[1].reset)
+			for(const [k] of order){ if(hits.size <= MAX_KEYS) break; hits.delete(k) }
+		}
 	}
 	return {
 		loginReserve: (key, max, windowMs, callback=()=>{}) => {
@@ -11,7 +15,7 @@ module.exports = () => {
 			prune(now)
 			const entry = hits.get(key)
 			if(entry && now <= entry.reset && entry.count >= max) return callback(true)
-			if(!entry || now > entry.reset) hits.set(key, { count: 1, reset: now + windowMs })
+			if(!entry || now > entry.reset) hits.set(key, { count: 1, reset: now + windowMs, max })
 			else entry.count++
 			callback(false)
 		},

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -9,7 +9,7 @@ const sendWebhook = require("./webhook.js")
 const INPUT = detector.INPUT
 const TEMP_DIR = path.join(process.cwd(), "objectTemp")
 const CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH || process.cwd(), "objectCaptures")
-const MAX_CAPTURES = parseInt(process.env.object_MAX_CAPTURES) || 500
+const MAX_CAPTURES = Number.isFinite(parseInt(process.env.object_MAX_CAPTURES)) ? parseInt(process.env.object_MAX_CAPTURES) : 500
 fs.mkdirSync(TEMP_DIR, { recursive: true })
 fs.mkdirSync(CAPTURES_DIR, { recursive: true })
 
@@ -40,7 +40,7 @@ const pruneCaptures = async () => {
 }
 
 const config = {
-	confidence: parseFloat(process.env.object_CONFIDENCE) || 0.5,
+	confidence: Number.isFinite(parseFloat(process.env.object_CONFIDENCE)) ? parseFloat(process.env.object_CONFIDENCE) : 0.5,
 	intervalMs: parseInt(process.env.object_INTERVAL_MS) || 5000,
 	classes: ["person", "car", "bird", "dog", "cat", "truck", "bus", "motorcycle", "umbrella", "bicycle"],
 }
@@ -178,6 +178,7 @@ module.exports = {
 	cameraCount,
 	getCameraNames,
 	CAPTURES_DIR,
+	MAX_CAPTURES,
 	getStatus: () => status,
 	getConfig: () => config,
 	setConfig: (updates) => {

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -244,3 +244,40 @@ describe("CAPTURES_DIR", () => {
 		expect(w.CAPTURES_DIR).toBe(path.join("/mnt/storage", "objectCaptures"))
 	})
 })
+
+describe("env-derived numeric config", () => {
+	const savedConf = process.env.object_CONFIDENCE
+	const savedMax = process.env.object_MAX_CAPTURES
+
+	afterEach(() => {
+		if (savedConf === undefined) delete process.env.object_CONFIDENCE
+		else process.env.object_CONFIDENCE = savedConf
+		if (savedMax === undefined) delete process.env.object_MAX_CAPTURES
+		else process.env.object_MAX_CAPTURES = savedMax
+		jest.resetModules()
+	})
+
+	test("object_CONFIDENCE=0 is honored, not coerced to default", () => {
+		process.env.object_CONFIDENCE = "0"
+		jest.resetModules()
+		expect(require("../backend/lib/worker.js").getConfig().confidence).toBe(0)
+	})
+
+	test("confidence defaults to 0.5 when unset or non-numeric", () => {
+		delete process.env.object_CONFIDENCE
+		jest.resetModules()
+		expect(require("../backend/lib/worker.js").getConfig().confidence).toBe(0.5)
+	})
+
+	test("object_MAX_CAPTURES=0 is honored, not coerced to default", () => {
+		process.env.object_MAX_CAPTURES = "0"
+		jest.resetModules()
+		expect(require("../backend/lib/worker.js").MAX_CAPTURES).toBe(0)
+	})
+
+	test("MAX_CAPTURES defaults to 500 when unset or non-numeric", () => {
+		delete process.env.object_MAX_CAPTURES
+		jest.resetModules()
+		expect(require("../backend/lib/worker.js").MAX_CAPTURES).toBe(500)
+	})
+})

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -3,6 +3,7 @@ const fs = require("fs")
 const { execFile } = require("child_process")
 const rimraf = require("rimraf")
 const moment = require("moment")
+const { loadCameras, webhookAlert } = require("lib")
 
 const Pool = require("pg").Pool
 const pool = new Pool({
@@ -31,7 +32,7 @@ module.exports = {
 
 	validateDays: (req, res, next) => {
 		const {days} = req.body
-		if(days != null){
+		if(days != null && days >= 0){
 			next()
 		}
 		else{
@@ -95,11 +96,12 @@ module.exports = {
 	},
 
 	dailyStats: (req, res) => {
-		const cameras = JSON.parse(process.env.cameras)
+		const cameras = loadCameras()
+		if(cameras.length == 0) return res.send([])
 		queryForDailyStats(cameras).then(values => {
 			const stats = values.rows.map(row => ({
 				timestamp: moment(row.timestamp).valueOf(),
-				...cameras.reduce((obj, cam) => ({ ...obj, [cam]: parseInt(row[cam]) || 0 }), {})
+				...cameras.reduce((obj, { name }) => ({ ...obj, [name]: parseInt(row[name]) || 0 }), {})
 			}))
 			res.send(stats)
 		}).catch(err => {
@@ -109,13 +111,14 @@ module.exports = {
 	},
 
 	fileStats: (req, res) => {
-		const cameras = JSON.parse(process.env.cameras)
+		const cameras = loadCameras()
+		if(cameras.length == 0) return res.send([])
 		queryForGroupedStats(cameras).then(values => {
 			let fileStats = values.rows.map(row => ({
 				timestamp: moment(row.timestamp).valueOf(),
-				...cameras.reduce((obj, item) => ({
+				...cameras.reduce((obj, { name }) => ({
 					...obj,
-					[item]: parseInt(row[item])
+					[name]: parseInt(row[name])
 				}), {})
 			}))
 			res.send(fileStats)
@@ -141,6 +144,16 @@ module.exports = {
 			if (usedBytes <= targetBytes) return res.send({ cleaned: false })
 
 			const toFree = usedBytes - targetBytes
+
+			const { rows: frameTotalRows } = await pool.query(
+				"SELECT COALESCE(SUM(size), 0) AS total FROM frame_files WHERE size IS NOT NULL AND size > 0"
+			)
+			const frameTotal = parseInt(frameTotalRows[0].total) || 0
+			if (toFree >= frameTotal) {
+				webhookAlert(`⚠️ Storage over ${maxGb}GB cap but non-frame artifacts (videos/zips) dominate — deleting all frames would not reach target, so auto-clean was skipped.`, "admin")
+				return res.send({ cleaned: false })
+			}
+
 			let freed = 0
 			let deleted = 0
 
@@ -174,23 +187,23 @@ module.exports = {
 	},
 
 	cameraMetrics: (req, res) => {
-		const cameras = JSON.parse(process.env.cameras)
+		const cameras = loadCameras()
 
-		const sizePromises = Promise.all(cameras.map((camera, index) => {
-			return queryForMetric(index+1, "size").then(extractValueForMetric("size"))
+		const sizePromises = Promise.all(cameras.map(({ id }) => {
+			return queryForMetric(id, "size").then(extractValueForMetric("size"))
 		}))
 
-		const countPromises = Promise.all(cameras.map((camera, index) => {
-			return queryForMetric(index+1, "count").then(extractValueForMetric("count"))
+		const countPromises = Promise.all(cameras.map(({ id }) => {
+			return queryForMetric(id, "count").then(extractValueForMetric("count"))
 		}))
 
 		Promise.all([sizePromises, countPromises]).then(values => {
 			let sizes = values[0]
 			let counts = values[1]
 			let metrics = { size: {}, count: {} }
-			cameras.forEach((camera, index) => {
-				metrics.size[camera] = sizes[index] ? sizes[index] : 0
-				metrics.count[camera] = counts[index] ? counts[index] : 0
+			cameras.forEach(({ name }, index) => {
+				metrics.size[name] = sizes[index] ? sizes[index] : 0
+				metrics.count[name] = counts[index] ? counts[index] : 0
 			})
 			res.send(metrics)
 		}).catch(err => {
@@ -214,12 +227,12 @@ const queryToAddToDeletionsTable = (camera, size, count) => {
 }
 
 const queryForDailyStats = (cameras) => {
-	const cols = cameras.map((cam, i) => `SUM(CASE WHEN camera=${i + 1} THEN size ELSE 0 END) as "${cam}"`)
+	const cols = cameras.map(({ id, name }) => `SUM(CASE WHEN camera=${id} THEN size ELSE 0 END) as "${name}"`)
 	return pool.query(`SELECT date_trunc('minute', timestamp) as timestamp,${cols.join(",")} FROM frame_files WHERE timestamp >= NOW() - INTERVAL '24 hours' GROUP BY 1 ORDER BY 1 ASC;`)
 }
 
 const queryForGroupedStats = (cameras) => {
-	const arrayOfColumns = cameras.map((cam, index) => `SUM(CASE WHEN camera=${index+1} THEN size ELSE 0 END) as "${cam}"`)
+	const arrayOfColumns = cameras.map(({ id, name }) => `SUM(CASE WHEN camera=${id} THEN size ELSE 0 END) as "${name}"`)
 	return pool.query(`SELECT date_trunc('hour', timestamp) as timestamp,${arrayOfColumns.join(",")} FROM frame_files GROUP BY 1 ORDER BY 1 ASC;`)
 }
 

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -40,10 +40,11 @@ describe("File Routes", () => {
 	})
 
 	describe("/file/dailyStats", () => {
-		afterEach(() => { delete process.env.cameras })
+		const { loadCameras } = require("lib")
+		afterEach(() => { loadCameras.mockReturnValue([]) })
 
 		test("maps rows to per-camera byte totals", async () => {
-			process.env.cameras = JSON.stringify(["cam1", "cam2"])
+			loadCameras.mockReturnValue([{ id: 1, name: "cam1" }, { id: 2, name: "cam2" }])
 			const ts = new Date("2026-06-11T10:00:00Z")
 			query.mockImplementationOnce(() => Promise.resolve({ rows: [
 				{ timestamp: ts, cam1: "100", cam2: "200" }
@@ -56,7 +57,7 @@ describe("File Routes", () => {
 		})
 
 		test("returns 500 on db error", async () => {
-			process.env.cameras = JSON.stringify(["cam1"])
+			loadCameras.mockReturnValue([{ id: 1, name: "cam1" }])
 			query.mockRejectedValueOnce(new Error("db error"))
 			const res = await supertest(app)
 				.get("/file/dailyStats")
@@ -151,19 +152,34 @@ describe("File Routes", () => {
 			test("deletes oldest frames until under target when over limit", async () => {
 				process.env.storage_MAX_GB = "1"
 				execFile.mockImplementation((_cmd, _args, cb) => cb(null, "2000000000\t/path\n"))
-				query.mockImplementationOnce(() => Promise.resolve({ rows: [
-					{ id: 1, camera: "1", name: "a.jpg", size: "600000000" },
-					{ id: 2, camera: "1", name: "b.jpg", size: "600000000" },
-					{ id: 3, camera: "1", name: "c.jpg", size: "600000000" }
-				] }))
+				query
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "1800000000" }] }))
+					.mockImplementationOnce(() => Promise.resolve({ rows: [
+						{ id: 1, camera: "1", name: "a.jpg", size: "600000000" },
+						{ id: 2, camera: "1", name: "b.jpg", size: "600000000" },
+						{ id: 3, camera: "1", name: "c.jpg", size: "600000000" }
+					] }))
 				const res = await supertest(app)
 					.post("/file/pathAutoClean")
 					.set("Cookie", cookieWithBearerToken)
 				expect(res.status).toBe(200)
 				expect(res.body).toEqual({ cleaned: true, deleted: 2 })
 				expect(unlinkSpy).toHaveBeenCalledTimes(2)
-				expect(query).toHaveBeenCalledTimes(2)
-				expect(query.mock.calls[1][1]).toEqual([[1, 2]])
+				expect(query).toHaveBeenCalledTimes(3)
+				expect(query.mock.calls[2][1]).toEqual([[1, 2]])
+			})
+
+			test("skips when non-frame artifacts dominate and deleting all frames can't reach target", async () => {
+				process.env.storage_MAX_GB = "1"
+				execFile.mockImplementation((_cmd, _args, cb) => cb(null, "2000000000\t/path\n"))
+				query.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "500000000" }] }))
+				const res = await supertest(app)
+					.post("/file/pathAutoClean")
+					.set("Cookie", cookieWithBearerToken)
+				expect(res.status).toBe(200)
+				expect(res.body).toEqual({ cleaned: false })
+				expect(query).toHaveBeenCalledTimes(1)
+				expect(unlinkSpy).not.toHaveBeenCalled()
 			})
 
 			test("returns 500 on db error", async () => {


### PR DESCRIPTION
Addresses the review findings raised by @susanchapas on #178. Original comments are preserved verbatim below (they are being removed from #178).

## Resolution

| # | Finding | Resolution |
|---|---------|-----------|
| 1 | `autoClean` can wipe entire frame dataset (file.js:147) | Skip + admin webhook alert when `toFree >= frameTotal` (deleting all frames can't reach target) |
| 2 | `days=0` globs `*.jpg`, deletes every frame (file.js:89) | `validateDays` now rejects `days < 0`; `days=0` (delete-all) kept valid by design |
| 3 | object service never gets `SECRETKEY` (splitAndValidateEnvVars:145) | `SECRETKEY` written to `env.object`. `scheduler_AUTH` not needed — object routes aren't in `schedulableUrls` |
| 4 | login limiter never releases on 4xx (authorization.js:40) | `validateBody` reordered before `loginLimiter` on `/login` **and** `/setup`; release on `>=500` |
| 5 | over-capacity prune evicts live lockouts (loginAttempts.js:6) | Evict unlocked / soonest-reset first; `max` stored on entry for lockout check |
| 6 | `object_CONFIDENCE=0` becomes `0.5` (worker.js:43) | `Number.isFinite` checks for `confidence` and `MAX_CAPTURES` |
| 7 | `data.list` deref crashes on 304/error (usePastImages.js:35) | `Array.isArray(data.list)` guard, defaults to `[]` |
| 8 | `dailyStats` maps cameras by array index (file.js:216) | All paths use `loadCameras()` real `id`/`name` (dailyStats, groupedStats, cameraMetrics) |

Tests added: storage autoClean skip-branch, worker env-zero (`confidence`/`MAX_CAPTURES`), command empty-body lockout, gateway setup-block.

---

## Original review comments (@susanchapas, from #178)

**🛑 Data loss: `storage/backend/routes/lib/file.js:147` — `autoClean` can wipe the entire frame dataset**

`toFree` is computed from `du -sb` of the whole captures dir (which includes generated `.mp4`/`.zip` artifacts), but `freed` is only incremented by `frame_files` row sizes:

```js
while (freed < toFree) {
```

When disk usage over `storage_MAX_GB` is dominated by non-frame artifacts (videos/zips), `freed` can never reach `toFree`. The inner batch loop consumes every 10000-row batch without the partial-batch `break` (line ~166) ever firing, so the loop only exits at `rows.length === 0` — after deleting **every** frame row and unlinking **every** frame file, while disk usage is still above target.

**Trigger:** `POST /pathAutoClean` (admin) when storage is over the cap mostly due to generated videos/zips → entire frame dataset destroyed, target still not met.

Fix: clamp `toFree` to the total tracked frame size, or account for non-frame artifacts in the cleanup target.

---

**🛑 Data loss: `storage/backend/routes/lib/file.js:89` — `days=0` globs `*.jpg` and deletes every frame**

The new empty-`clobArr` branch inverts the previous safe behavior:

```js
const glob = clobArr.length == 0
    ? "*.jpg"
    : `./!(${clobArr.join("|")})*.jpg`
```

`validateDays` only checks `days != null`, so `days=0` passes. With `days=0`, `beforeDate === now`, the DB DELETE matches all rows (so the `numberOfFilesDeletedInDatabase == 0` early return doesn't fire), and `generateBeforeDateGlobNotPatternsArray` returns an empty `clobArr` (every `now.diff(beforeDate, unit) > 0` is false). The ternary then builds glob `"*.jpg"` and rimraf deletes every frame on disk for the camera.

Old code did the opposite: empty `clobArr` → `{deleted:false}`, removing nothing.

**Trigger:** `POST /pathClean` (admin) or scheduler with `days=0` / any edge value → camera's frames wiped.

Fix: empty `clobArr` should delete nothing (restore the old guard).

---

**🛑 `chimera/splitAndValidateEnvVars.js:145` — object service never gets `SECRETKEY`, so its auth always fails**

`SECRETKEY` is written only to `env.command` and `env.lib`:

```js
env.command += writeVarLine("SECRETKEY")
env.lib += writeVarLine("SECRETKEY")
```

…never to `env.object`. But `object/backend/object.js` mounts `app.use(auth.createAuthorize(pool))`, and `lib/utils/auth.js` reads `const secretKey = process.env.SECRETKEY` at module load. `object/start.js` loads only `object/.env` via dotenv, so `secretKey` is `undefined` in the object process.

Result: every authenticated request hits `jwt.verify(token, undefined, …)` → error callback → `303 /?loginForm` (GET) or `401` (POST). `scheduler_AUTH` is likewise never written to `env.object`, so the scheduler bypass also breaks.

**Trigger:** any authenticated request to the object service after a fresh `node splitAndValidateEnvVars.js` generation → object service unusable behind auth in the default generated config.

Fix: write `SECRETKEY` (and `scheduler_AUTH`) into `env.object`.

---

**`command/backend/routes/authorization.js:40` — login rate limiter never releases the slot on 4xx responses**

```js
res.on("finish", () => { if (res.statusCode < 400) release(key) })
```

On `/login` the middleware order is `loginLimiter, validateBody, passwordCheck, login`. `loginLimiter` calls `reserve()` and registers the `finish` handler above before `next()`. An empty/missing body makes `validateBody` return `400` *before* any password check — and since `400` is not `< 400`, the reserved slot is never released.

**Trigger:** repeatedly `POST /login` with an empty body from one IP. With `max:10, windowMs:15min`, after 10 empty submissions that IP is locked out (`429`) for 15 minutes without ever attempting a real password. The same gap also fails to release on a genuine `500` (e.g. session-insert failure on a valid login), counting it against the limit.

Fix: release the reserved slot for non-auth-failure outcomes (e.g. release unless `statusCode === 401/403`), or reserve only after `validateBody`/`passwordCheck`.

---

**`memory/lib/loginAttempts.js:6` — over-capacity prune evicts live lockout entries, bypassing the lockout window**

```js
if(hits.size > MAX_KEYS) for(const k of hits.keys()) { if(hits.size <= MAX_KEYS) break; hits.delete(k) }
```

The first prune loop only removes *expired* entries. The second loop (above) deletes the oldest entries in insertion order with **no expiry/lockout check**, gated only by `hits.size > MAX_KEYS` (20000). Once >20000 distinct keys have live windows, the first loop frees nothing and the second evicts live entries indiscriminately.

Caller uses `key = ${req.ip}:${req.path}`, `windowMs=15min`, `max=10`. An attacker spoofing >20000 source IPs within the window can evict an active `count>=max` lockout entry; the next `loginReserve` for that key hits the `!entry` branch and recreates `{count:1, reset:now+windowMs}`, resetting the count and **bypassing the active lockout**.

Fix: when over capacity, evict by soonest expiry / skip non-expired locked entries, rather than blind oldest-first deletion.

---

**`object/backend/lib/worker.js:43` — `object_CONFIDENCE=0` silently becomes `0.5` (falsy-zero)**

```js
confidence: parseFloat(process.env.object_CONFIDENCE) || 0.5,
```

`parseFloat("0") || 0.5` evaluates to `0.5`. An operator setting the threshold to `0` (to capture all detections) silently gets `0.5` instead, so detections below 0.5 are dropped. The value flows into `detector.detect(toTensor(raw), config.confidence)`.

That `0` is a legitimate intended value is proven by the runtime-update path (lines ~184-186), which validates `c >= 0 && c <= 1` and accepts zero — yet env initialization coerces it away.

Same falsy-zero bug at line ~12: `MAX_CAPTURES = parseInt(process.env.object_MAX_CAPTURES) || 500` → `object_MAX_CAPTURES=0` becomes `500`.

Fix: use a null-coalescing/explicit-NaN check (e.g. `Number.isFinite(parseFloat(x)) ? parseFloat(x) : default`).

---

**`command/frontend/hooks/usePastImages.js:35` — `data.list` deref crashes the render on a 304 / errored response**

```js
list: data.list,
```

`jsonProcessing` (with the newly added 304 branch in `request.js`) returns `undefined` when the response is HTTP `304` (`if (res.status === 304) return undefined`) and also calls back `undefined` on fetch/parse error (`.catch(() => callback(undefined))`). `updateImages` dereferences `data.list` with no null guard.

**Trigger:** any state change calling `updateImages` while `POST /convert/listFramesVideo` returns `304` (repeated/cached request) or the fetch rejects → `Cannot read properties of undefined (reading 'list')` inside the `useEffect`-driven setState, crashing the SummaryScrubber / past-images render. The `304 → undefined` branch is new in this PR, making the crash newly reachable.

Fix: guard for `undefined`/falsy `data` before reading `data.list`.

---

**`storage/backend/routes/lib/file.js:216` — `dailyStats` maps cameras by array index, diverging from real `camera_id` (plausible)**

```js
const cols = cameras.map((cam, i) => `SUM(CASE WHEN camera=${i + 1} THEN size ELSE 0 END) as "${cam}"`)
```

`queryForDailyStats` keys columns off the array index of `process.env.cameras` (a list of camera *names*), assuming DB `frame_files.camera` ids are contiguous and 1-based in the same order. But this PR's new `events.js`/`/usage` uses an independent identity source — `loadCameras()` reads explicit `camera_id` values from each motion `.conf` and queries `WHERE camera = $1` with those real ids (sorted, `id > 0`, not required to be contiguous/1-based).

**Trigger:** a deployment with non-contiguous/non-1-based ids, e.g. env `["A","C"]` but DB ids `1` and `3` → dailyStats sums `camera=1` and `camera=2`, attributing nothing to id 3 and mislabeling id-2 data under "C". Daily-stats chart shows wrong/zero data.

This is the pre-existing `i+1` convention (also in `queryForGroupedStats`/`cameraMetrics`), newly exposed by `events.js` adopting explicit `camera_id`. **Plausible** — depends on whether real deployments use non-1-based ids. Worth aligning both paths on `loadCameras()` ids.
