### PR TITLE
Allow admin recovery via /setup when no admin exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,22 +39,3 @@ npm run docker:up
 `docker:logs` tails output · `docker:down` stops · `docker:rebuild` redeploys · `docker:delete` wipes volumes.
 
 > **Bare-metal is unsupported.** Please use Docker. Running via pm2 on bare-metal is heavily discouraged and no longer documented.
-
-### Admin account recovery
-
-If you are locked out of the admin account — a forgotten password, or the admin row was removed — an operator with deployment access can recover it:
-
-1. Note the `setup_TOKEN` value (it is already required for the command service to start).
-2. POST to `/authorization/setup` with that token, the admin username, and a new password:
-
-```sh
-curl -X POST https://<host>/authorization/setup \
-  -H "Content-Type: application/json" \
-  -d '{"token":"<setup_TOKEN>","username":"<admin>","password":"<new-password>"}'
-```
-
-This creates the admin if it does not exist, or resets the password of the named account and ensures it has the `admin` role if it does. The account can log in immediately afterward. The in-app setup screen only appears on a fresh install (empty account table), so an existing admin can only be recovered through this request.
-
-Keep `setup_TOKEN` secret: anyone who has it can create or reset an admin through this route.
-
-> `/authorization/setup` is rate-limited to 10 attempts per 15 minutes per IP, and wrong-token attempts count toward that limit. If you lock yourself out, wait 15 minutes before retrying.

--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ npm run docker:up
 If you are locked out of the admin account — a forgotten password, or the admin row was removed — an operator with deployment access can recover it:
 
 1. Note the `setup_TOKEN` value (it is already required for the command service to start).
-2. POST to `/setup` (or use the setup screen) with that token, the admin username, and a new password.
+2. POST to `/authorization/setup` with that token, the admin username, and a new password:
 
-This creates the admin if it does not exist, or resets the password of the named account and ensures it has the `admin` role if it does. The account can log in immediately afterward.
+```sh
+curl -X POST https://<host>/authorization/setup \
+  -H "Content-Type: application/json" \
+  -d '{"token":"<setup_TOKEN>","username":"<admin>","password":"<new-password>"}'
+```
+
+This creates the admin if it does not exist, or resets the password of the named account and ensures it has the `admin` role if it does. The account can log in immediately afterward. The in-app setup screen only appears on a fresh install (empty account table), so an existing admin can only be recovered through this request.
 
 Keep `setup_TOKEN` secret: anyone who has it can create or reset an admin through this route.
 
-> `/setup` is rate-limited to 10 attempts per 15 minutes per IP, and wrong-token attempts count toward that limit. If you lock yourself out, wait 15 minutes before retrying.
+> `/authorization/setup` is rate-limited to 10 attempts per 15 minutes per IP, and wrong-token attempts count toward that limit. If you lock yourself out, wait 15 minutes before retrying.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ npm run docker:up
 
 ### Admin account recovery
 
-If no admin user remains (e.g. the admin account was deleted), an operator can create a new one:
+If you are locked out of the admin account — a forgotten password, or the admin row was removed — an operator with deployment access can recover it:
 
-1. Set the `setup_TOKEN` environment variable to a secret value and restart.
-2. POST to `/setup` (or use the setup screen) with that token plus a username and password.
+1. Note the `setup_TOKEN` value (it is already required for the command service to start).
+2. POST to `/setup` (or use the setup screen) with that token, the admin username, and a new password.
 
-A new admin is created as long as no admin currently exists. The chosen username must not already be taken.
+This creates the admin if it does not exist, or resets the password of the named account and ensures it has the `admin` role if it does. The account can log in immediately afterward.
+
+Keep `setup_TOKEN` secret: anyone who has it can create or reset an admin through this route.
+
+> `/setup` is rate-limited to 10 attempts per 15 minutes per IP, and wrong-token attempts count toward that limit. If you lock yourself out, wait 15 minutes before retrying.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ npm run docker:up
 `docker:logs` tails output · `docker:down` stops · `docker:rebuild` redeploys · `docker:delete` wipes volumes.
 
 > **Bare-metal is unsupported.** Please use Docker. Running via pm2 on bare-metal is heavily discouraged and no longer documented.
+
+### Admin account recovery
+
+If no admin user remains (e.g. the admin account was deleted), an operator can create a new one:
+
+1. Set the `setup_TOKEN` environment variable to a secret value and restart.
+2. POST to `/setup` (or use the setup screen) with that token plus a username and password.
+
+A new admin is created as long as no admin currently exists. The chosen username must not already be taken.

--- a/command/README.md
+++ b/command/README.md
@@ -10,6 +10,7 @@ The command server is face of the operation. It runs the web-app and the authent
 | :-|:- |:-:|:-:|:-:|
 |POST|/login|Auth Routes|N/A|N/A|
 |POST|/verify|Auth Routes|N/A|N/A|
+|POST|/setup|Bootstrap or recover admin (requires `setup_TOKEN`)|N/A|N/A|
 ## ▶ /
 
 |Type|Route|Description|Parameters|Returns|

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -72,8 +72,8 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 		const result = await withTransaction(async (client) => {
 			await client.query("SELECT pg_advisory_xact_lock(1)")
 			return client.query(
-				"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth)",
-				[username, hash]
+				"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth WHERE role = 'admin') AND ($3::boolean OR NOT EXISTS (SELECT 1 FROM auth))",
+				[username, hash, !!process.env.setup_TOKEN]
 			)
 		})
 		if (result.rowCount === 0) return res.status(403).json({ error: true })

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -72,10 +72,12 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 		const result = await withTransaction(async (client) => {
 			await client.query("SELECT pg_advisory_xact_lock(1)")
 			if (process.env.setup_TOKEN) {
-				return client.query(
+				const upsert = await client.query(
 					"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
 					[username, hash]
 				)
+				await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1", [username])
+				return upsert
 			}
 			return client.query(
 				"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth)",

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -73,8 +73,9 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 			await client.query("SELECT pg_advisory_xact_lock(1)")
 			if (process.env.setup_TOKEN) {
 				const noAdmin = (await client.query("SELECT 1 FROM auth WHERE role = 'admin' LIMIT 1")).rowCount === 0
-				const targetIsAdmin = (await client.query("SELECT role FROM auth WHERE username = $1", [username])).rows[0]?.role === "admin"
-				if (!noAdmin && !targetIsAdmin) return { rowCount: 0 }
+				const target = (await client.query("SELECT role FROM auth WHERE username = $1", [username])).rows[0]
+				const allowed = target ? target.role === "admin" : noAdmin
+				if (!allowed) return { rowCount: 0 }
 				const upsert = await client.query(
 					"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
 					[username, hash]

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -72,6 +72,9 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 		const result = await withTransaction(async (client) => {
 			await client.query("SELECT pg_advisory_xact_lock(1)")
 			if (process.env.setup_TOKEN) {
+				const noAdmin = (await client.query("SELECT 1 FROM auth WHERE role = 'admin' LIMIT 1")).rowCount === 0
+				const targetIsAdmin = (await client.query("SELECT role FROM auth WHERE username = $1", [username])).rows[0]?.role === "admin"
+				if (!noAdmin && !targetIsAdmin) return { rowCount: 0 }
 				const upsert = await client.query(
 					"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
 					[username, hash]

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -71,9 +71,15 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 		const hash = await bcrypt.hash(password, salt)
 		const result = await withTransaction(async (client) => {
 			await client.query("SELECT pg_advisory_xact_lock(1)")
+			if (process.env.setup_TOKEN) {
+				return client.query(
+					"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
+					[username, hash]
+				)
+			}
 			return client.query(
-				"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth WHERE role = 'admin') AND ($3::boolean OR NOT EXISTS (SELECT 1 FROM auth))",
-				[username, hash, !!process.env.setup_TOKEN]
+				"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth)",
+				[username, hash]
 			)
 		})
 		if (result.rowCount === 0) return res.status(403).json({ error: true })

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -74,6 +74,7 @@ describe("Authorization Routes", () => {
 				.send({ username: "existingadmin", password: "newpassword123", token: "recovery-token" })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
+			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1", ["existingadmin"])
 		})
 
 		test("rejects setup with an invalid setup_TOKEN", async () => {

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -56,10 +56,22 @@ describe("Authorization Routes", () => {
 			process.env.setup_TOKEN = "recovery-token"
 			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
 			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
-			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // INSERT
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // upsert
 			const res = await supertest(app)
 				.post("/authorization/setup")
 				.send({ username: "newadmin", password: "password123", token: "recovery-token" })
+			expect(res.status).toBe(200)
+			expect(res.body).toEqual({ error: false })
+		})
+
+		test("resets the password of an existing admin with a valid setup_TOKEN", async () => {
+			process.env.setup_TOKEN = "recovery-token"
+			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
+			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // upsert (ON CONFLICT)
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.send({ username: "existingadmin", password: "newpassword123", token: "recovery-token" })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 		})

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -52,6 +52,27 @@ describe("Authorization Routes", () => {
 			expect(res.body).toEqual({ error: true })
 		})
 
+		test("allows admin recovery with a valid setup_TOKEN when no admin exists", async () => {
+			process.env.setup_TOKEN = "recovery-token"
+			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
+			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // INSERT
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.send({ username: "newadmin", password: "password123", token: "recovery-token" })
+			expect(res.status).toBe(200)
+			expect(res.body).toEqual({ error: false })
+		})
+
+		test("rejects setup with an invalid setup_TOKEN", async () => {
+			process.env.setup_TOKEN = "right-token"
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.send({ username: "admin", password: "password123", token: "wrong-token" })
+			expect(res.status).toBe(403)
+			expect(res.body).toEqual({ error: true })
+		})
+
 		test("returns 400 when username or password is missing", async () => {
 			const res = await supertest(app)
 				.post("/authorization/setup")

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -56,6 +56,8 @@ describe("Authorization Routes", () => {
 			process.env.setup_TOKEN = "recovery-token"
 			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
 			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 0 }) // no admin exists
+			mockedPool.query.mockResolvedValueOnce({ rows: [] }) // target is a new user
 			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // upsert
 			const res = await supertest(app)
 				.post("/authorization/setup")
@@ -68,6 +70,8 @@ describe("Authorization Routes", () => {
 			process.env.setup_TOKEN = "recovery-token"
 			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
 			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // an admin already exists
+			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin" }] }) // target is that admin
 			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // upsert (ON CONFLICT)
 			const res = await supertest(app)
 				.post("/authorization/setup")
@@ -75,6 +79,33 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1", ["existingadmin"])
+		})
+
+		test("rejects taking over a non-admin account while an admin exists", async () => {
+			process.env.setup_TOKEN = "recovery-token"
+			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
+			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // an admin already exists
+			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "user" }] }) // target is a non-admin
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.send({ username: "victim", password: "password123", token: "recovery-token" })
+			expect(res.status).toBe(403)
+			expect(res.body).toEqual({ error: true })
+			expect(mockedPool.query).not.toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1", ["victim"])
+		})
+
+		test("rejects minting a second admin while an admin exists", async () => {
+			process.env.setup_TOKEN = "recovery-token"
+			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
+			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // an admin already exists
+			mockedPool.query.mockResolvedValueOnce({ rows: [] }) // target is a new user
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.send({ username: "second-admin", password: "password123", token: "recovery-token" })
+			expect(res.status).toBe(403)
+			expect(res.body).toEqual({ error: true })
 		})
 
 		test("rejects setup with an invalid setup_TOKEN", async () => {

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -81,6 +81,21 @@ describe("Authorization Routes", () => {
 			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1", ["existingadmin"])
 		})
 
+		test("rejects taking over an existing non-admin account when no admin exists", async () => {
+			process.env.setup_TOKEN = "recovery-token"
+			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
+			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 0 }) // no admin exists
+			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "user" }] }) // target is an existing non-admin
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.send({ username: "victim", password: "password123", token: "recovery-token" })
+			expect(res.status).toBe(403)
+			expect(res.body).toEqual({ error: true })
+			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
+			expect(mockedPool.query).not.toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1", ["victim"])
+		})
+
 		test("rejects taking over a non-admin account while an admin exists", async () => {
 			process.env.setup_TOKEN = "recovery-token"
 			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
@@ -92,6 +107,7 @@ describe("Authorization Routes", () => {
 				.send({ username: "victim", password: "password123", token: "recovery-token" })
 			expect(res.status).toBe(403)
 			expect(res.body).toEqual({ error: true })
+			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
 			expect(mockedPool.query).not.toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1", ["victim"])
 		})
 
@@ -106,6 +122,7 @@ describe("Authorization Routes", () => {
 				.send({ username: "second-admin", password: "password123", token: "recovery-token" })
 			expect(res.status).toBe(403)
 			expect(res.body).toEqual({ error: true })
+			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
 		})
 
 		test("rejects setup with an invalid setup_TOKEN", async () => {


### PR DESCRIPTION
Closes #210

Relaxes the POST /setup guard so it fires when no admin account exists (previously: only when no account existed at all), and requires a configured setup_TOKEN for the recovery case. Documents the recovery procedure in the README.
