### PR TITLE
Re-throw command setup_TOKEN guard in launcher; add admin confirm password

### DIFF
--- a/command/frontend/app/AdminPanel.jsx
+++ b/command/frontend/app/AdminPanel.jsx
@@ -22,7 +22,7 @@ const AdminPanel = ({ withButton } = {}) => {
 	const [tempPassword, setTempPassword] = useState(null)
 	const [copied, setCopied] = useState(false)
 	const [editTarget, setEditTarget] = useState(null)
-	const [editForm, setEditForm] = useState({ role: "", password: "" })
+	const [editForm, setEditForm] = useState({ role: "", password: "", confirm: "" })
 	const [deleteTarget, setDeleteTarget] = useState(null)
 	const [expandedSessions, setExpandedSessions] = useState({})
 	const [sessions, setSessions] = useState({})
@@ -58,6 +58,7 @@ const AdminPanel = ({ withButton } = {}) => {
 	const updateUser = (e) => {
 		e.preventDefault()
 		if (editForm.password) {
+			if (editForm.password !== editForm.confirm) return toast("Passwords do not match")
 			const invalid = validatePassword(editForm.password)
 			if (invalid) return toast(invalid)
 		}
@@ -263,7 +264,7 @@ const AdminPanel = ({ withButton } = {}) => {
 											{expandedSessions[user.username] ? "Hide Sessions" : "Sessions"}
 										</Button>
 										<Dialog open={editTarget?.username === user.username} onOpenChange={open => {
-											if (open) { setEditTarget(user); setEditForm({ role: user.role, password: "" }) }
+											if (open) { setEditTarget(user); setEditForm({ role: user.role, password: "", confirm: "" }) }
 											else setEditTarget(null)
 										}}>
 											<DialogTrigger asChild>
@@ -293,6 +294,16 @@ const AdminPanel = ({ withButton } = {}) => {
 															onChange={e => setEditForm(f => ({ ...f, password: e.target.value }))}
 															className="bg-surface-raised border-border text-primary placeholder:text-muted"
 															placeholder="leave blank to keep current"
+														/>
+													</div>
+													<div className="flex flex-col gap-1">
+														<Label className="text-primary">Confirm Password</Label>
+														<Input
+															type="password"
+															value={editForm.confirm}
+															onChange={e => setEditForm(f => ({ ...f, confirm: e.target.value }))}
+															className="bg-surface-raised border-border text-primary placeholder:text-muted"
+															placeholder="re-enter new password"
 														/>
 													</div>
 													<DialogFooter>

--- a/server.js
+++ b/server.js
@@ -2,11 +2,16 @@ require("dotenv").config()
 
 console.log("--- Starting Servers ---")
 
-const startService = (name, mod) => {
-	try { mod.start() } catch (e) { console.error(`❌ ${name} failed to start:`, e.message) }
+const startService = (name, mod, { fatal = false } = {}) => {
+	try {
+		mod.start()
+	} catch (e) {
+		console.error(`❌ ${name} failed to start:`, e.message)
+		if (fatal) throw e
+	}
 }
 
-startService("command", require("command"))
+startService("command", require("command"), { fatal: true })
 startService("storage", require("storage"))
 startService("livestream", require("livestream"))
 startService("schedule", require("schedule"))


### PR DESCRIPTION
Stacked on #202 — targets that branch because the `server.js` change only exists there (not yet on `develop`). Will retarget to `develop` once #202 merges.

## 1. `server.js` — re-throw command's `setup_TOKEN` guard
Addresses review comment https://github.com/jjjpanda/Chimera/pull/202#discussion_r3478916569.

The `startService` wrapper added in #202 swallowed `command`'s hard guard: `command/server.js` `throw`s when `setup_TOKEN` is missing in order to fail loud, but the wrapper downgraded that to a single `console.error` while every other service kept booting — inconsistent with the standalone entry (`command/start.js`), which still hard-crashes on the same misconfig.

`startService` now accepts a `fatal` flag, and `command` is started with `{ fatal: true }` — its throw is logged **and** re-propagated, halting the combined launcher exactly like the standalone path. The other services stay best-effort.

## 2. `AdminPanel` — confirm password (Closes #203)
The admin **Edit User → New Password** field had no confirmation. Added a **Confirm Password** input mirroring `ChangePasswordForm`, and `updateUser` now rejects with "Passwords do not match" when the two differ (only when a new password is actually being set).

## Validation
- `command` jest server-guard test passes (`test/server.test.js`).
- `vite build` of the command frontend succeeds.
- No e2e/unit test exercises the edit-password path. Lint is unchanged (the file carries pre-existing `indent`/`no-unescaped-entities` warnings; the new block matches the sibling field's style).
