### PR TITLE
Address PR #178 review findings

### DIFF
--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -1,18 +1,18 @@
 require("dotenv").config()
 const fs = require("fs")
 const path = require("path")
+const { parseSchema } = require("./preflight.js")
 
 let allEnvPresent = true
+const optionalKeys = new Set(parseSchema().filter(v => v.optional).map(v => v.key))
 
 const checkVar = (varName) => {
-	if(varName in process.env){
-		return true
-	}
-	else{
-		console.log("MISSING ENV VAR", varName)
-		allEnvPresent = false
-		return false
-	}
+	if (optionalKeys.has(varName)) return true
+	const val = process.env[varName]
+	if (val != null && val.trim() !== "") return true
+	console.log("MISSING ENV VAR", varName)
+	allEnvPresent = false
+	return false
 }
 
 const isFolderCheck = (varName) => {

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -1,13 +1,14 @@
 require("dotenv").config()
 const fs = require("fs")
 const path = require("path")
-const { parseSchema } = require("./preflight.js")
+const { parseSchema, isServiceOff } = require("./preflight.js")
 
 let allEnvPresent = true
 const optionalKeys = new Set(parseSchema().filter(v => v.optional).map(v => v.key))
+const envLines = Object.entries(process.env).map(([k, v]) => `${k} = ${v}`)
 
 const checkVar = (varName) => {
-	if (optionalKeys.has(varName)) return true
+	if (optionalKeys.has(varName) || isServiceOff(envLines, varName)) return true
 	const val = process.env[varName]
 	if (val != null && val.trim() !== "") return true
 	console.log("MISSING ENV VAR", varName)

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
 		"<rootDir>/gateway/jest.config.js",
 		"<rootDir>/lib/jest.config.js",
 		"<rootDir>/livestream/jest.config.js",
+		"<rootDir>/memory/jest.config.js",
 		"<rootDir>/object/jest.config.js",
 		"<rootDir>/schedule/jest.config.js",
 		"<rootDir>/storage/jest.config.js"

--- a/lib/test/handleSecureServerStart.test.js
+++ b/lib/test/handleSecureServerStart.test.js
@@ -1,0 +1,26 @@
+const EventEmitter = require("events")
+const https = require("https")
+const fs = require("fs")
+const handleSecureServerStart = require("../utils/handleSecureServerStart.js")
+
+jest.mock("https")
+jest.mock("fs")
+
+describe("handleSecureServerStart", () => {
+	test("forwards a listen error (EADDRINUSE) to failureCallback instead of crashing", (done) => {
+		fs.readFile.mockImplementation((p, cb) => cb(null, Buffer.from("pem")))
+		const server = new EventEmitter()
+		server.listen = jest.fn()
+		https.createServer.mockReturnValue(server)
+
+		handleSecureServerStart({}, 443, () => {}, (err) => {
+			expect(err).toBeDefined()
+			expect(err.code).toBe("EADDRINUSE")
+			done()
+		})
+
+		const err = new Error("listen EADDRINUSE")
+		err.code = "EADDRINUSE"
+		expect(() => server.emit("error", err)).not.toThrow()
+	})
+})

--- a/lib/test/handleServerStart.test.js
+++ b/lib/test/handleServerStart.test.js
@@ -1,0 +1,24 @@
+const EventEmitter = require("events")
+const express = require("express")
+const handleServerStart = require("../utils/handleServerStart.js")
+
+describe("handleServerStart", () => {
+	test("forwards an async listen error (EADDRINUSE) to failureCallback", (done) => {
+		const blocker = express().listen(0, () => {
+			const port = blocker.address().port
+			handleServerStart(express(), port, () => {}, (err) => {
+				expect(err).toBeDefined()
+				expect(err.code).toBe("EADDRINUSE")
+				blocker.close(done)
+			})
+		})
+	})
+
+	test("ignores a listen error when no failureCallback is supplied", () => {
+		const server = new EventEmitter()
+		server.close = () => {}
+		const app = { listen: () => server }
+		handleServerStart(app, 0, () => {})
+		expect(() => server.emit("error", new Error("boom"))).not.toThrow()
+	})
+})

--- a/lib/utils/handleSecureServerStart.js
+++ b/lib/utils/handleSecureServerStart.js
@@ -8,8 +8,10 @@ module.exports = (app, port, successCallback, failureCallback) => {
 				if(!err){
 					const credentials = {key: privateKey, cert: certificate}
 					const server = https.createServer(credentials, app)
-					server.listen(port)
-					successCallback()
+					server.on("error", (err) => {
+						if (typeof failureCallback === "function") failureCallback(err)
+					})
+					server.listen(port, successCallback)
 				}
 				else{
 					failureCallback()

--- a/lib/utils/handleServerStart.js
+++ b/lib/utils/handleServerStart.js
@@ -2,6 +2,9 @@ const process = require("process")
 
 module.exports = (app, port, successCallback, failureCallback) => {
 	const server = app.listen(port, successCallback)
+	server.on("error", (err) => {
+		if (typeof failureCallback === "function") failureCallback(err)
+	})
 	process.on("SIGINT", () => {
 		server.close()
 		failureCallback()

--- a/memory/jest.config.js
+++ b/memory/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	displayName: "memory",
 	clearMocks: true,
 	moduleFileExtensions: [
 		"js",

--- a/memory/lib/objectState.js
+++ b/memory/lib/objectState.js
@@ -3,5 +3,5 @@ const { objectState } = require("lib")
 module.exports = () => ({
 	objectGetState: (callback=()=>{}) => callback({ config: objectState.getConfig(), status: objectState.getStatus() }),
 	objectSetConfig: (updates, callback=()=>{}) => callback(objectState.setConfig(updates || {})),
-	objectScan: (camera, callback=()=>{}) => Promise.resolve(objectState.scan(camera)).then(callback).catch(e => callback({ error: e.message }))
+	objectScan: (camera, callback=()=>{}) => Promise.resolve(objectState.scan(camera)).then(detections => callback({ detections })).catch(e => callback({ error: e.message }))
 })

--- a/memory/lib/objectState.js
+++ b/memory/lib/objectState.js
@@ -3,5 +3,5 @@ const { objectState } = require("lib")
 module.exports = () => ({
 	objectGetState: (callback=()=>{}) => callback({ config: objectState.getConfig(), status: objectState.getStatus() }),
 	objectSetConfig: (updates, callback=()=>{}) => callback(objectState.setConfig(updates || {})),
-	objectScan: (camera, callback=()=>{}) => Promise.resolve(objectState.scan(camera)).then(callback)
+	objectScan: (camera, callback=()=>{}) => Promise.resolve(objectState.scan(camera)).then(callback).catch(e => callback({ error: e.message }))
 })

--- a/memory/test/objectState.test.js
+++ b/memory/test/objectState.test.js
@@ -1,0 +1,17 @@
+const { objectState } = require("lib")
+const makeHandlers = require("../lib/objectState.js")
+
+describe("memory objectScan handler", () => {
+	test("wraps resolved detections as { detections }", async () => {
+		const detections = [{ class: "car", score: 0.77, box: [0, 0, 1, 1] }]
+		objectState.register({ scan: () => Promise.resolve(detections) })
+		const result = await new Promise(res => makeHandlers().objectScan(3, res))
+		expect(result).toEqual({ detections })
+	})
+
+	test("wraps a scan rejection as { error }", async () => {
+		objectState.register({ scan: () => Promise.reject(new Error("frame grab failed")) })
+		const result = await new Promise(res => makeHandlers().objectScan(3, res))
+		expect(result).toEqual({ error: "frame grab failed" })
+	})
+})

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -163,6 +163,9 @@ const stopWorkers = () => {
 		clearTimeout(timers[camera])
 		delete timers[camera]
 	}
+	for (const camera of Object.keys(status)) {
+		status[camera].running = false
+	}
 }
 
 module.exports = {

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -133,7 +133,7 @@ const scan = async (id) => {
 		return detections
 	} catch (e) {
 		st.error = e.message
-		return []
+		throw e
 	}
 }
 
@@ -145,7 +145,7 @@ const startWorkers = () => {
 	for (const cam of list) {
 		status[cam.id] = { running: true, lastRun: null, lastDetection: null, error: null }
 		const loop = async () => {
-			await scan(cam.id)
+			await scan(cam.id).catch(() => {})
 			if (workersRunning) timers[cam.id] = setTimeout(loop, config.intervalMs)
 		}
 		loop()

--- a/object/backend/routes/object.js
+++ b/object/backend/routes/object.js
@@ -54,7 +54,7 @@ app.post("/scan", requireAdmin, (req, res) => {
 		event: "objectScan",
 		args: [camera],
 		onState: ({ detections, error }) => error ? res.status(502).send({ error }) : res.send({ camera, detections }),
-		local: () => worker.scan(camera).then(detections => res.send({ camera, detections }))
+		local: () => worker.scan(camera).then(detections => res.send({ camera, detections })).catch(e => res.status(502).send({ error: e.message }))
 	})
 })
 

--- a/object/backend/routes/object.js
+++ b/object/backend/routes/object.js
@@ -53,7 +53,7 @@ app.post("/scan", requireAdmin, (req, res) => {
 		rerunOnTimeout: false,
 		event: "objectScan",
 		args: [camera],
-		onState: detections => res.send({ camera, detections }),
+		onState: ({ detections, error }) => error ? res.status(502).send({ error }) : res.send({ camera, detections }),
 		local: () => worker.scan(camera).then(detections => res.send({ camera, detections }))
 	})
 })

--- a/object/test/object.test.js
+++ b/object/test/object.test.js
@@ -107,6 +107,17 @@ describe("Object Routes", () => {
 			})
 			.end(done)
 	})
+
+	test("Scan returns 502 when the local worker scan fails", (done) => {
+		require("../backend/lib/worker.js").scan.mockRejectedValueOnce(new Error("frame grab failed"))
+		supertest(app)
+			.post("/object/scan")
+			.set("Cookie", authorized)
+			.send({ camera: 1 })
+			.expect(502)
+			.expect((res) => expect(res.body.error).toBe("frame grab failed"))
+			.end(done)
+	})
 })
 
 describe("Object Routes (shared state via a connected memory client)", () => {

--- a/object/test/object.test.js
+++ b/object/test/object.test.js
@@ -4,12 +4,13 @@ process.env.memory_ON = "true"
 
 let mockConnected = false
 let mockEmitError = false
+let mockScanError = false
 const mockEmit = jest.fn((event, arg, cb2) => {
 	const cb = typeof cb2 === "function" ? cb2 : arg
 	if (mockEmitError) return cb(new Error("ack timeout"))
 	if (event === "objectGetState") cb(null, { config: { confidence: 0.42, intervalMs: 5000, classes: [] }, status: { 9: { running: true } } })
 	else if (event === "objectSetConfig") cb(null, { confidence: 0.8, intervalMs: 5000, classes: [] })
-	else if (event === "objectScan") cb(null, [{ class: "car", score: 0.77, box: [0, 0, 1, 1] }])
+	else if (event === "objectScan") cb(null, mockScanError ? { error: "scan failed" } : { detections: [{ class: "car", score: 0.77, box: [0, 0, 1, 1] }] })
 })
 
 const mockQuery = jest.fn().mockResolvedValue({
@@ -111,7 +112,7 @@ describe("Object Routes", () => {
 describe("Object Routes (shared state via a connected memory client)", () => {
 	beforeAll(() => { mockConnected = true })
 	afterAll(() => { mockConnected = false })
-	afterEach(() => { mockEmitError = false })
+	afterEach(() => { mockEmitError = false; mockScanError = false })
 
 	test("status reads state from the memory client", (done) => {
 		supertest(app)
@@ -175,6 +176,17 @@ describe("Object Routes (shared state via a connected memory client)", () => {
 				expect(res.body.config.confidence).toBe(0.5)
 				expect(res.body.cameras["1"].running).toBe(true)
 			})
+			.end(done)
+	})
+
+	test("returns 502 when the memory scan acks an error", (done) => {
+		mockScanError = true
+		supertest(app)
+			.post("/object/scan")
+			.set("Cookie", authorized)
+			.send({ camera: 3 })
+			.expect(502)
+			.expect((res) => expect(res.body.error).toBe("scan failed"))
 			.end(done)
 	})
 

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -121,10 +121,9 @@ describe("scan", () => {
 		delete process.env.object_ALERT_ON
 	})
 
-	test("records ffmpeg failure in status and returns []", async () => {
+	test("records ffmpeg failure in status and rejects", async () => {
 		execFile.mockImplementation((file, args, opts, cb) => cb(new Error("ffmpeg boom")))
-		const detections = await worker.scan(4)
-		expect(detections).toEqual([])
+		await expect(worker.scan(4)).rejects.toThrow("ffmpeg boom")
 		expect(detector.detect).not.toHaveBeenCalled()
 		expect(worker.getStatus()[4].error).toBe("ffmpeg boom")
 	})

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -191,6 +191,16 @@ describe("startWorkers / stopWorkers", () => {
 		expect(execFile).toHaveBeenCalledTimes(2)
 		expect(jest.getTimerCount()).toBe(0)
 	})
+
+	test("stopWorkers flips every camera's running flag to false", async () => {
+		worker.startWorkers()
+		await tick()
+		expect(worker.getStatus()[1].running).toBe(true)
+		expect(worker.getStatus()[2].running).toBe(true)
+		worker.stopWorkers()
+		expect(worker.getStatus()[1].running).toBe(false)
+		expect(worker.getStatus()[2].running).toBe(false)
+	})
 })
 
 describe("setConfig validation", () => {

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -221,6 +221,7 @@ module.exports = {
 			res.send(metrics)
 		}).catch(err => {
 			console.log("err", err)
+			res.status(500).send({ error: true })
 		})
 	}
 }

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -37,7 +37,30 @@ describe("File Routes", () => {
 	})
 
 	describe("/file/pathMetrics", () => {
-		test("bruh", () => expect(2+2).toBe(4))
+		const { loadCameras } = require("lib")
+		afterEach(() => { loadCameras.mockReturnValue([]) })
+
+		test("maps per-camera size and count metrics", async () => {
+			loadCameras.mockReturnValue([{ id: 1, name: "cam1" }])
+			query
+				.mockImplementationOnce(() => Promise.resolve({ rows: [{ sum: "500" }] }))
+				.mockImplementationOnce(() => Promise.resolve({ rows: [{ count: "7" }] }))
+			const res = await supertest(app)
+				.post("/file/pathMetrics")
+				.set("Cookie", cookieWithBearerToken)
+			expect(res.status).toBe(200)
+			expect(res.body).toEqual({ size: { cam1: "500" }, count: { cam1: "7" } })
+		})
+
+		test("returns 500 when a metric query fails instead of hanging", async () => {
+			loadCameras.mockReturnValue([{ id: 1, name: "cam1" }])
+			query.mockRejectedValueOnce(new Error("db error"))
+			const res = await supertest(app)
+				.post("/file/pathMetrics")
+				.set("Cookie", cookieWithBearerToken)
+			expect(res.status).toBe(500)
+			expect(res.body).toEqual({ error: true })
+		})
 	})
 
 	describe("/file/dailyStats", () => {


### PR DESCRIPTION
Closes #213

Addresses the five PR #178 review findings:
- cameraMetrics now responds on DB error (500) instead of hanging
- handleServerStart attaches server.on('error') so an async listen failure (e.g. EADDRINUSE) no longer crashes the whole process
- validateEnvVars is value-aware (blank required vars now fail) and skips optional (***) vars, deriving the optional set from preflight's schema
- objectScan rejects gracefully via callback instead of hanging + unhandledRejection
- stopWorkers resets the per-camera running flag
