### PR TITLE
Fix PR #178 review comments

### DIFF
--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -55,9 +55,8 @@ app.get("/status", async (req, res) => {
 		const result = await pool.query("SELECT COUNT(*) FROM auth")
 		res.json({ setup: parseInt(result.rows[0].count) > 0, tokenRequired: !!process.env.setup_TOKEN })
 	} catch (e) {
-		console.error(e)
 		if (e.code === "42P01") return res.json({ setup: false, tokenRequired: !!process.env.setup_TOKEN })
-		res.status(500).json({ error: true })
+		sendError(res, e)
 	}
 })
 
@@ -91,8 +90,7 @@ app.post("/verify", authorize, async (req, res) => {
 		const row = result.rows[0] ?? {}
 		res.json({ error: false, role: req.decoded.role, forcePasswordChange: row.force_password_change ?? false, theme: row.theme ?? "system" })
 	} catch (e) {
-		console.error(e)
-		res.status(500).json({ error: true })
+		sendError(res, e)
 	}
 })
 
@@ -103,8 +101,7 @@ app.put("/theme", authorize, validateBody, async (req, res) => {
 		await pool.query("UPDATE auth SET theme = $1 WHERE username = $2", [theme, req.decoded.username])
 		res.json({ error: false })
 	} catch (e) {
-		console.error(e)
-		res.status(500).json({ error: true })
+		sendError(res, e)
 	}
 })
 
@@ -113,8 +110,7 @@ app.get("/users", authorize, requireAdmin, async (req, res) => {
 		const result = await pool.query("SELECT username, role, last_login FROM auth ORDER BY username")
 		res.json(result.rows)
 	} catch (e) {
-		console.error(e)
-		res.status(500).json({ error: true })
+		sendError(res, e)
 	}
 })
 
@@ -130,8 +126,8 @@ app.post("/users", authorize, requireAdmin, validateBody, async (req, res) => {
 		await pool.query("INSERT INTO auth(username, hash, role, force_password_change, temp_password_expires) VALUES($1, $2, $3, TRUE, NOW() + INTERVAL '24 hours')", [username, hash, role])
 		res.json({ error: false, tempPassword })
 	} catch (e) {
-		console.error(e)
-		res.status(e.code === "23505" ? 400 : 500).json({ error: true })
+		if (e.code === "23505") return sendError(res, new HttpError(400))
+		sendError(res, e)
 	}
 })
 
@@ -184,8 +180,7 @@ app.get("/users/:username/sessions", authorize, requireAdmin, async (req, res) =
 		)
 		res.json(result.rows)
 	} catch (e) {
-		console.error(e)
-		res.status(500).json({ error: true })
+		sendError(res, e)
 	}
 })
 
@@ -197,8 +192,7 @@ app.delete("/sessions/:id", authorize, requireAdmin, async (req, res) => {
 		if (result.rowCount === 0) return res.status(404).json({ error: true })
 		res.json({ error: false })
 	} catch (e) {
-		console.error(e)
-		res.status(500).json({ error: true })
+		sendError(res, e)
 	}
 })
 
@@ -246,8 +240,7 @@ app.post("/logout", authorize, async (req, res) => {
 		res.clearCookie("bearertoken", { httpOnly: true, secure: process.env.NODE_ENV !== "development", sameSite: "lax" })
 		res.json({ error: false })
 	} catch (e) {
-		console.error(e)
-		res.status(500).json({ error: true })
+		sendError(res, e)
 	}
 })
 

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -1,7 +1,7 @@
 var express = require("express")
-var { validateBody, auth } = require("lib")
+var { validateBody, auth, password } = require("lib")
 const { requireAdmin } = auth
-const { passwordCheck, login, pool } = require("./lib/auth.js")
+const { passwordCheck, login, pool, withTransaction, HttpError } = require("./lib/auth.js")
 const authorize = auth.createAuthorize(pool)
 
 const bcrypt = require("bcryptjs")
@@ -10,8 +10,14 @@ const memory = require("memory")
 
 const app = express.Router()
 
-const isValidPassword = (p) => typeof p === "string" && p.length >= 8
-const PASSWORD_REQUIREMENT = "Password must be at least 8 characters."
+const { minLength: MIN_PASSWORD_LENGTH, requirement: PASSWORD_REQUIREMENT } = password
+const isValidPassword = (p) => typeof p === "string" && p.length >= MIN_PASSWORD_LENGTH
+
+const sendError = (res, e) => {
+	if (e instanceof HttpError) return res.status(e.status).json({ error: true, ...(e.errors && { errors: e.errors }) })
+	console.error(e)
+	res.status(500).json({ error: true })
+}
 
 const sharedAttempts = process.env.memory_ON == "true"
 const memoryClient = sharedAttempts ? memory.client("AUTH") : null
@@ -61,26 +67,20 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	if (!username) return res.status(400).json({ error: true })
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(username)) return res.status(400).json({ error: true, errors: "Username must be 3-50 characters and contain only letters, numbers, dashes, dots, and underscores." })
-	let client
 	try {
-		client = await pool.connect()
 		const salt = await bcrypt.genSalt(10)
 		const hash = await bcrypt.hash(password, salt)
-		await client.query("BEGIN")
-		await client.query("SELECT pg_advisory_xact_lock(1)")
-		const result = await client.query(
-			"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth)",
-			[username, hash]
-		)
-		await client.query("COMMIT")
+		const result = await withTransaction(async (client) => {
+			await client.query("SELECT pg_advisory_xact_lock(1)")
+			return client.query(
+				"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth)",
+				[username, hash]
+			)
+		})
 		if (result.rowCount === 0) return res.status(403).json({ error: true })
 		res.json({ error: false })
 	} catch (e) {
-		console.error(e)
-		if (client) await client.query("ROLLBACK").catch(() => {})
-		res.status(500).json({ error: true })
-	} finally {
-		if (client) client.release()
+		sendError(res, e)
 	}
 })
 
@@ -141,50 +141,37 @@ app.patch("/users/:username", authorize, requireAdmin, validateBody, async (req,
 	if (password === undefined && role === undefined) return res.status(400).json({ error: true })
 	if (password !== undefined && !isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	if (role !== undefined && !["admin", "user"].includes(role)) return res.status(400).json({ error: true })
-	let hash, client
+	let hash
 	try {
 		if (password !== undefined) {
 			const salt = await bcrypt.genSalt(10)
 			hash = await bcrypt.hash(password, salt)
 		}
-		client = await pool.connect()
-		await client.query("BEGIN")
-		const target = await client.query("SELECT role FROM auth WHERE username = $1", [username])
-		if (target.rowCount === 0) {
-			await client.query("ROLLBACK")
-			return res.status(404).json({ error: true })
-		}
-		if (target.rows[0].role === "admin" && role === "user") {
-			const adminRows = await client.query("SELECT username FROM auth WHERE role = 'admin' FOR UPDATE")
-			if (adminRows.rows.length <= 1) {
-				await client.query("ROLLBACK")
-				return res.status(400).json({ error: true, errors: "cannot demote last admin" })
+		await withTransaction(async (client) => {
+			const target = await client.query("SELECT role FROM auth WHERE username = $1", [username])
+			if (target.rowCount === 0) throw new HttpError(404)
+			if (target.rows[0].role === "admin" && role === "user") {
+				const adminRows = await client.query("SELECT username FROM auth WHERE role = 'admin' FOR UPDATE")
+				if (adminRows.rows.length <= 1) throw new HttpError(400, "cannot demote last admin")
 			}
-		}
-		const updates = []
-		const values = []
-		if (role !== undefined) {
-			values.push(role)
-			updates.push(`role = $${values.length}`)
-		}
-		if (password !== undefined) {
-			values.push(hash)
-			updates.push(`hash = $${values.length}`)
-			updates.push("force_password_change = FALSE", "temp_password_expires = NULL")
-		}
-		values.push(username)
-		await client.query(`UPDATE auth SET ${updates.join(", ")} WHERE username = $${values.length}`, values)
-		if (password !== undefined || role !== undefined) {
+			const updates = []
+			const values = []
+			if (role !== undefined) {
+				values.push(role)
+				updates.push(`role = $${values.length}`)
+			}
+			if (password !== undefined) {
+				values.push(hash)
+				updates.push(`hash = $${values.length}`)
+				updates.push("force_password_change = FALSE", "temp_password_expires = NULL")
+			}
+			values.push(username)
+			await client.query(`UPDATE auth SET ${updates.join(", ")} WHERE username = $${values.length}`, values)
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
-		}
-		await client.query("COMMIT")
+		})
 		res.json({ error: false })
 	} catch (e) {
-		console.error(e)
-		if (client) await client.query("ROLLBACK").catch(() => {})
-		res.status(500).json({ error: true })
-	} finally {
-		if (client) client.release()
+		sendError(res, e)
 	}
 })
 
@@ -218,31 +205,19 @@ app.delete("/sessions/:id", authorize, requireAdmin, async (req, res) => {
 app.delete("/users/:username", authorize, requireAdmin, async (req, res) => {
 	const { username } = req.params
 	if (username === req.decoded.username) return res.status(400).json({ error: true })
-	let client
 	try {
-		client = await pool.connect()
-		await client.query("BEGIN")
-		const target = await client.query("SELECT role FROM auth WHERE username = $1", [username])
-		if (target.rowCount === 0) {
-			await client.query("ROLLBACK")
-			return res.status(404).json({ error: true })
-		}
-		if (target.rows[0].role === "admin") {
-			const adminRows = await client.query("SELECT username FROM auth WHERE role = 'admin' FOR UPDATE")
-			if (adminRows.rows.length <= 1) {
-				await client.query("ROLLBACK")
-				return res.status(400).json({ error: true, errors: "cannot delete last admin" })
+		await withTransaction(async (client) => {
+			const target = await client.query("SELECT role FROM auth WHERE username = $1", [username])
+			if (target.rowCount === 0) throw new HttpError(404)
+			if (target.rows[0].role === "admin") {
+				const adminRows = await client.query("SELECT username FROM auth WHERE role = 'admin' FOR UPDATE")
+				if (adminRows.rows.length <= 1) throw new HttpError(400, "cannot delete last admin")
 			}
-		}
-		await client.query("DELETE FROM auth WHERE username = $1", [username])
-		await client.query("COMMIT")
+			await client.query("DELETE FROM auth WHERE username = $1", [username])
+		})
 		res.json({ error: false })
 	} catch (e) {
-		console.error(e)
-		if (client) await client.query("ROLLBACK").catch(() => {})
-		res.status(500).json({ error: true })
-	} finally {
-		if (client) client.release()
+		sendError(res, e)
 	}
 })
 
@@ -250,22 +225,16 @@ app.post("/password", authorize, validateBody, async (req, res) => {
 	const { password } = req.body
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	const username = req.decoded.username
-	let client
 	try {
 		const salt = await bcrypt.genSalt(10)
 		const hash = await bcrypt.hash(password, salt)
-		client = await pool.connect()
-		await client.query("BEGIN")
-		await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2", [hash, username])
-		await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
-		await client.query("COMMIT")
+		await withTransaction(async (client) => {
+			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2", [hash, username])
+			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
+		})
 		res.json({ error: false })
 	} catch (e) {
-		console.error(e)
-		if (client) await client.query("ROLLBACK").catch(() => {})
-		res.status(500).json({ error: true })
-	} finally {
-		if (client) client.release()
+		sendError(res, e)
 	}
 })
 

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -14,8 +14,33 @@ const pool = new Pool({
 
 const DUMMY_HASH = bcrypt.hashSync("invalid", 10)
 
+class HttpError extends Error {
+	constructor(status, errors) {
+		super(errors || "http error")
+		this.status = status
+		this.errors = errors
+	}
+}
+
+const withTransaction = async (fn) => {
+	const client = await pool.connect()
+	try {
+		await client.query("BEGIN")
+		const result = await fn(client)
+		await client.query("COMMIT")
+		return result
+	} catch (e) {
+		await client.query("ROLLBACK").catch(() => {})
+		throw e
+	} finally {
+		client.release()
+	}
+}
+
 module.exports = {
 	pool,
+	withTransaction,
+	HttpError,
 	passwordCheck: (req, res, next) => {
 		const { username, password } = req.body
 		const deny = () => res.status(400).json({ error: true, errors: "Invalid username or password" })
@@ -47,6 +72,7 @@ module.exports = {
 		}
 		jwt.sign({ username, role: req.userRole, jti }, secretKey, { expiresIn: "30d" },
 			(err, token) => {
+				if (err || !token) return res.status(500).json({ error: true })
 				res.cookie("bearertoken", `Bearer ${token}`, {
 					maxAge: 2592000000,
 					httpOnly: true,

--- a/command/frontend/js/password.js
+++ b/command/frontend/js/password.js
@@ -1,7 +1,6 @@
-const MIN_PASSWORD_LENGTH = 8
-const PASSWORD_REQUIREMENT = `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`
+import pw from "lib/utils/password.json"
 
-const validatePassword = (password) =>
+export const MIN_PASSWORD_LENGTH = pw.minLength
+export const PASSWORD_REQUIREMENT = pw.requirement
+export const validatePassword = (password) =>
 	typeof password === "string" && password.length >= MIN_PASSWORD_LENGTH ? null : PASSWORD_REQUIREMENT
-
-export { MIN_PASSWORD_LENGTH, PASSWORD_REQUIREMENT, validatePassword }

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -75,6 +75,18 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(400)
 			expect(res.body).toEqual({ error: true, errors: "Password must be at least 8 characters." })
 		})
+
+		test("returns 500 when the transaction throws a generic error", async () => {
+			const errSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+			mockedPool.query.mockRejectedValueOnce(new Error("db down"))
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.send({ username: "admin", password: "password123" })
+			expect(res.status).toBe(500)
+			expect(res.body).toEqual({ error: true })
+			expect(errSpy).toHaveBeenCalled()
+			errSpy.mockRestore()
+		})
 	})
 
 	describe("POST /authorization/login", () => {
@@ -120,6 +132,16 @@ describe("Authorization Routes", () => {
 				.send({ username: "bob", password: "temppass123" })
 			expect(res.status).toBe(200)
 			expect(res.body.error).toBe(false)
+		})
+
+		test("returns 500 when token signing fails", async () => {
+			const signSpy = jest.spyOn(jwt, "sign").mockImplementationOnce((payload, key, opts, cb) => cb(new Error("sign failed")))
+			const res = await supertest(app)
+				.post("/authorization/login")
+				.send({ username: "admin", password: "mockedPassword" })
+			expect(res.status).toBe(500)
+			expect(res.body).toEqual({ error: true })
+			signSpy.mockRestore()
 		})
 	})
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ module.exports = {
 	handleServerStart: require("./utils/handleServerStart.js"),
 	handleSecureServerStart: require("./utils/handleSecureServerStart.js"),
 	validateBody: require("./utils/validateBody.js"),
+	password: require("./utils/password.json"),
 	subprocess: require("./utils/subprocess.js"),
 	formatBytes: require("./utils/formatBytes.js"),
 	tempMiddleware: require("./utils/tempMiddleware.js"),

--- a/lib/utils/password.json
+++ b/lib/utils/password.json
@@ -1,0 +1,4 @@
+{
+	"minLength": 8,
+	"requirement": "Password must be at least 8 characters."
+}


### PR DESCRIPTION
Addresses the three inline review comments on #178.

- **jwt.sign error swallowed** (`lib/auth.js`): callback ignored `err`, setting a `Bearer undefined` cookie + `{error:false}` on sign failure. Now returns 500 without setting the cookie.
- **Password rule duplicated client/server** (DRY): hoisted length + message to `lib/utils/password.json`, consumed by both `authorization.js` and `frontend/js/password.js`. JSON chosen as the only format cleanly consumable by the CJS backend, jest, and Vite without bundler config.
- **Transaction boilerplate** (DRY): added `withTransaction` + `HttpError` to `lib/auth.js`; refactored `/setup`, `PATCH /users/:username`, `DELETE /users/:username`, `POST /password` with a shared `sendError` mapper.

Verified: command (77) + lib (32) jest tests pass, Vite production build succeeds, eslint clean.