### PR TITLE
Restore deleted guard in deleteFileDirectory

### DIFF
--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -73,7 +73,7 @@ module.exports = {
 
 	deleteFileDirectory: (req, res) => {
 		rimraf(req.body.appendedPath, (err) => {
-			res.send({deleted: !err})
+			res.send({deleted: !err && req.numberOfFilesDeletedInDatabase > 0})
 		})
 	},
 

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -92,6 +92,16 @@ describe("File Routes", () => {
 				.set("Cookie", "userCookie")
 				.expect(403, done)
 		})
+
+		test("reports deleted:false when the database delete matched no rows", async () => {
+			query.mockImplementationOnce(() => Promise.resolve({ rows: [] }))
+			const res = await supertest(app)
+				.post("/file/pathDelete")
+				.send({ camera: 1 })
+				.set("Cookie", cookieWithBearerToken)
+			expect(res.status).toBe(200)
+			expect(res.body).toEqual({ deleted: false })
+		})
 	})
 
 	describe("/file/pathClean", () => {


### PR DESCRIPTION
Addresses the review comment on #202 (`storage/backend/routes/lib/file.js`).

PR #202 dropped the `&& req.numberOfFilesDeletedInDatabase > 0` guard from `deleteFileDirectory`. Since `rimraf` resolves without error on a missing/empty path, a delete against a camera with no tracked frames returned `{deleted: true}`, making the frontend toast "Files Deleted" when nothing was actually removed. The sibling `deleteFilesBeforeDateGlob` kept its guard, so dropping it here was accidental.

- Restore the guard: `res.send({deleted: !err && req.numberOfFilesDeletedInDatabase > 0})`
- Add a regression test asserting `deleted:false` when the DB delete matched no rows (fails on the pre-fix code, passes after).