### PR TITLE
Add periodic pruning for task_runs table

### DIFF
--- a/command/backend/command.js
+++ b/command/backend/command.js
@@ -1,6 +1,6 @@
 var path       = require("path")
 var express    = require("express")
-const { helmetOptions, tracker, auth } = require("lib")
+const { helmetOptions, tracker, auth, pruneInterval } = require("lib")
 const { pool } = require("./routes/lib/auth.js")
 const helmet = require("helmet")
 
@@ -27,11 +27,6 @@ for(const webpath of ["/login", "/", "/clip", "/live", "/recordings", "/stats", 
 	}))
 }
 
-app.startDbPruning = () => {
-	const prune = () => {
-		pool.query("DELETE FROM sessions WHERE revoked = TRUE OR issued_at < NOW() - INTERVAL '30 days'").catch(console.error)
-	}
-	return setInterval(prune, 1000 * 60 * 60 * 12).unref()
-}
+app.startDbPruning = () => pruneInterval(pool, "DELETE FROM sessions WHERE revoked = TRUE OR issued_at < NOW() - INTERVAL '30 days'")
 
 module.exports = app

--- a/command/backend/command.js
+++ b/command/backend/command.js
@@ -27,4 +27,11 @@ for(const webpath of ["/login", "/", "/clip", "/live", "/recordings", "/stats", 
 	}))
 }
 
+app.startDbPruning = () => {
+	const prune = () => {
+		pool.query("DELETE FROM sessions WHERE revoked = TRUE OR issued_at < NOW() - INTERVAL '30 days'").catch(console.error)
+	}
+	return setInterval(prune, 1000 * 60 * 60 * 12).unref()
+}
+
 module.exports = app

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -244,9 +244,5 @@ app.post("/logout", authorize, async (req, res) => {
 	}
 })
 
-setInterval(() => {
-	pool.query("DELETE FROM sessions WHERE revoked = TRUE OR issued_at < NOW() - INTERVAL '30 days'").catch(console.error)
-}, 1000 * 60 * 60 * 12).unref()
-
 app.rateLimit = rateLimit
 module.exports = app

--- a/command/server.js
+++ b/command/server.js
@@ -1,4 +1,4 @@
-const {handleServerStart} = require("lib")
+const {handleServerStart, isPrimeInstance} = require("lib")
 const app = require("./backend/command.js")
 
 module.exports = {
@@ -8,6 +8,7 @@ module.exports = {
 			console.log("\t▶ Authorization Routes:\t /authorization")
 			console.log("\t▶ Resource Routes:\t /res")
 			console.log("\t▶ Web App Launched")
+			if (isPrimeInstance) app.startDbPruning()
 		}
 		const failureCallback = () => {
 			console.log("🎮 Command Off ❌")

--- a/command/test/dbPruning.test.js
+++ b/command/test/dbPruning.test.js
@@ -1,0 +1,20 @@
+jest.mock("memory")
+jest.mock("pg")
+
+const app = require("../backend/command.js")
+const { mockedPool } = require("pg")
+
+describe("startDbPruning", () => {
+	test("prunes sessions on the interval", () => {
+		let prune
+		const spy = jest.spyOn(global, "setInterval").mockImplementation((cb) => {
+			prune = cb
+			return { unref: () => {} }
+		})
+		app.startDbPruning()
+		prune()
+		const queries = mockedPool.query.mock.calls.map((c) => c[0])
+		expect(queries).toContainEqual(expect.stringMatching(/^DELETE FROM sessions WHERE revoked = TRUE OR issued_at < NOW\(\) - INTERVAL '30 days'$/))
+		spy.mockRestore()
+	})
+})

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,5 +16,6 @@ module.exports = {
 	helmetOptions: require("./utils/helmetOptions.js"),
 	loadCameras: require("./utils/loadCameras.js").loadCameras,
 	objectState: require("./utils/objectState.js"),
+	pruneInterval: require("./utils/pruneInterval.js"),
 	isPrimeInstance: !("NODE_APP_INSTANCE" in process.env) || process.env.NODE_APP_INSTANCE === "0"
 }

--- a/lib/utils/pruneInterval.js
+++ b/lib/utils/pruneInterval.js
@@ -1,0 +1,4 @@
+module.exports = (pool, sql) => {
+	const prune = () => pool.query(sql).catch(console.error)
+	return setInterval(prune, 1000 * 60 * 60 * 12).unref()
+}

--- a/schedule/backend/routes/lib/scheduler.js
+++ b/schedule/backend/routes/lib/scheduler.js
@@ -149,8 +149,12 @@ module.exports = {
 		if (client.connected) register()
 	},
 
-	startTaskRunPruning: () => {
-		const prune = () => pool.query("DELETE FROM task_runs WHERE ran_at < NOW() - INTERVAL '30 days'").catch(console.error)
+	startDbPruning: () => {
+		const prune = () => {
+			pool.query("DELETE FROM task_runs WHERE ran_at < NOW() - INTERVAL '30 days'").catch(console.error)
+			pool.query("DELETE FROM sessions WHERE revoked = TRUE OR issued_at < NOW() - INTERVAL '30 days'").catch(console.error)
+			pool.query("DELETE FROM frame_deletes WHERE timestamp < NOW() - INTERVAL '30 days'").catch(console.error)
+		}
 		return setInterval(prune, 1000 * 60 * 60 * 12).unref()
 	}
 }

--- a/schedule/backend/routes/lib/scheduler.js
+++ b/schedule/backend/routes/lib/scheduler.js
@@ -152,7 +152,6 @@ module.exports = {
 	startDbPruning: () => {
 		const prune = () => {
 			pool.query("DELETE FROM task_runs WHERE ran_at < NOW() - INTERVAL '30 days'").catch(console.error)
-			pool.query("DELETE FROM sessions WHERE revoked = TRUE OR issued_at < NOW() - INTERVAL '30 days'").catch(console.error)
 			pool.query("DELETE FROM frame_deletes WHERE timestamp < NOW() - INTERVAL '30 days'").catch(console.error)
 		}
 		return setInterval(prune, 1000 * 60 * 60 * 12).unref()

--- a/schedule/backend/routes/lib/scheduler.js
+++ b/schedule/backend/routes/lib/scheduler.js
@@ -152,7 +152,6 @@ module.exports = {
 	startDbPruning: () => {
 		const prune = () => {
 			pool.query("DELETE FROM task_runs WHERE ran_at < NOW() - INTERVAL '30 days'").catch(console.error)
-			pool.query("DELETE FROM frame_deletes WHERE timestamp < NOW() - INTERVAL '30 days'").catch(console.error)
 		}
 		return setInterval(prune, 1000 * 60 * 60 * 12).unref()
 	}

--- a/schedule/backend/routes/lib/scheduler.js
+++ b/schedule/backend/routes/lib/scheduler.js
@@ -2,7 +2,7 @@ const cron     = require("node-cron")
 const axios  = require("axios").default.create({
 	validateStatus: (status) => status == 200,
 })
-const { webhookAlert, alertTime, randomID, jsonFileHanding, auth } = require("lib")
+const { webhookAlert, alertTime, randomID, jsonFileHanding, auth, pruneInterval } = require("lib")
 const pool = require("../../lib/pool")
 
 const {schedulableUrls} = auth
@@ -149,12 +149,7 @@ module.exports = {
 		if (client.connected) register()
 	},
 
-	startDbPruning: () => {
-		const prune = () => {
-			pool.query("DELETE FROM task_runs WHERE ran_at < NOW() - INTERVAL '30 days'").catch(console.error)
-		}
-		return setInterval(prune, 1000 * 60 * 60 * 12).unref()
-	}
+	startDbPruning: () => pruneInterval(pool, "DELETE FROM task_runs WHERE ran_at < NOW() - INTERVAL '30 days'")
 }
 
 const validateRequestURL = (url) => {

--- a/schedule/backend/routes/lib/scheduler.js
+++ b/schedule/backend/routes/lib/scheduler.js
@@ -147,6 +147,11 @@ module.exports = {
 		}
 		client.on("connect", register)
 		if (client.connected) register()
+	},
+
+	startTaskRunPruning: () => {
+		const prune = () => pool.query("DELETE FROM task_runs WHERE ran_at < NOW() - INTERVAL '30 days'").catch(console.error)
+		return setInterval(prune, 1000 * 60 * 60 * 12).unref()
 	}
 }
 

--- a/schedule/server.js
+++ b/schedule/server.js
@@ -1,6 +1,6 @@
 const {handleServerStart, isPrimeInstance} = require("lib")
 const app = require("./backend/schedule.js")
-const { autoRegisterCleanup, startTaskRunPruning } = require("./backend/routes/lib/scheduler.js")
+const { autoRegisterCleanup, startDbPruning } = require("./backend/routes/lib/scheduler.js")
 
 module.exports = {
 	start: () => {
@@ -9,7 +9,7 @@ module.exports = {
 			console.log("\t▶ Scheduler Routes:\t /task")
 			if (isPrimeInstance) {
 				autoRegisterCleanup()
-				startTaskRunPruning()
+				startDbPruning()
 			}
 		}
 		const failureCallback = () => {

--- a/schedule/server.js
+++ b/schedule/server.js
@@ -1,13 +1,16 @@
 const {handleServerStart, isPrimeInstance} = require("lib")
 const app = require("./backend/schedule.js")
-const { autoRegisterCleanup } = require("./backend/routes/lib/scheduler.js")
+const { autoRegisterCleanup, startTaskRunPruning } = require("./backend/routes/lib/scheduler.js")
 
 module.exports = {
 	start: () => {
 		const successCallback = () => {
 			console.log(`⌚ Schedule On ▶ PORT ${process.env.schedule_PORT}`)
 			console.log("\t▶ Scheduler Routes:\t /task")
-			if (isPrimeInstance) autoRegisterCleanup()
+			if (isPrimeInstance) {
+				autoRegisterCleanup()
+				startTaskRunPruning()
+			}
 		}
 		const failureCallback = () => {
 			console.log("⌚ Schedule Off ❌")

--- a/schedule/test/dbPruning.test.js
+++ b/schedule/test/dbPruning.test.js
@@ -1,4 +1,3 @@
-jest.mock("lib")
 jest.mock("axios")
 jest.mock("pg")
 jest.mock("memory", () => ({

--- a/schedule/test/dbPruning.test.js
+++ b/schedule/test/dbPruning.test.js
@@ -1,0 +1,27 @@
+jest.mock("lib")
+jest.mock("axios")
+jest.mock("pg")
+jest.mock("memory", () => ({
+	client: () => ({ emit: () => {}, on: () => {}, off: () => {} }),
+	server: () => {}
+}))
+
+const { startDbPruning } = require("../backend/routes/lib/scheduler.js")
+const { mockedPool } = require("pg")
+
+describe("startDbPruning", () => {
+	test("prunes task_runs and frame_deletes on the interval", () => {
+		let prune
+		const spy = jest.spyOn(global, "setInterval").mockImplementation((cb) => {
+			prune = cb
+			return { unref: () => {} }
+		})
+		startDbPruning()
+		prune()
+		const queries = mockedPool.query.mock.calls.map((c) => c[0])
+		expect(queries).toContainEqual(expect.stringMatching(/^DELETE FROM task_runs WHERE ran_at < NOW\(\) - INTERVAL '30 days'$/))
+		expect(queries).toContainEqual(expect.stringMatching(/^DELETE FROM frame_deletes WHERE timestamp < NOW\(\) - INTERVAL '30 days'$/))
+		expect(queries).not.toContainEqual(expect.stringContaining("sessions"))
+		spy.mockRestore()
+	})
+})

--- a/schedule/test/dbPruning.test.js
+++ b/schedule/test/dbPruning.test.js
@@ -10,7 +10,7 @@ const { startDbPruning } = require("../backend/routes/lib/scheduler.js")
 const { mockedPool } = require("pg")
 
 describe("startDbPruning", () => {
-	test("prunes task_runs and frame_deletes on the interval", () => {
+	test("prunes task_runs on the interval", () => {
 		let prune
 		const spy = jest.spyOn(global, "setInterval").mockImplementation((cb) => {
 			prune = cb
@@ -20,7 +20,7 @@ describe("startDbPruning", () => {
 		prune()
 		const queries = mockedPool.query.mock.calls.map((c) => c[0])
 		expect(queries).toContainEqual(expect.stringMatching(/^DELETE FROM task_runs WHERE ran_at < NOW\(\) - INTERVAL '30 days'$/))
-		expect(queries).toContainEqual(expect.stringMatching(/^DELETE FROM frame_deletes WHERE timestamp < NOW\(\) - INTERVAL '30 days'$/))
+		expect(queries).not.toContainEqual(expect.stringContaining("frame_deletes"))
 		expect(queries).not.toContainEqual(expect.stringContaining("sessions"))
 		spy.mockRestore()
 	})

--- a/storage/__mocks__/pg.js
+++ b/storage/__mocks__/pg.js
@@ -1,0 +1,12 @@
+const queryFn = jest.fn(() => Promise.resolve({ rows: [], rowCount: 0 }))
+
+const mockedPool = {
+	query: queryFn,
+	end: jest.fn(),
+	on: jest.fn()
+}
+
+module.exports = {
+	Pool: jest.fn(() => mockedPool),
+	mockedPool
+}

--- a/storage/backend/storage.js
+++ b/storage/backend/storage.js
@@ -1,6 +1,6 @@
 var path       = require("path")
 var express    = require("express")
-const { auth, helmetOptions, tracker } = require("lib")
+const { auth, helmetOptions, tracker, pruneInterval } = require("lib")
 const helmet = require("helmet")
 const pool = require("./lib/pool")
 
@@ -54,11 +54,6 @@ fs.readdir(imgDir, (err, files) => {
 	}
 })
 
-app.startDbPruning = () => {
-	const prune = () => {
-		pool.query("DELETE FROM frame_deletes WHERE timestamp < NOW() - INTERVAL '30 days'").catch(console.error)
-	}
-	return setInterval(prune, 1000 * 60 * 60 * 12).unref()
-}
+app.startDbPruning = () => pruneInterval(pool, "DELETE FROM frame_deletes WHERE timestamp < NOW() - INTERVAL '30 days'")
 
 module.exports = app

--- a/storage/backend/storage.js
+++ b/storage/backend/storage.js
@@ -54,4 +54,11 @@ fs.readdir(imgDir, (err, files) => {
 	}
 })
 
+app.startDbPruning = () => {
+	const prune = () => {
+		pool.query("DELETE FROM frame_deletes WHERE timestamp < NOW() - INTERVAL '30 days'").catch(console.error)
+	}
+	return setInterval(prune, 1000 * 60 * 60 * 12).unref()
+}
+
 module.exports = app

--- a/storage/server.js
+++ b/storage/server.js
@@ -1,4 +1,4 @@
-const {handleServerStart} = require("lib")
+const {handleServerStart, isPrimeInstance} = require("lib")
 const app = require("./backend/storage.js")
 
 module.exports = {
@@ -8,6 +8,7 @@ module.exports = {
 			console.log("\t▶ Converter Routes:\t /converter")
 			console.log("\t▶ Motion Routes:\t /motion")
 			console.log("\t▶ File Routes:\t /shared")
+			if (isPrimeInstance) app.startDbPruning()
 		}
 		const failureCallback = () => {
 			console.log("📂 Storage Off ❌")

--- a/storage/test/dbPruning.test.js
+++ b/storage/test/dbPruning.test.js
@@ -1,0 +1,29 @@
+process.env.storage_FOLDERPATH = "/tmp/storage-dbprune-test"
+
+jest.mock("lib")
+jest.mock("fs")
+jest.mock("memory")
+jest.mock("pm2")
+jest.mock("axios")
+jest.mock("pg", () => {
+	const query = jest.fn(() => Promise.resolve({ rows: [] }))
+	return { Pool: jest.fn(() => ({ query, on: jest.fn() })), __query: query }
+})
+
+const app = require("../backend/storage.js")
+const { __query: query } = require("pg")
+
+describe("startDbPruning", () => {
+	test("prunes frame_deletes on the interval", () => {
+		let prune
+		const spy = jest.spyOn(global, "setInterval").mockImplementation((cb) => {
+			prune = cb
+			return { unref: () => {} }
+		})
+		app.startDbPruning()
+		prune()
+		const queries = query.mock.calls.map((c) => c[0])
+		expect(queries).toContainEqual(expect.stringMatching(/^DELETE FROM frame_deletes WHERE timestamp < NOW\(\) - INTERVAL '30 days'$/))
+		spy.mockRestore()
+	})
+})

--- a/storage/test/dbPruning.test.js
+++ b/storage/test/dbPruning.test.js
@@ -1,17 +1,13 @@
 process.env.storage_FOLDERPATH = "/tmp/storage-dbprune-test"
 
-jest.mock("lib")
 jest.mock("fs")
 jest.mock("memory")
 jest.mock("pm2")
 jest.mock("axios")
-jest.mock("pg", () => {
-	const query = jest.fn(() => Promise.resolve({ rows: [] }))
-	return { Pool: jest.fn(() => ({ query, on: jest.fn() })), __query: query }
-})
+jest.mock("pg")
 
 const app = require("../backend/storage.js")
-const { __query: query } = require("pg")
+const { mockedPool } = require("pg")
 
 describe("startDbPruning", () => {
 	test("prunes frame_deletes on the interval", () => {
@@ -22,7 +18,7 @@ describe("startDbPruning", () => {
 		})
 		app.startDbPruning()
 		prune()
-		const queries = query.mock.calls.map((c) => c[0])
+		const queries = mockedPool.query.mock.calls.map((c) => c[0])
 		expect(queries).toContainEqual(expect.stringMatching(/^DELETE FROM frame_deletes WHERE timestamp < NOW\(\) - INTERVAL '30 days'$/))
 		spy.mockRestore()
 	})


### PR DESCRIPTION
Closes #211

### What this does (plain words)

Some database tables keep every row forever and slowly grow. This makes the app delete rows older than 30 days on a timer that fires every 12 hours. The timer only runs on the **prime** instance, so when the app runs as several copies they don't all delete at the same time.

### Which tables get cleaned

- **`task_runs`** (schedule) — the history of scheduled jobs. *This is the table #211 asked for.*
- **`sessions`** (command) — login sessions. This cleanup **already existed**; it's now moved into the shared helper and put behind the prime-instance check (previously every copy ran it on every startup).
- **`frame_deletes`** (storage) — a write-only log of deleted camera frames. Nothing reads it anywhere in the repo, so trimming it is safe; it just stops growing forever.

### How it's built

All three share one tiny helper — `pruneInterval(pool, sql)` in `lib` — instead of three near-identical copies of the same `setInterval` + `DELETE` code. Each service's test asserts its own table's query.

### Heads-up on behavior change

Session cleanup now runs **only on the prime instance, and only when the command service is enabled** (it starts in the server's success callback). For a normal single-instance deploy nothing changes. In a split deploy where command is turned off on a node, the prime instance running command handles it.
