### PR TITLE
Overhaul all READMEs to document the post-#178 setup (#219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,85 +2,47 @@
 
 <img src="command/frontend/res/logo.png" alt="logo" width="100"/>
 
-Chimera is a microservices-based security camera system for RTSP/IP cameras.
+Microservices security-camera system for RTSP/IP cameras.
 
-Microservices:
+**Services:** [command](command) · [livestream](livestream) · [schedule](schedule) · [storage](storage) · [gateway](gateway) · [memory](memory) · [object](object)
 
-1. [command](command)
-2. [livestream](livestream)
-3. [schedule](schedule)
-4. [storage](storage)
-5. [gateway](gateway)
-6. [memory](memory)
-7. [object](object)
+**Shared:** [lib](lib) (utilities every service imports) · [chimera](chimera) (boot scripts: preflight wizard, env validation, schema creation)
 
-Shared code & bootstrap:
-- [lib](lib) - shared utilities for every service (auth middleware, webhook alerts, camera loading, etc.).
-- [chimera](chimera) - boot/config scripts: `preflight.js` (config wizard), `validateEnvVars.js` (fail-fast env check), `prepareDatabase.js` (schema creation).
+**Bundled in the image:** [motion](https://github.com/Motion-Project/motion) (saves RTSP frames, with [storage](storage)) · [ffmpeg](https://ffmpeg.org) · [heartbeat](https://github.com/jjjpanda/heartbeat) · [postgres](https://www.postgresql.org) (own container)
 
-Bundled dependencies (in the Docker image):
-1. [motion](https://github.com/Motion-Project/motion) - saves RTSP frames; co-located with [storage](storage).
-2. [ffmpeg](https://ffmpeg.org) - used by [livestream](livestream) and [storage](storage).
-3. [heartbeat](https://github.com/jjjpanda/heartbeat) - confirms the server is up.
-4. [postgres](https://www.postgresql.org) - the database (its own container).
+---
+# Quick start (Docker)
 
-## Quick Start (Docker)
+Bare-metal is unsupported. The image bundles motion, ffmpeg, Node, and pm2, and pins `TZ=UTC` (required — non-UTC misaligns clips/zips/frames).
 
-The image bundles motion, ffmpeg, Node, and pm2, pins `TZ=UTC` (required; non-UTC misaligns clips/zips/frames), and runs Postgres as a side container whose schema is created automatically on boot.
-
-### 1. Configure
 ```
 cp env.example .env          # fill in values; leave optional fields blank after =
 cp motion.conf.example motion.conf
-```
-Add a `cameraconf/camN.conf` per camera (see [`camera.conf.example`](cameraconf/camera.conf.example)).
-
-Or run `npm run preflight` to interactively seed and validate `.env`, `motion.conf`, and `cameraconf/*.conf` against [`env.example`](env.example) before building; it skips checks for services you turned off. `docker:build`/`docker:up` run `preflight --check` first, so a bad config blocks the build.
-
-### 2. Build & run
-```
+# add a cameraconf/camN.conf per camera (see cameraconf/camera.conf.example)
 npm run docker:build
 npm run docker:up
 ```
-`docker:logs` tails · `docker:down` stops · `docker:rebuild` redeploys · `docker:delete` wipes volumes.
 
-### 3. First run
-No users exist on first boot. Open the gateway and create the first admin from the setup screen (calls `POST /authorization/setup`, authorized with `setup_TOKEN` from `.env`). Auth, RBAC, and sessions live in [command](command).
+- `npm run preflight` seeds and validates `.env` / `motion.conf` / `cameraconf/*.conf` before building; `docker:build`/`up` run it first, so a bad config blocks the build.
+- `docker:logs` tails · `docker:down` stops · `docker:rebuild` redeploys · `docker:delete` wipes volumes.
+- **First run:** no users exist — open the gateway and create the first admin from the setup screen (`POST /authorization/setup`, authorized with `setup_TOKEN`).
 
-> Bare-metal is unsupported. Use Docker; pm2 on bare-metal is discouraged and undocumented.
+---
+# Architecture
 
-## Architecture
+One Node process under pm2, fronted by a Postgres side container. Each service is toggled by `<prefix>_ON`; off means it never starts.
 
-One Node process under pm2, fronted by a Postgres side container. Each service is toggled by its `<prefix>_ON` flag in `.env`; if off, it never starts.
-
-**Process tree** — pm2 ([`pm2.config.js`](pm2.config.js)) runs the Node app plus a few native helpers:
-
+pm2 ([pm2.config.js](pm2.config.js)):
 ```
-pm2
-├─ chimera  (server.js)   one process; runs all enabled services
-├─ motion                 storage_ON
-├─ ffmpeg × N             one HLS transcoder per camera, livestream_ON
-└─ heartbeat              production only
+chimera  (server.js)   one process; runs all enabled services
+motion                 storage_ON
+ffmpeg × N             one HLS transcoder per camera, livestream_ON
+heartbeat              production only
 ```
 
-Inside `chimera`, [`server.js`](server.js) starts services in order: **command** first (fatal — the process exits if it fails), then **storage**, **livestream**, **schedule**, **object**, then the **memory** coordination socket, then the **gateway** last. The gateway is the single public entrypoint: it reverse-proxies every service with `<prefix>_PROXY_ON=true` and terminates TLS.
+- [server.js](server.js) starts services in order: **command** (fatal on failure), storage, livestream, schedule, object, the **memory** socket, then the **gateway** last. The gateway is the only public entrypoint — reverse-proxies every `<prefix>_PROXY_ON=true` service and terminates TLS.
+- Boot chain ([entrypoint.sh](entrypoint.sh), aborts on first failure): ACME dir → `validateEnvVars.js` → `prepareDatabase.js` → `pm2-runtime`.
+- Postgres runs as a side container ([docker-compose.yml](docker-compose.yml)); Chimera waits on its healthcheck.
+- `chimeraInstances`: `1` = single process; `>1`/`max` = cluster, which forces `memory_ON=true` so instances coordinate through the memory socket.
 
-**Boot chain** — Docker [`entrypoint.sh`](entrypoint.sh) runs before pm2, aborting on the first failure:
-
-```
-ACME dir → validateEnvVars.js → prepareDatabase.js → pm2-runtime
- (TLS)     (fail-fast env)       (create schema)      (start pm2)
-```
-
-Postgres runs as a side container ([`docker-compose.yml`](docker-compose.yml), `postgres:15`); Chimera waits on its healthcheck. `TZ=UTC` is pinned on both and is required — non-UTC misaligns clips, zips, and frames.
-
-**Single vs. cluster** — `chimeraInstances` picks the mode: `1` is a single fork-mode process; `>1` or `max` is cluster mode, which forces `memory_ON=true` so instances coordinate through the memory socket.
-
-**Schema** — [`prepareDatabase.js`](chimera/prepareDatabase.js) idempotently creates these tables (plus indexes), per owning service:
-
-- **storage** — `frame_files`, `frame_deletes`
-- **command** — `auth`, `sessions`
-- **object** — `objects_detected`
-- **schedule** — `task_runs`
-
-See [`env.example`](env.example) for the full config schema.
+**Schema** ([prepareDatabase.js](chimera/prepareDatabase.js), created idempotently): `frame_files` / `frame_deletes` (storage) · `auth` / `sessions` (command) · `objects_detected` (object) · `task_runs` (schedule). Full config in [env.example](env.example).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="command/frontend/res/logo.png" alt="logo" width="100"/>
 
-Chimera is a microservices-based security camera system for RTSP/IP cameras (Linux only).
+Chimera is a microservices-based security camera system for RTSP/IP cameras.
 
 List of microservices: 
 
@@ -14,6 +14,10 @@ List of microservices:
 6. [memory](memory)
 7. [object](object)
 
+Shared code & bootstrap:
+- [lib](lib) - shared utilities used by every service (auth middleware, webhook alerts, camera loading, etc.).
+- [chimera](chimera) - boot/config scripts: `preflight.js` (config wizard), `validateEnvVars.js` (fail-fast env check), `prepareDatabase.js` (schema creation).
+
 Massive Dependencies (all bundled in the Docker image):
 1. [motion](https://github.com/Motion-Project/motion) - saves RTSP frames; co-located with [storage](storage), see why there.
 2. [ffmpeg](https://ffmpeg.org) - used by [livestream](livestream) and [storage](storage).
@@ -22,14 +26,16 @@ Massive Dependencies (all bundled in the Docker image):
 
 ## Quick Start (Docker)
 
-Docker is the supported way to run Chimera. The image bundles motion, ffmpeg, Node, and pm2, pins `TZ=UTC` (required — frame timestamps and the UI both assume UTC), and runs Postgres as a side container whose schema is created automatically on boot.
+Docker is the supported way to run Chimera. The image bundles motion, ffmpeg, Node, and pm2, pins `TZ=UTC` (required — non-UTC misaligns clips/zips/frames), and runs Postgres as a side container whose schema is created automatically on boot.
 
 ### 1. Configure
 ```
 cp env.example .env          # fill in values; leave optional fields blank after =
 cp motion.conf.example motion.conf
 ```
-Add a `cameraconf/camN.conf` per camera (see [`motion.conf.example`](motion.conf.example)).
+Add a `cameraconf/camN.conf` per camera (see [`camera.conf.example`](cameraconf/camera.conf.example)).
+
+Or run `npm run preflight` to interactively seed and validate `.env`, `motion.conf`, and `cameraconf/*.conf` against [`env.example`](env.example) before building. It skips checks for services you have turned off. `docker:build`/`docker:up` already run `preflight --check` first, so a bad config blocks the build.
 
 ### 2. Build & run
 ```
@@ -38,4 +44,16 @@ npm run docker:up
 ```
 `docker:logs` tails output · `docker:down` stops · `docker:rebuild` redeploys · `docker:delete` wipes volumes.
 
+### 3. First run
+On first boot no users exist. Open the gateway in a browser and create the first admin from the setup screen, which calls `POST /authorization/setup`. The call is authorized with the required `setup_TOKEN` from `.env`. Auth, RBAC, and sessions all live in [command](command).
+
 > **Bare-metal is unsupported.** Please use Docker. Running via pm2 on bare-metal is heavily discouraged and no longer documented.
+
+## Architecture
+
+- **One Node process.** [`server.js`](server.js) `require()`s each service and starts them in order: command (fatal — the process exits if it fails), storage, livestream, schedule, object — all via `.start()` — then the [memory](memory) socket (via `.server()`), then the [gateway](gateway) (via `.start()`). Each service is gated by its own `<prefix>_ON` flag in `.env`, so a service left off is simply not started.
+- **pm2 is the process manager** ([`pm2.config.js`](pm2.config.js)). It runs that single `chimera` app and, alongside it, launches `motion` (when `storage_ON=true`), one `ffmpeg` HLS process per camera (when `livestream_ON=true`), and `heartbeat` (production only). `chimeraInstances` sets the pm2 mode: `1` runs a single fork-mode process, while `> 1` (or `max`) switches to cluster mode and forces `memory_ON=true` so instances stay coordinated through the memory socket.
+- **Docker boot chain** ([`entrypoint.sh`](entrypoint.sh)): create the ACME challenge dir → `node chimera/validateEnvVars.js` (fail-fast if a required env var is missing) → `node chimera/prepareDatabase.js` (idempotently create tables/indexes) → `exec pm2-runtime pm2.config.js`.
+- **Postgres side container.** [`docker-compose.yml`](docker-compose.yml) runs the Chimera image plus a `postgres:15` container; Chimera waits on its healthcheck before starting. `TZ=UTC` is pinned on both containers and is required.
+- **Schema** (created by [`chimera/prepareDatabase.js`](chimera/prepareDatabase.js)): `frame_files`, `frame_deletes` (storage); `auth`, `sessions` (command auth/RBAC); `objects_detected` (object); `task_runs` (schedule); plus supporting indexes.
+- **Single public entrypoint.** The [gateway](gateway) reverse-proxies each service whose `<prefix>_PROXY_ON=true` and terminates TLS. See [`env.example`](env.example) for the full configuration schema.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,36 @@ No users exist on first boot. Open the gateway and create the first admin from t
 
 ## Architecture
 
-- One Node process. [`server.js`](server.js) `require()`s and starts each service in order: command (fatal; process exits if it fails), storage, livestream, schedule, object (all via `.start()`), then the [memory](memory) socket (via `.server()`), then the [gateway](gateway) (via `.start()`). Each service is gated by its `<prefix>_ON` flag in `.env`; if off, it is not started.
-- pm2 ([`pm2.config.js`](pm2.config.js)) manages one `chimera` app and launches `motion` (`storage_ON=true`), one `ffmpeg` HLS process per camera (`livestream_ON=true`), and `heartbeat` (production only). `chimeraInstances` sets the mode: `1` = single fork-mode process; `> 1` (or `max`) = cluster mode, which forces `memory_ON=true` so instances coordinate through the memory socket.
-- Docker boot chain ([`entrypoint.sh`](entrypoint.sh)): create ACME challenge dir → `node chimera/validateEnvVars.js` (fail-fast on missing required env var) → `node chimera/prepareDatabase.js` (idempotently create tables/indexes) → `exec pm2-runtime pm2.config.js`.
-- Postgres side container ([`docker-compose.yml`](docker-compose.yml)): Chimera image plus `postgres:15`; Chimera waits on its healthcheck before starting. `TZ=UTC` pinned on both, required.
-- Schema ([`chimera/prepareDatabase.js`](chimera/prepareDatabase.js)): `frame_files`, `frame_deletes` (storage); `auth`, `sessions` (command auth/RBAC); `objects_detected` (object); `task_runs` (schedule); plus indexes.
-- Gateway reverse-proxies each service with `<prefix>_PROXY_ON=true` and terminates TLS. See [`env.example`](env.example) for the full config schema.
+One Node process under pm2, fronted by a Postgres side container. Each service is toggled by its `<prefix>_ON` flag in `.env`; if off, it never starts.
+
+**Process tree** — pm2 ([`pm2.config.js`](pm2.config.js)) runs the Node app plus a few native helpers:
+
+```
+pm2
+├─ chimera  (server.js)   one process; runs all enabled services
+├─ motion                 storage_ON
+├─ ffmpeg × N             one HLS transcoder per camera, livestream_ON
+└─ heartbeat              production only
+```
+
+Inside `chimera`, [`server.js`](server.js) starts services in order: **command** first (fatal — the process exits if it fails), then **storage**, **livestream**, **schedule**, **object**, then the **memory** coordination socket, then the **gateway** last. The gateway is the single public entrypoint: it reverse-proxies every service with `<prefix>_PROXY_ON=true` and terminates TLS.
+
+**Boot chain** — Docker [`entrypoint.sh`](entrypoint.sh) runs before pm2, aborting on the first failure:
+
+```
+ACME dir → validateEnvVars.js → prepareDatabase.js → pm2-runtime
+ (TLS)     (fail-fast env)       (create schema)      (start pm2)
+```
+
+Postgres runs as a side container ([`docker-compose.yml`](docker-compose.yml), `postgres:15`); Chimera waits on its healthcheck. `TZ=UTC` is pinned on both and is required — non-UTC misaligns clips, zips, and frames.
+
+**Single vs. cluster** — `chimeraInstances` picks the mode: `1` is a single fork-mode process; `>1` or `max` is cluster mode, which forces `memory_ON=true` so instances coordinate through the memory socket.
+
+**Schema** — [`prepareDatabase.js`](chimera/prepareDatabase.js) idempotently creates these tables (plus indexes), per owning service:
+
+- **storage** — `frame_files`, `frame_deletes`
+- **command** — `auth`, `sessions`
+- **object** — `objects_detected`
+- **schedule** — `task_runs`
+
+See [`env.example`](env.example) for the full config schema.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Chimera is a microservices-based security camera system for RTSP/IP cameras.
 
-List of microservices: 
+Microservices:
 
 1. [command](command)
 2. [livestream](livestream)
@@ -15,18 +15,18 @@ List of microservices:
 7. [object](object)
 
 Shared code & bootstrap:
-- [lib](lib) - shared utilities used by every service (auth middleware, webhook alerts, camera loading, etc.).
+- [lib](lib) - shared utilities for every service (auth middleware, webhook alerts, camera loading, etc.).
 - [chimera](chimera) - boot/config scripts: `preflight.js` (config wizard), `validateEnvVars.js` (fail-fast env check), `prepareDatabase.js` (schema creation).
 
-Massive Dependencies (all bundled in the Docker image):
-1. [motion](https://github.com/Motion-Project/motion) - saves RTSP frames; co-located with [storage](storage), see why there.
+Bundled dependencies (in the Docker image):
+1. [motion](https://github.com/Motion-Project/motion) - saves RTSP frames; co-located with [storage](storage).
 2. [ffmpeg](https://ffmpeg.org) - used by [livestream](livestream) and [storage](storage).
-3. [heartbeat](https://github.com/jjjpanda/heartbeat) - confirms the server is still up.
-4. [postgres](https://www.postgresql.org) - the database (runs as its own container).
+3. [heartbeat](https://github.com/jjjpanda/heartbeat) - confirms the server is up.
+4. [postgres](https://www.postgresql.org) - the database (its own container).
 
 ## Quick Start (Docker)
 
-Docker is the supported way to run Chimera. The image bundles motion, ffmpeg, Node, and pm2, pins `TZ=UTC` (required — non-UTC misaligns clips/zips/frames), and runs Postgres as a side container whose schema is created automatically on boot.
+The image bundles motion, ffmpeg, Node, and pm2, pins `TZ=UTC` (required; non-UTC misaligns clips/zips/frames), and runs Postgres as a side container whose schema is created automatically on boot.
 
 ### 1. Configure
 ```
@@ -35,25 +35,25 @@ cp motion.conf.example motion.conf
 ```
 Add a `cameraconf/camN.conf` per camera (see [`camera.conf.example`](cameraconf/camera.conf.example)).
 
-Or run `npm run preflight` to interactively seed and validate `.env`, `motion.conf`, and `cameraconf/*.conf` against [`env.example`](env.example) before building. It skips checks for services you have turned off. `docker:build`/`docker:up` already run `preflight --check` first, so a bad config blocks the build.
+Or run `npm run preflight` to interactively seed and validate `.env`, `motion.conf`, and `cameraconf/*.conf` against [`env.example`](env.example) before building; it skips checks for services you turned off. `docker:build`/`docker:up` run `preflight --check` first, so a bad config blocks the build.
 
 ### 2. Build & run
 ```
 npm run docker:build
 npm run docker:up
 ```
-`docker:logs` tails output · `docker:down` stops · `docker:rebuild` redeploys · `docker:delete` wipes volumes.
+`docker:logs` tails · `docker:down` stops · `docker:rebuild` redeploys · `docker:delete` wipes volumes.
 
 ### 3. First run
-On first boot no users exist. Open the gateway in a browser and create the first admin from the setup screen, which calls `POST /authorization/setup`. The call is authorized with the required `setup_TOKEN` from `.env`. Auth, RBAC, and sessions all live in [command](command).
+No users exist on first boot. Open the gateway and create the first admin from the setup screen (calls `POST /authorization/setup`, authorized with `setup_TOKEN` from `.env`). Auth, RBAC, and sessions live in [command](command).
 
-> **Bare-metal is unsupported.** Please use Docker. Running via pm2 on bare-metal is heavily discouraged and no longer documented.
+> Bare-metal is unsupported. Use Docker; pm2 on bare-metal is discouraged and undocumented.
 
 ## Architecture
 
-- **One Node process.** [`server.js`](server.js) `require()`s each service and starts them in order: command (fatal — the process exits if it fails), storage, livestream, schedule, object — all via `.start()` — then the [memory](memory) socket (via `.server()`), then the [gateway](gateway) (via `.start()`). Each service is gated by its own `<prefix>_ON` flag in `.env`, so a service left off is simply not started.
-- **pm2 is the process manager** ([`pm2.config.js`](pm2.config.js)). It runs that single `chimera` app and, alongside it, launches `motion` (when `storage_ON=true`), one `ffmpeg` HLS process per camera (when `livestream_ON=true`), and `heartbeat` (production only). `chimeraInstances` sets the pm2 mode: `1` runs a single fork-mode process, while `> 1` (or `max`) switches to cluster mode and forces `memory_ON=true` so instances stay coordinated through the memory socket.
-- **Docker boot chain** ([`entrypoint.sh`](entrypoint.sh)): create the ACME challenge dir → `node chimera/validateEnvVars.js` (fail-fast if a required env var is missing) → `node chimera/prepareDatabase.js` (idempotently create tables/indexes) → `exec pm2-runtime pm2.config.js`.
-- **Postgres side container.** [`docker-compose.yml`](docker-compose.yml) runs the Chimera image plus a `postgres:15` container; Chimera waits on its healthcheck before starting. `TZ=UTC` is pinned on both containers and is required.
-- **Schema** (created by [`chimera/prepareDatabase.js`](chimera/prepareDatabase.js)): `frame_files`, `frame_deletes` (storage); `auth`, `sessions` (command auth/RBAC); `objects_detected` (object); `task_runs` (schedule); plus supporting indexes.
-- **Single public entrypoint.** The [gateway](gateway) reverse-proxies each service whose `<prefix>_PROXY_ON=true` and terminates TLS. See [`env.example`](env.example) for the full configuration schema.
+- One Node process. [`server.js`](server.js) `require()`s and starts each service in order: command (fatal; process exits if it fails), storage, livestream, schedule, object (all via `.start()`), then the [memory](memory) socket (via `.server()`), then the [gateway](gateway) (via `.start()`). Each service is gated by its `<prefix>_ON` flag in `.env`; if off, it is not started.
+- pm2 ([`pm2.config.js`](pm2.config.js)) manages one `chimera` app and launches `motion` (`storage_ON=true`), one `ffmpeg` HLS process per camera (`livestream_ON=true`), and `heartbeat` (production only). `chimeraInstances` sets the mode: `1` = single fork-mode process; `> 1` (or `max`) = cluster mode, which forces `memory_ON=true` so instances coordinate through the memory socket.
+- Docker boot chain ([`entrypoint.sh`](entrypoint.sh)): create ACME challenge dir → `node chimera/validateEnvVars.js` (fail-fast on missing required env var) → `node chimera/prepareDatabase.js` (idempotently create tables/indexes) → `exec pm2-runtime pm2.config.js`.
+- Postgres side container ([`docker-compose.yml`](docker-compose.yml)): Chimera image plus `postgres:15`; Chimera waits on its healthcheck before starting. `TZ=UTC` pinned on both, required.
+- Schema ([`chimera/prepareDatabase.js`](chimera/prepareDatabase.js)): `frame_files`, `frame_deletes` (storage); `auth`, `sessions` (command auth/RBAC); `objects_detected` (object); `task_runs` (schedule); plus indexes.
+- Gateway reverse-proxies each service with `<prefix>_PROXY_ON=true` and terminates TLS. See [`env.example`](env.example) for the full config schema.

--- a/chimera/README.md
+++ b/chimera/README.md
@@ -1,0 +1,69 @@
+# Chimera bootstrap <img src="../command/frontend/res/logo.png" alt="logo" width="20"/>
+
+The `chimera/` directory holds the bootstrap layer that runs **before** any service starts: it validates configuration, prepares the Postgres schema, and (on the host, before Docker) runs an interactive config wizard. These are one-shot scripts, not long-running servers — they have no HTTP routes.
+
+---
+# Boot chain
+
+`entrypoint.sh` is the container entrypoint. It runs, in order, and aborts on the first failure (`set -e`):
+
+1. `mkdir -p ./.well-known/acme-challenge` — the ACME challenge directory the [gateway](../gateway) serves for TLS certificate issuance.
+2. `node chimera/validateEnvVars.js` — fail-fast validation of required env vars.
+3. `node chimera/prepareDatabase.js` — idempotently create the Postgres tables and indexes.
+4. `exec pm2-runtime pm2.config.js` — hand off to pm2, which launches the Chimera Node process (`server.js`) — a single instance when `chimeraInstances == 1`, or a cluster of `chimeraInstances` instances (which also forces `memory_ON=true`) when it is `>1` or `max` — plus `motion` (when `storage_ON=true`), one `ffmpeg` HLS process per camera (when `livestream_ON=true`), and `heartbeat` (production). See [`../pm2.config.js`](../pm2.config.js).
+
+The preflight wizard is **not** part of this chain — it runs on the host before `docker compose up`.
+
+---
+# validateEnvVars.js
+
+Loads `.env` via `dotenv` and checks that every required env var is present. It does **not** short-circuit on the first gap: every check runs unconditionally, and each missing or invalid var prints its own message (`MISSING ENV VAR <name>`, or a path error such as `SHOULD BE AN ABSOLUTE PATH` / `SHOULD BE A FOLDER` / `SHOULD BE A FILE`), so a single run reports **all** problems. `process.exit(1)` is called just once at the very end when anything failed, so the container never boots half-configured.
+
+- **Required vs optional** — keys marked `***` in [`../env.example`](../env.example) are optional and skipped (`optionalKeys` is derived from the schema via `preflight.parseSchema`).
+- **Disabled services skip their checks** — the same `preflight.isServiceOff` logic used by the wizard is applied here: a key prefixed `command_`, `schedule_`, `storage_`, `livestream_`, `object_`, `memory_`, or `gateway_` is skipped when its `<prefix>_ON` is `false`. The `<prefix>_ON` toggle itself is always checked. `storage_MOTION_CONF_FILEPATH` is only required when a camera-consuming service (storage/object/livestream) is on.
+- **Path checks** — `confirmPath()` additionally verifies that path vars are absolute and are the right kind (file vs folder): `privateKey_FILEPATH`, `certificate_FILEPATH`, `ffmpeg_FILEPATH`, `ffprobe_FILEPATH` must be files; `storage_FOLDERPATH` and `livestream_FOLDERPATH` must be folders.
+
+---
+# prepareDatabase.js
+
+Connects to Postgres with the `database_*` env vars and runs each `CREATE TABLE` / `CREATE INDEX` once. It is **idempotent**: a table that already exists surfaces error code `42P07` (`relation already exists`) which is treated as success, and indexes use `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. Any other failure exits `1`.
+
+Tables created (owning service in parentheses):
+
+|Table|Owner|Purpose|
+| :-|:-:|:- |
+|`frame_files`|[storage](../storage)|One row per saved motion frame (`camera`, `timestamp`, `name`, `size`)|
+|`frame_deletes`|[storage](../storage)|Audit of quota-driven deletions (`camera`, `timestamp`, `size`, `count`)|
+|`auth`|[command](../command)|Users: `username`, `hash`, `role`, `theme`, `force_password_change`, `temp_password_expires`, `last_login`|
+|`sessions`|[command](../command)|Sessions keyed by `jti` (`ip`, `user_agent`, `revoked`), FK to `auth(username)` `ON DELETE CASCADE`|
+|`objects_detected`|[object](../object)|Detections: `camera`, `timestamp`, `type`, `confidence`, `box` (JSONB), `image`|
+|`task_runs`|[schedule](../schedule)|Scheduler run log: `task_id`, `url`, `status`, `http_status`, `error`, `ran_at`|
+
+Supporting indexes: `idx_frame_files_camera_timestamp` on `frame_files(camera, timestamp)`, `idx_objects_detected_camera_timestamp` on `objects_detected(camera, timestamp)`, and `idx_task_runs_ran_at` on `task_runs(ran_at)`.
+
+The module also exports `creationTasks` so tests can introspect the schema.
+
+---
+# preflight.js — `npm run preflight`
+
+An interactive wizard that seeds and validates local config against the schema in [`../env.example`](../env.example) **before** you run Docker. It checks three things: `.env`, `motion.conf`, and `cameraconf/*.conf`.
+
+```
+npm run preflight            # interactive wizard (fixes problems in place)
+npm run preflight -- --check # non-interactive report, exits 1 if blocked (CI)
+```
+
+Mode selection: `--check` forces the report-only path; it is also chosen automatically when stdin is not a TTY (unless `--interactive` is passed).
+
+**.env** — in interactive mode, a missing `.env` is seeded from `env.example`; in `--check` mode a missing `.env` is reported as a failure (`.env ✗ missing`) that blocks Docker, with no seeding. Each schema key is then validated: required keys must be set (and not left at the placeholder), `(true | false)` keys must be `true`/`false`, and `_PORT`/`_PORT_SECURE` keys must be numeric. Interactive mode re-prompts until each value is valid and writes it back; `--check` lists every problem. Disabled services are skipped via the same `isServiceOff` rule as `validateEnvVars.js`, so you are never asked about a service whose `<prefix>_ON` is `false`.
+
+**motion.conf** and **cameraconf/** are only checked when storage, object, or livestream is enabled. Interactive mode offers to copy `motion.conf.example` to `motion.conf`, then validates every camera `.conf` (parsed with [lib](../lib) `loadCameras.parseConf`) for a positive unique `camera_id`, a unique `camera_name`, and a `netcam_url` with a scheme (e.g. `rtsp://`), and can scaffold new `cameraconf/camN.conf` files. The camera directory defaults to `cameraconf/`; a **relative** `camera_dir` in `motion.conf` overrides it (resolved against the repo root), but an absolute `camera_dir` is ignored here and falls back to `cameraconf/`. (Note `loadCameras.js`, used by pm2, does honor an absolute `camera_dir`, so the two can disagree.)
+
+Both paths exit `1` when anything is still unresolved (Docker blocked) and `0` when all checks pass. The module exports `parseSchema`, `typeOf`, `varProblem`, `cameraProblems`, and `isServiceOff` for reuse (notably by `validateEnvVars.js`) and testing.
+
+---
+# How it fits
+
+- `validateEnvVars.js` and `prepareDatabase.js` are gates in the container boot chain (`entrypoint.sh`); pm2 only starts once both succeed.
+- `preflight.js` runs on the host and shares its schema parsing and service-toggle logic with `validateEnvVars.js`, so host-side and container-side validation stay consistent.
+- The env schema of record is [`../env.example`](../env.example); camera definitions live in `cameraconf/*.conf` and are parsed by [lib](../lib)/`utils/loadCameras.js`.

--- a/chimera/README.md
+++ b/chimera/README.md
@@ -1,32 +1,39 @@
 # Chimera bootstrap <img src="../command/frontend/res/logo.png" alt="logo" width="20"/>
 
-The `chimera/` directory holds the bootstrap layer that runs **before** any service starts: it validates configuration, prepares the Postgres schema, and (on the host, before Docker) runs an interactive config wizard. These are one-shot scripts, not long-running servers — they have no HTTP routes.
+One-shot bootstrap scripts that run before any service starts: they validate config, prepare the Postgres schema, and (on the host, before Docker) run a config wizard; no HTTP routes.
 
 ---
 # Boot chain
 
-`entrypoint.sh` is the container entrypoint. It runs, in order, and aborts on the first failure (`set -e`):
+`entrypoint.sh` is the container entrypoint. It runs in order and aborts on the first failure (`set -e`):
 
-1. `mkdir -p ./.well-known/acme-challenge` — the ACME challenge directory the [gateway](../gateway) serves for TLS certificate issuance.
+1. `mkdir -p ./.well-known/acme-challenge` — ACME challenge dir the [gateway](../gateway) serves for TLS cert issuance.
 2. `node chimera/validateEnvVars.js` — fail-fast validation of required env vars.
-3. `node chimera/prepareDatabase.js` — idempotently create the Postgres tables and indexes.
-4. `exec pm2-runtime pm2.config.js` — hand off to pm2, which launches the Chimera Node process (`server.js`) — a single instance when `chimeraInstances == 1`, or a cluster of `chimeraInstances` instances (which also forces `memory_ON=true`) when it is `>1` or `max` — plus `motion` (when `storage_ON=true`), one `ffmpeg` HLS process per camera (when `livestream_ON=true`), and `heartbeat` (production). See [`../pm2.config.js`](../pm2.config.js).
+3. `node chimera/prepareDatabase.js` — idempotently create Postgres tables and indexes.
+4. `exec pm2-runtime pm2.config.js` — hand off to pm2 ([`../pm2.config.js`](../pm2.config.js)).
 
-The preflight wizard is **not** part of this chain — it runs on the host before `docker compose up`.
+pm2 launches:
+
+- `server.js` (Chimera): single instance when `chimeraInstances == 1`; cluster of `chimeraInstances` when `>1` or `max` (forces `memory_ON=true`).
+- `motion` when `storage_ON=true`.
+- one `ffmpeg` HLS process per camera when `livestream_ON=true`.
+- `heartbeat` in production.
+
+Preflight is not part of this chain; it runs on the host before `docker compose up`.
 
 ---
 # validateEnvVars.js
 
-Loads `.env` via `dotenv` and checks that every required env var is present. It does **not** short-circuit on the first gap: every check runs unconditionally, and each missing or invalid var prints its own message (`MISSING ENV VAR <name>`, or a path error such as `SHOULD BE AN ABSOLUTE PATH` / `SHOULD BE A FOLDER` / `SHOULD BE A FILE`), so a single run reports **all** problems. `process.exit(1)` is called just once at the very end when anything failed, so the container never boots half-configured.
+Loads `.env` via `dotenv` and checks every required var. All checks run unconditionally (no short-circuit): each missing or invalid var prints its own message (`MISSING ENV VAR <name>`, or `SHOULD BE AN ABSOLUTE PATH` / `SHOULD BE A FOLDER` / `SHOULD BE A FILE`), so one run reports every problem. Calls `process.exit(1)` once at the end if anything failed, so the container never boots half-configured.
 
-- **Required vs optional** — keys marked `***` in [`../env.example`](../env.example) are optional and skipped (`optionalKeys` is derived from the schema via `preflight.parseSchema`).
-- **Disabled services skip their checks** — the same `preflight.isServiceOff` logic used by the wizard is applied here: a key prefixed `command_`, `schedule_`, `storage_`, `livestream_`, `object_`, `memory_`, or `gateway_` is skipped when its `<prefix>_ON` is `false`. The `<prefix>_ON` toggle itself is always checked. `storage_MOTION_CONF_FILEPATH` is only required when a camera-consuming service (storage/object/livestream) is on.
-- **Path checks** — `confirmPath()` additionally verifies that path vars are absolute and are the right kind (file vs folder): `privateKey_FILEPATH`, `certificate_FILEPATH`, `ffmpeg_FILEPATH`, `ffprobe_FILEPATH` must be files; `storage_FOLDERPATH` and `livestream_FOLDERPATH` must be folders.
+- Optional keys (`***` in [`../env.example`](../env.example)) are skipped; `optionalKeys` comes from `preflight.parseSchema`.
+- Disabled services skip their checks via `preflight.isServiceOff`: a key prefixed `command_`, `schedule_`, `storage_`, `livestream_`, `object_`, `memory_`, or `gateway_` is skipped when its `<prefix>_ON` is `false`. The `<prefix>_ON` toggle itself is always checked. `storage_MOTION_CONF_FILEPATH` is required only when storage, object, or livestream is on.
+- Path checks (`confirmPath()`), all must be absolute: `privateKey_FILEPATH`, `certificate_FILEPATH`, `ffmpeg_FILEPATH`, `ffprobe_FILEPATH` must be files; `storage_FOLDERPATH`, `livestream_FOLDERPATH` must be folders.
 
 ---
 # prepareDatabase.js
 
-Connects to Postgres with the `database_*` env vars and runs each `CREATE TABLE` / `CREATE INDEX` once. It is **idempotent**: a table that already exists surfaces error code `42P07` (`relation already exists`) which is treated as success, and indexes use `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. Any other failure exits `1`.
+Connects with the `database_*` env vars and runs each `CREATE TABLE` / `CREATE INDEX` once. Idempotent: an existing table surfaces `42P07` (`relation already exists`), treated as success; indexes use `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. Any other failure exits `1`. Exports `creationTasks` so tests can introspect the schema.
 
 Tables created (owning service in parentheses):
 
@@ -39,31 +46,19 @@ Tables created (owning service in parentheses):
 |`objects_detected`|[object](../object)|Detections: `camera`, `timestamp`, `type`, `confidence`, `box` (JSONB), `image`|
 |`task_runs`|[schedule](../schedule)|Scheduler run log: `task_id`, `url`, `status`, `http_status`, `error`, `ran_at`|
 
-Supporting indexes: `idx_frame_files_camera_timestamp` on `frame_files(camera, timestamp)`, `idx_objects_detected_camera_timestamp` on `objects_detected(camera, timestamp)`, and `idx_task_runs_ran_at` on `task_runs(ran_at)`.
-
-The module also exports `creationTasks` so tests can introspect the schema.
+Indexes: `idx_frame_files_camera_timestamp` on `frame_files(camera, timestamp)`, `idx_objects_detected_camera_timestamp` on `objects_detected(camera, timestamp)`, `idx_task_runs_ran_at` on `task_runs(ran_at)`.
 
 ---
 # preflight.js — `npm run preflight`
 
-An interactive wizard that seeds and validates local config against the schema in [`../env.example`](../env.example) **before** you run Docker. It checks three things: `.env`, `motion.conf`, and `cameraconf/*.conf`.
+Interactive wizard that seeds and validates local config against [`../env.example`](../env.example) before Docker. Checks `.env`, `motion.conf`, and `cameraconf/*.conf`.
 
 ```
 npm run preflight            # interactive wizard (fixes problems in place)
 npm run preflight -- --check # non-interactive report, exits 1 if blocked (CI)
 ```
 
-Mode selection: `--check` forces the report-only path; it is also chosen automatically when stdin is not a TTY (unless `--interactive` is passed).
-
-**.env** — in interactive mode, a missing `.env` is seeded from `env.example`; in `--check` mode a missing `.env` is reported as a failure (`.env ✗ missing`) that blocks Docker, with no seeding. Each schema key is then validated: required keys must be set (and not left at the placeholder), `(true | false)` keys must be `true`/`false`, and `_PORT`/`_PORT_SECURE` keys must be numeric. Interactive mode re-prompts until each value is valid and writes it back; `--check` lists every problem. Disabled services are skipped via the same `isServiceOff` rule as `validateEnvVars.js`, so you are never asked about a service whose `<prefix>_ON` is `false`.
-
-**motion.conf** and **cameraconf/** are only checked when storage, object, or livestream is enabled. Interactive mode offers to copy `motion.conf.example` to `motion.conf`, then validates every camera `.conf` (parsed with [lib](../lib) `loadCameras.parseConf`) for a positive unique `camera_id`, a unique `camera_name`, and a `netcam_url` with a scheme (e.g. `rtsp://`), and can scaffold new `cameraconf/camN.conf` files. The camera directory defaults to `cameraconf/`; a **relative** `camera_dir` in `motion.conf` overrides it (resolved against the repo root), but an absolute `camera_dir` is ignored here and falls back to `cameraconf/`. (Note `loadCameras.js`, used by pm2, does honor an absolute `camera_dir`, so the two can disagree.)
-
-Both paths exit `1` when anything is still unresolved (Docker blocked) and `0` when all checks pass. The module exports `parseSchema`, `typeOf`, `varProblem`, `cameraProblems`, and `isServiceOff` for reuse (notably by `validateEnvVars.js`) and testing.
-
----
-# How it fits
-
-- `validateEnvVars.js` and `prepareDatabase.js` are gates in the container boot chain (`entrypoint.sh`); pm2 only starts once both succeed.
-- `preflight.js` runs on the host and shares its schema parsing and service-toggle logic with `validateEnvVars.js`, so host-side and container-side validation stay consistent.
-- The env schema of record is [`../env.example`](../env.example); camera definitions live in `cameraconf/*.conf` and are parsed by [lib](../lib)/`utils/loadCameras.js`.
+- Mode: `--check` forces report-only; also used automatically when stdin is not a TTY, unless `--interactive` is passed.
+- `.env`: interactive mode seeds a missing `.env` from `env.example`; `--check` reports it as `.env ✗ missing` (blocks Docker, no seeding). Each key is validated: required keys must be set (not left at the placeholder), `(true | false)` keys must be `true`/`false`, `_PORT`/`_PORT_SECURE` keys must be numeric. Interactive re-prompts until valid and writes back; `--check` lists every problem. Disabled services are skipped via `isServiceOff`.
+- `motion.conf` / `cameraconf/`: checked only when storage, object, or livestream is on. Interactive offers to copy `motion.conf.example` to `motion.conf`, validates every camera `.conf` (parsed with [lib](../lib) `loadCameras.parseConf`) for a positive unique `camera_id`, a unique `camera_name`, and a `netcam_url` with a scheme (e.g. `rtsp://`), and can scaffold new `cameraconf/camN.conf`. Camera dir defaults to `cameraconf/`; a relative `camera_dir` in `motion.conf` overrides it (resolved against repo root), but an absolute `camera_dir` is ignored here and falls back to `cameraconf/`. (`loadCameras.js`, used by pm2, does honor an absolute `camera_dir`, so the two can disagree.)
+- Exits `1` when anything is unresolved (Docker blocked), `0` when all checks pass. Exports `parseSchema`, `typeOf`, `varProblem`, `cameraProblems`, `isServiceOff` for reuse (notably `validateEnvVars.js`) and testing.

--- a/chimera/README.md
+++ b/chimera/README.md
@@ -1,64 +1,45 @@
 # Chimera bootstrap <img src="../command/frontend/res/logo.png" alt="logo" width="20"/>
 
-One-shot bootstrap scripts that run before any service starts: they validate config, prepare the Postgres schema, and (on the host, before Docker) run a config wizard; no HTTP routes.
+One-shot scripts that run before any service starts: validate config, prepare the Postgres schema, and (on the host) run a config wizard. No HTTP routes.
 
 ---
 # Boot chain
 
-`entrypoint.sh` is the container entrypoint. It runs in order and aborts on the first failure (`set -e`):
+[entrypoint.sh](entrypoint.sh), the container entrypoint — runs in order, aborts on first failure (`set -e`):
 
-1. `mkdir -p ./.well-known/acme-challenge` — ACME challenge dir the [gateway](../gateway) serves for TLS cert issuance.
-2. `node chimera/validateEnvVars.js` — fail-fast validation of required env vars.
-3. `node chimera/prepareDatabase.js` — idempotently create Postgres tables and indexes.
-4. `exec pm2-runtime pm2.config.js` — hand off to pm2 ([`../pm2.config.js`](../pm2.config.js)).
+1. `mkdir -p ./.well-known/acme-challenge` — ACME dir the [gateway](../gateway) serves for TLS.
+2. `validateEnvVars.js` — fail-fast env validation.
+3. `prepareDatabase.js` — create Postgres tables/indexes.
+4. `exec pm2-runtime pm2.config.js` — hand off to pm2.
 
-pm2 launches:
-
-- `server.js` (Chimera): single instance when `chimeraInstances == 1`; cluster of `chimeraInstances` when `>1` or `max` (forces `memory_ON=true`).
-- `motion` when `storage_ON=true`.
-- one `ffmpeg` HLS process per camera when `livestream_ON=true`.
-- `heartbeat` in production.
-
-Preflight is not part of this chain; it runs on the host before `docker compose up`.
+Preflight is not in this chain; it runs on the host before `docker compose up`.
 
 ---
 # validateEnvVars.js
 
-Loads `.env` via `dotenv` and checks every required var. All checks run unconditionally (no short-circuit): each missing or invalid var prints its own message (`MISSING ENV VAR <name>`, or `SHOULD BE AN ABSOLUTE PATH` / `SHOULD BE A FOLDER` / `SHOULD BE A FILE`), so one run reports every problem. Calls `process.exit(1)` once at the end if anything failed, so the container never boots half-configured.
+Checks every required env var — all checks run (no short-circuit), so one run reports every problem, then `exit(1)` if anything failed.
 
-- Optional keys (`***` in [`../env.example`](../env.example)) are skipped; `optionalKeys` comes from `preflight.parseSchema`.
-- Disabled services skip their checks via `preflight.isServiceOff`: a key prefixed `command_`, `schedule_`, `storage_`, `livestream_`, `object_`, `memory_`, or `gateway_` is skipped when its `<prefix>_ON` is `false`. The `<prefix>_ON` toggle itself is always checked. `storage_MOTION_CONF_FILEPATH` is required only when storage, object, or livestream is on.
-- Path checks (`confirmPath()`), all must be absolute: `privateKey_FILEPATH`, `certificate_FILEPATH`, `ffmpeg_FILEPATH`, `ffprobe_FILEPATH` must be files; `storage_FOLDERPATH`, `livestream_FOLDERPATH` must be folders.
+- Optional keys (`***` in [env.example](../env.example)) skipped; disabled services skip their `<prefix>_*` keys (the `<prefix>_ON` toggle is always checked).
+- `storage_MOTION_CONF_FILEPATH` required only when storage/object/livestream is on.
+- Absolute-path checks: key/cert/ffmpeg/ffprobe files; `storage_FOLDERPATH` / `livestream_FOLDERPATH` folders.
 
 ---
 # prepareDatabase.js
 
-Connects with the `database_*` env vars and runs each `CREATE TABLE` / `CREATE INDEX` once. Idempotent: an existing table surfaces `42P07` (`relation already exists`), treated as success; indexes use `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. Any other failure exits `1`. Exports `creationTasks` so tests can introspect the schema.
+Connects with `database_*` and runs each `CREATE TABLE`/`INDEX` once — idempotent (existing table → `42P07`, treated as success; indexes use `IF NOT EXISTS`). Any other error exits `1`.
 
-Tables created (owning service in parentheses):
-
-|Table|Owner|Purpose|
-| :-|:-:|:- |
-|`frame_files`|[storage](../storage)|One row per saved motion frame (`camera`, `timestamp`, `name`, `size`)|
-|`frame_deletes`|[storage](../storage)|Audit of quota-driven deletions (`camera`, `timestamp`, `size`, `count`)|
-|`auth`|[command](../command)|Users: `username`, `hash`, `role`, `theme`, `force_password_change`, `temp_password_expires`, `last_login`|
-|`sessions`|[command](../command)|Sessions keyed by `jti` (`ip`, `user_agent`, `revoked`), FK to `auth(username)` `ON DELETE CASCADE`|
-|`objects_detected`|[object](../object)|Detections: `camera`, `timestamp`, `type`, `confidence`, `box` (JSONB), `image`|
-|`task_runs`|[schedule](../schedule)|Scheduler run log: `task_id`, `url`, `status`, `http_status`, `error`, `ran_at`|
-
-Indexes: `idx_frame_files_camera_timestamp` on `frame_files(camera, timestamp)`, `idx_objects_detected_camera_timestamp` on `objects_detected(camera, timestamp)`, `idx_task_runs_ran_at` on `task_runs(ran_at)`.
+Tables (owner): `frame_files`, `frame_deletes` (storage) · `auth`, `sessions` (command) · `objects_detected` (object) · `task_runs` (schedule). Plus timestamp indexes on `frame_files`, `objects_detected`, `task_runs`.
 
 ---
 # preflight.js — `npm run preflight`
 
-Interactive wizard that seeds and validates local config against [`../env.example`](../env.example) before Docker. Checks `.env`, `motion.conf`, and `cameraconf/*.conf`.
+Interactive wizard that seeds and validates `.env`, `motion.conf`, and `cameraconf/*.conf` against [env.example](../env.example) before Docker.
 
 ```
-npm run preflight            # interactive wizard (fixes problems in place)
-npm run preflight -- --check # non-interactive report, exits 1 if blocked (CI)
+npm run preflight            # interactive; fixes problems in place
+npm run preflight -- --check # report-only, exits 1 if blocked (CI, non-TTY)
 ```
 
-- Mode: `--check` forces report-only; also used automatically when stdin is not a TTY, unless `--interactive` is passed.
-- `.env`: interactive mode seeds a missing `.env` from `env.example`; `--check` reports it as `.env ✗ missing` (blocks Docker, no seeding). Each key is validated: required keys must be set (not left at the placeholder), `(true | false)` keys must be `true`/`false`, `_PORT`/`_PORT_SECURE` keys must be numeric. Interactive re-prompts until valid and writes back; `--check` lists every problem. Disabled services are skipped via `isServiceOff`.
-- `motion.conf` / `cameraconf/`: checked only when storage, object, or livestream is on. Interactive offers to copy `motion.conf.example` to `motion.conf`, validates every camera `.conf` (parsed with [lib](../lib) `loadCameras.parseConf`) for a positive unique `camera_id`, a unique `camera_name`, and a `netcam_url` with a scheme (e.g. `rtsp://`), and can scaffold new `cameraconf/camN.conf`. Camera dir defaults to `cameraconf/`; a relative `camera_dir` in `motion.conf` overrides it (resolved against repo root), but an absolute `camera_dir` is ignored here and falls back to `cameraconf/`. (`loadCameras.js`, used by pm2, does honor an absolute `camera_dir`, so the two can disagree.)
-- Exits `1` when anything is unresolved (Docker blocked), `0` when all checks pass. Exports `parseSchema`, `typeOf`, `varProblem`, `cameraProblems`, `isServiceOff` for reuse (notably `validateEnvVars.js`) and testing.
+- `.env`: interactive seeds a missing file from `env.example` and re-prompts until valid; `--check` only reports. Validates required / boolean / port keys; skips disabled services.
+- `motion.conf` / `cameraconf/`: checked only when storage/object/livestream is on. Validates each camera `.conf` (unique `camera_id` / `camera_name`, `netcam_url` scheme) and can scaffold new ones. An absolute `camera_dir` in `motion.conf` is ignored here (falls back to `cameraconf/`), but `loadCameras.js` (used by pm2) does honor it — the two can disagree.
+- Exits `1` when anything is unresolved. Exports helpers reused by `validateEnvVars.js` and tests.

--- a/command/README.md
+++ b/command/README.md
@@ -3,42 +3,13 @@
 Serves the web app and handles authentication, RBAC, and session management.
 
 ---
-# Routes
-## ▶ /authorization
+# API
 
-`auth` = session (`authorize`); `admin` = session + admin (`requireAdmin`); `none` = public.
+Three access levels: public, session-required (`authorize`), and admin-only (`requireAdmin`). Authentication, RBAC, and sessions all live here — other services validate their sessions against this service's `auth`/`sessions` tables via [lib](../lib).
 
-|Type|Route|Auth|Description|Body|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|GET|/status|none|Setup state and whether a token is required|—|`{setup, tokenRequired}`|
-|POST|/setup|token*|Bootstrap first admin or recover admin (rate-limited)|`{username, password, token?}`|`{error}`|
-|POST|/login|none|Authenticate, set `bearertoken` cookie (rate-limited)|`{username, password}`|`{error, ...}` + cookie|
-|POST|/verify|auth|Validate session|—|`{role, theme, forcePasswordChange}`|
-|PUT|/theme|auth|Save theme (`light`/`dark`/`system`)|`{theme}`|`{error}`|
-|GET|/users|admin|List users|—|`[{username, role, last_login}]`|
-|POST|/users|admin|Create user with temp password|`{username, role}`|`{tempPassword}`|
-|PATCH|/users/:username|admin|Update role/password (can't demote last admin)|`{role?, password?}`|`{error}`|
-|DELETE|/users/:username|admin|Delete user (not self, not last admin)|—|`{error}`|
-|GET|/users/:username/sessions|admin|List user's sessions|—|`[{id, issued_at, last_seen, ip, user_agent, revoked}]`|
-|DELETE|/sessions/:id|admin|Revoke a session|—|`{error}`|
-|POST|/password|auth|Change own password|`{password}`|`{error}`|
-|POST|/logout|auth|Revoke session, clear cookie|—|`{error}`|
+The API covers login/logout and session verification, the first-admin bootstrap and admin recovery (`/authorization/setup`), admin-only user and session management (create/list/update/delete users, list and revoke sessions), theme, and password changes. It also lists cameras (RTSP credentials stripped) for the web app.
 
-\* `/setup` is public but rate-limited. `setup_TOKEN` is required; the service won't boot without it (`command/server.js`), so a reachable `/setup` always demands the token. A valid token bootstraps the first admin (when the `auth` table is empty) or resets an existing admin (recovery).
-
-## ▶ /cameras
-
-Behind `authorize`; session required.
-
-|Type|Route|Auth|Description|Body|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|GET|/|auth|List cameras (RTSP creds stripped)|—|`[{id, name, rtsp_url}]`|
-
-## ▶ /command
-
-|Type|Route|Auth|Description|Parameters|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|GET|/health|none|Server alive|N/A|N/A|
+`setup_TOKEN` is required — the service won't boot without it ([`server.js`](server.js)) — so a reachable `/setup` always demands the token. A valid token bootstraps the first admin (when the `auth` table is empty) or resets an existing admin (recovery). `/setup` is public but rate-limited.
 
 ---
 # Web app
@@ -48,20 +19,7 @@ Behind `authorize`; session required.
 - Rendering and navigation are client-side React (`frontend/App.jsx`): dynamic `/:route` segment plus dedicated `/` and `/login`.
 - Unauthenticated visitors are redirected to `/login`.
 
-Sections defined in `frontend/app/SideMenu.jsx`, mapped to paths by `frontend/js/routeIndexMapping.js`:
-
-|Section|Path|Notes|
-| :-|:- |:- |
-|Home|/||
-|Live|/live||
-|Clip Maker|/clip||
-|Recordings|/recordings||
-|Stats|/stats||
-|Schedule|/schedule||
-|Objects|/objects||
-|Admin|/admin|Admin only; hidden unless role is `admin` (RBAC-gated)|
-
-Mobile nav shows a subset (Clip, Live, Home, Recordings, Stats); desktop shows all.
+Sections (defined in `frontend/app/SideMenu.jsx`, mapped to paths by `frontend/js/routeIndexMapping.js`): Home, Live, Clip Maker, Recordings, Stats, Schedule, Objects, and an admin-only Admin section (hidden unless your role is `admin`). Mobile nav shows a subset (Clip, Live, Home, Recordings, Stats); desktop shows all.
 
 ---
 # Config

--- a/command/README.md
+++ b/command/README.md
@@ -24,7 +24,7 @@ The command server is the face of the operation. It serves the web app and handl
 |POST|/password|auth|Change your own password|`{password}`|`{error}`|
 |POST|/logout|auth|Revoke the current session and clear the cookie|—|`{error}`|
 
-\* `/setup` is public but rate-limited. When `setup_TOKEN` is configured it must be supplied, and the call can bootstrap the first admin (when none exists) or reset an existing admin account (recovery). When `setup_TOKEN` is not configured it only bootstraps the very first admin — i.e. it succeeds only while the `auth` table is empty.
+\* `/setup` is public but rate-limited. `setup_TOKEN` is **required** — the command service refuses to boot without it (`command/server.js`), so a reachable `/setup` always demands the token. With a valid token the call bootstraps the first admin (when the `auth` table is empty) or resets an existing admin account (recovery).
 
 ## ▶ /cameras
 

--- a/command/README.md
+++ b/command/README.md
@@ -1,51 +1,54 @@
 # Command <img src="frontend/res/logo.png" alt="logo" width="20"/> 
 
-The command server is the face of the operation. It serves the web app and handles authentication, RBAC, and session management for the whole system.
+Serves the web app and handles authentication, RBAC, and session management.
 
 ---
 # Routes
 ## ▶ /authorization
 
-`auth` = valid session required (`authorize`). `admin` = valid session **and** admin role (`authorize` + `requireAdmin`). `none` = public.
+`auth` = session (`authorize`); `admin` = session + admin (`requireAdmin`); `none` = public.
 
 |Type|Route|Auth|Description|Body|Returns|
 | :-|:- |:-:|:-|:-:|:-:|
-|GET|/status|none|Whether setup has been completed and if a setup token is required|—|`{setup, tokenRequired}`|
-|POST|/setup|token*|Bootstrap the first admin, or recover the admin account (rate-limited)|`{username, password, token?}`|`{error}`|
-|POST|/login|none|Authenticate and set the `bearertoken` cookie (rate-limited)|`{username, password}`|`{error, ...}` + cookie|
-|POST|/verify|auth|Validate the current session|—|`{role, theme, forcePasswordChange}`|
-|PUT|/theme|auth|Save the user's theme preference (`light`/`dark`/`system`)|`{theme}`|`{error}`|
-|GET|/users|admin|List all users|—|`[{username, role, last_login}]`|
-|POST|/users|admin|Create a user with a temporary password|`{username, role}`|`{tempPassword}`|
-|PATCH|/users/:username|admin|Update a user's role and/or password (can't demote the last admin)|`{role?, password?}`|`{error}`|
-|DELETE|/users/:username|admin|Delete a user (not yourself, not the last admin)|—|`{error}`|
-|GET|/users/:username/sessions|admin|List a user's sessions|—|`[{id, issued_at, last_seen, ip, user_agent, revoked}]`|
+|GET|/status|none|Setup state and whether a token is required|—|`{setup, tokenRequired}`|
+|POST|/setup|token*|Bootstrap first admin or recover admin (rate-limited)|`{username, password, token?}`|`{error}`|
+|POST|/login|none|Authenticate, set `bearertoken` cookie (rate-limited)|`{username, password}`|`{error, ...}` + cookie|
+|POST|/verify|auth|Validate session|—|`{role, theme, forcePasswordChange}`|
+|PUT|/theme|auth|Save theme (`light`/`dark`/`system`)|`{theme}`|`{error}`|
+|GET|/users|admin|List users|—|`[{username, role, last_login}]`|
+|POST|/users|admin|Create user with temp password|`{username, role}`|`{tempPassword}`|
+|PATCH|/users/:username|admin|Update role/password (can't demote last admin)|`{role?, password?}`|`{error}`|
+|DELETE|/users/:username|admin|Delete user (not self, not last admin)|—|`{error}`|
+|GET|/users/:username/sessions|admin|List user's sessions|—|`[{id, issued_at, last_seen, ip, user_agent, revoked}]`|
 |DELETE|/sessions/:id|admin|Revoke a session|—|`{error}`|
-|POST|/password|auth|Change your own password|`{password}`|`{error}`|
-|POST|/logout|auth|Revoke the current session and clear the cookie|—|`{error}`|
+|POST|/password|auth|Change own password|`{password}`|`{error}`|
+|POST|/logout|auth|Revoke session, clear cookie|—|`{error}`|
 
-\* `/setup` is public but rate-limited. `setup_TOKEN` is **required** — the command service refuses to boot without it (`command/server.js`), so a reachable `/setup` always demands the token. With a valid token the call bootstraps the first admin (when the `auth` table is empty) or resets an existing admin account (recovery).
+\* `/setup` is public but rate-limited. `setup_TOKEN` is required; the service won't boot without it (`command/server.js`), so a reachable `/setup` always demands the token. A valid token bootstraps the first admin (when the `auth` table is empty) or resets an existing admin (recovery).
 
 ## ▶ /cameras
 
-Mounted behind `authorize`, so a valid session is required.
+Behind `authorize`; session required.
 
 |Type|Route|Auth|Description|Body|Returns|
 | :-|:- |:-:|:-|:-:|:-:|
-|GET|/|auth|List configured cameras (RTSP credentials stripped)|—|`[{id, name, rtsp_url}]`|
+|GET|/|auth|List cameras (RTSP creds stripped)|—|`[{id, name, rtsp_url}]`|
 
 ## ▶ /command
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/health|Confirms server alive|N/A|N/A|
+|Type|Route|Auth|Description|Parameters|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|GET|/health|none|Server alive|N/A|N/A|
 
 ---
 # Web app
 
-The backend serves the compiled single-page app (`dist/`, built from `frontend/`) as static files at `/`, `/login`, and every app path (`/clip`, `/live`, `/recordings`, `/stats`, `/schedule`, `/admin`, `/objects`); `/res` serves static assets such as the logo. All rendering and navigation happen client-side in React (`frontend/App.jsx`), which matches the app sections via a dynamic `/:route` segment alongside dedicated `/` and `/login` routes; unauthenticated visitors are redirected to `/login`.
+- Serves the compiled SPA (`dist/`, built from `frontend/`) as static files at `/`, `/login`, and every app path below.
+- `/res` serves static assets (logo).
+- Rendering and navigation are client-side React (`frontend/App.jsx`): dynamic `/:route` segment plus dedicated `/` and `/login`.
+- Unauthenticated visitors are redirected to `/login`.
 
-The app is organized into sections defined in `frontend/app/SideMenu.jsx` and mapped to paths by `frontend/js/routeIndexMapping.js`:
+Sections defined in `frontend/app/SideMenu.jsx`, mapped to paths by `frontend/js/routeIndexMapping.js`:
 
 |Section|Path|Notes|
 | :-|:- |:- |
@@ -56,6 +59,11 @@ The app is organized into sections defined in `frontend/app/SideMenu.jsx` and ma
 |Stats|/stats||
 |Schedule|/schedule||
 |Objects|/objects||
-|Admin|/admin|Admin only — hidden unless the session role is `admin` (RBAC-gated)|
+|Admin|/admin|Admin only; hidden unless role is `admin` (RBAC-gated)|
 
-Mobile navigation surfaces a subset of these (Clip, Live, Home, Recordings, Stats); the full set is available on desktop.
+Mobile nav shows a subset (Clip, Live, Home, Recordings, Stats); desktop shows all.
+
+---
+# Config
+
+`command_ON`, `command_PORT`, `command_HOST`, `command_PROXY_ON`, `SECRETKEY`, `setup_TOKEN`; see [../env.example](../env.example).

--- a/command/README.md
+++ b/command/README.md
@@ -5,21 +5,22 @@ Serves the web app and handles authentication, RBAC, and session management.
 ---
 # API
 
-Three access levels: public, session-required (`authorize`), and admin-only (`requireAdmin`). Authentication, RBAC, and sessions all live here — other services validate their sessions against this service's `auth`/`sessions` tables via [lib](../lib).
+Three access levels: public, session (`authorize`), admin (`requireAdmin`). Auth/RBAC/sessions live here; other services validate against this service's `auth`/`sessions` tables via [lib](../lib).
 
-The API covers login/logout and session verification, the first-admin bootstrap and admin recovery (`/authorization/setup`), admin-only user and session management (create/list/update/delete users, list and revoke sessions), theme, and password changes. It also lists cameras (RTSP credentials stripped) for the web app.
+- login/logout, session verification
+- first-admin bootstrap + admin recovery (`/authorization/setup`)
+- admin-only user and session management (create/list/update/delete users; list/revoke sessions)
+- theme and password changes
+- list cameras (RTSP credentials stripped) for the web app
 
-`setup_TOKEN` is required — the service won't boot without it ([`server.js`](server.js)) — so a reachable `/setup` always demands the token. A valid token bootstraps the first admin (when the `auth` table is empty) or resets an existing admin (recovery). `/setup` is public but rate-limited.
+`setup_TOKEN` is required — the service won't boot without it ([server.js](server.js)). A valid token bootstraps the first admin (empty `auth` table) or resets an existing one (recovery). `/setup` is public but rate-limited.
 
 ---
 # Web app
 
-- Serves the compiled SPA (`dist/`, built from `frontend/`) as static files at `/`, `/login`, and every app path below.
-- `/res` serves static assets (logo).
-- Rendering and navigation are client-side React (`frontend/App.jsx`): dynamic `/:route` segment plus dedicated `/` and `/login`.
-- Unauthenticated visitors are redirected to `/login`.
-
-Sections (defined in `frontend/app/SideMenu.jsx`, mapped to paths by `frontend/js/routeIndexMapping.js`): Home, Live, Clip Maker, Recordings, Stats, Schedule, Objects, and an admin-only Admin section (hidden unless your role is `admin`). Mobile nav shows a subset (Clip, Live, Home, Recordings, Stats); desktop shows all.
+- Serves the compiled SPA (`dist/`, built from `frontend/`) at `/`, `/login`, and every app path; `/res` serves static assets.
+- Client-side React ([frontend/App.jsx](frontend/App.jsx)); unauthenticated visitors redirect to `/login`.
+- Sections: Home, Live, Clip Maker, Recordings, Stats, Schedule, Objects, and an admin-only Admin (hidden unless role is `admin`). Mobile shows a subset.
 
 ---
 # Config

--- a/command/README.md
+++ b/command/README.md
@@ -1,30 +1,61 @@
 # Command <img src="frontend/res/logo.png" alt="logo" width="20"/> 
 
-The command server is face of the operation. It runs the web-app and the authentication of the other endpoints. 
+The command server is the face of the operation. It serves the web app and handles authentication, RBAC, and session management for the whole system.
 
 ---
 # Routes
 ## ▶ /authorization
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|POST|/login|Auth Routes|N/A|N/A|
-|POST|/verify|Auth Routes|N/A|N/A|
-|POST|/setup|Bootstrap or recover admin (requires `setup_TOKEN`)|N/A|N/A|
-## ▶ /
+`auth` = valid session required (`authorize`). `admin` = valid session **and** admin role (`authorize` + `requireAdmin`). `none` = public.
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/res|res|N/A|N/A|
-|GET|/|Serves main website|None|html|
-|GET|/live|Serves main website|None|html|
-|GET|/process|Serves main website|None|html|
-|GET|/scrub|Serves main website|None|html|
-|GET|/stats|Serves main website|None|html|
-|GET|/login|Serves the login page|None|html|
+|Type|Route|Auth|Description|Body|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|GET|/status|none|Whether setup has been completed and if a setup token is required|—|`{setup, tokenRequired}`|
+|POST|/setup|token*|Bootstrap the first admin, or recover the admin account (rate-limited)|`{username, password, token?}`|`{error}`|
+|POST|/login|none|Authenticate and set the `bearertoken` cookie (rate-limited)|`{username, password}`|`{error, ...}` + cookie|
+|POST|/verify|auth|Validate the current session|—|`{role, theme, forcePasswordChange}`|
+|PUT|/theme|auth|Save the user's theme preference (`light`/`dark`/`system`)|`{theme}`|`{error}`|
+|GET|/users|admin|List all users|—|`[{username, role, last_login}]`|
+|POST|/users|admin|Create a user with a temporary password|`{username, role}`|`{tempPassword}`|
+|PATCH|/users/:username|admin|Update a user's role and/or password (can't demote the last admin)|`{role?, password?}`|`{error}`|
+|DELETE|/users/:username|admin|Delete a user (not yourself, not the last admin)|—|`{error}`|
+|GET|/users/:username/sessions|admin|List a user's sessions|—|`[{id, issued_at, last_seen, ip, user_agent, revoked}]`|
+|DELETE|/sessions/:id|admin|Revoke a session|—|`{error}`|
+|POST|/password|auth|Change your own password|`{password}`|`{error}`|
+|POST|/logout|auth|Revoke the current session and clear the cookie|—|`{error}`|
+
+\* `/setup` is public but rate-limited. When `setup_TOKEN` is configured it must be supplied, and the call can bootstrap the first admin (when none exists) or reset an existing admin account (recovery). When `setup_TOKEN` is not configured it only bootstraps the very first admin — i.e. it succeeds only while the `auth` table is empty.
+
+## ▶ /cameras
+
+Mounted behind `authorize`, so a valid session is required.
+
+|Type|Route|Auth|Description|Body|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|GET|/|auth|List configured cameras (RTSP credentials stripped)|—|`[{id, name, rtsp_url}]`|
 
 ## ▶ /command
 
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
 |GET|/health|Confirms server alive|N/A|N/A|
+
+---
+# Web app
+
+The backend serves the compiled single-page app (`dist/`, built from `frontend/`) as static files at `/`, `/login`, and every app path (`/clip`, `/live`, `/recordings`, `/stats`, `/schedule`, `/admin`, `/objects`); `/res` serves static assets such as the logo. All rendering and navigation happen client-side in React (`frontend/App.jsx`), which matches the app sections via a dynamic `/:route` segment alongside dedicated `/` and `/login` routes; unauthenticated visitors are redirected to `/login`.
+
+The app is organized into sections defined in `frontend/app/SideMenu.jsx` and mapped to paths by `frontend/js/routeIndexMapping.js`:
+
+|Section|Path|Notes|
+| :-|:- |:- |
+|Home|/||
+|Live|/live||
+|Clip Maker|/clip||
+|Recordings|/recordings||
+|Stats|/stats||
+|Schedule|/schedule||
+|Objects|/objects||
+|Admin|/admin|Admin only — hidden unless the session role is `admin` (RBAC-gated)|
+
+Mobile navigation surfaces a subset of these (Clip, Live, Home, Recordings, Stats); the full set is available on desktop.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -33,13 +33,7 @@ Reverse proxy and single public entrypoint; matches each request by method + pat
 ---
 # ACME challenges
 
-Before any proxying, the gateway statically serves `/.well-known/` from the repo-root `.well-known/` directory (dotfiles allowed), so HTTP-01 challenges are answered directly and exempt from the HTTPS redirect. `entrypoint.sh` creates `./.well-known/acme-challenge` on boot.
-
-## ▶ /.well-known
-
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/acme-challenge/:token|Serves the ACME HTTP-01 challenge file|`token` (file name)|Challenge file contents|
+Before any proxying, the gateway statically serves `/.well-known/` from the repo-root `.well-known/` directory (dotfiles allowed), so HTTP-01 challenge files (`/.well-known/acme-challenge/<token>`) are answered directly and exempt from the HTTPS redirect. `entrypoint.sh` creates `./.well-known/acme-challenge` on boot.
 
 ---
 # Runtime

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,17 +1,59 @@
 # Gateway <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The gateway is an API gateway for all servers that need to be exposed by one domain.
+The gateway is the single public entrypoint for the system: a reverse proxy that forwards each incoming request to the microservice that owns its path. "Proxied" means a request hitting the gateway's domain is matched by method + path and transparently forwarded to that service's `<prefix>_HOST`, so the whole system is reachable through one domain.
 
-[services.js](services.js) has all of the API details necessary for the gateway.
+---
+# Proxied services
 
+[services.js](services.js) is the routing table. Each entry is proxied only when its `<prefix>_PROXY_ON` flag is `true`, and matching requests are forwarded to that service's `<prefix>_HOST`.
+
+|Service|Enable flag|Target|Methods proxied|
+| :-|:- |:- |:- |
+|[storage](../storage)|`storage_PROXY_ON`|`storage_HOST`|GET, POST, DELETE|
+|[schedule](../schedule)|`schedule_PROXY_ON`|`schedule_HOST`|GET, POST|
+|[livestream](../livestream)|`livestream_PROXY_ON`|`livestream_HOST`|GET, POST|
+|[object](../object)|`object_PROXY_ON`|`object_HOST`|GET, POST|
+|[command](../command)|`command_PROXY_ON`|`command_HOST`|GET, POST, PUT, PATCH, DELETE|
+
+Each entry declares a per-method path regex; `postPathRegex` and `getPathRegex` are required, and `deletePathRegex` / `putPathRegex` / `patchPathRegex` are optional. A request is proxied only when both its method **and** its path match the corresponding (start-anchored) regex — anything unmatched is not forwarded.
+
+```js
+module.exports = [..., {
+	serviceOn: process.env.storage_PROXY_ON === "true",  // proxy this entry only when its <prefix>_PROXY_ON is "true"
+	log: "📂 Storage Proxied ◀",                          // printed on boot when the service is proxied
+	baseURL: process.env.storage_HOST,                   // <prefix>_HOST the matching requests are forwarded to
+	postPathRegex: /\/convert\/.../,                      // POST paths to proxy (required)
+	getPathRegex: /\/shared\/.../,                        // GET paths to proxy (required)
+	deletePathRegex: /\/camera\/\d+/                      // DELETE paths (optional; putPathRegex/patchPathRegex also supported)
+}, ...]
 ```
-module.exports = [...,
-    {
-        serviceOn: true //a boolean for whether a service is meant to be proxied,
-        log: "I'm proxied!" //a string to print when said service is proxied,
-        baseURL: https://microservice.bruh //base URL domain for the service,
-        postPathRegex: /\/.*/ //a regex of which POST routes to proxy,
-        getPathRegex: /\/.*/ //a regex of which GET routes to proxy 
-    }
-...]
-```
+
+Proxied requests are forwarded with `X-Forwarded-*` headers (`xfwd`) so downstream services see the original client; the gateway itself performs no auth — each service enforces its own after the proxy hop.
+
+---
+# Ports & TLS
+
+When `gateway_ON=true`, the gateway's [server.js](server.js) runs the same Express app on two listeners:
+
+- `gateway_PORT` — HTTP, via [lib](../lib) `handleServerStart`.
+- `gateway_PORT_SECURE` — HTTPS, via [lib](../lib) `handleSecureServerStart`, reading the TLS key/cert from `privateKey_FILEPATH` and `certificate_FILEPATH`. This is the public HTTPS port; if either file is missing or unreadable the secure listener stays down and logs `🗺️🔒 Secure Gateway Off ❌`.
+
+When `gateway_HTTPS_Redirect=true`, any request that is not already secure (and is not a `/.well-known/` request) is redirected to `https://<host><url>`.
+
+---
+# ACME challenges
+
+Before any proxying, the gateway statically serves `/.well-known/` from the repo-root `.well-known/` directory (dotfiles allowed), so HTTP-01 ACME challenges are answered directly and are exempt from the HTTPS redirect. `entrypoint.sh` creates `./.well-known/acme-challenge` on boot.
+
+## ▶ /.well-known
+
+|Type|Route|Description|Parameters|Returns|
+| :-|:- |:-:|:-:|:-:|
+|GET|/acme-challenge/:token|Serves the ACME HTTP-01 challenge file from `.well-known/acme-challenge/`|`token` (file name)|Challenge file contents|
+
+---
+# How it fits
+
+- The root [server.js](../server.js) calls `gateway.start()` last (after `command`, `storage`, `livestream`, `schedule`, `object`, and the `memory` socket); that call is unconditional, and the `gateway_ON` check lives inside the gateway's [server.js](server.js), which decides whether to actually listen. It runs in the same Node process under pm2.
+- `helmet` security headers ([lib](../lib) `helmetOptions`) are applied to every response except statically-served `/.well-known/` files, since helmet is registered after that static middleware.
+- Config keys live in [../env.example](../env.example) under the Gateway section: the `<prefix>_PROXY_ON` toggles, the per-service `<prefix>_HOST` targets, `gateway_ON`, `gateway_PORT`, `gateway_PORT_SECURE`, `privateKey_FILEPATH`, `certificate_FILEPATH`, and `gateway_HTTPS_Redirect`.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,11 +1,11 @@
 # Gateway <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The gateway is the single public entrypoint for the system: a reverse proxy that forwards each incoming request to the microservice that owns its path. "Proxied" means a request hitting the gateway's domain is matched by method + path and transparently forwarded to that service's `<prefix>_HOST`, so the whole system is reachable through one domain.
+Reverse proxy and single public entrypoint; matches each request by method + path (`services.js`) and forwards it to that service's `<prefix>_HOST`.
 
 ---
 # Proxied services
 
-[services.js](services.js) is the routing table. Each entry is proxied only when its `<prefix>_PROXY_ON` flag is `true`, and matching requests are forwarded to that service's `<prefix>_HOST`.
+[services.js](services.js) is the routing table. An entry is proxied only when its `<prefix>_PROXY_ON` is `true`.
 
 |Service|Enable flag|Target|Methods proxied|
 | :-|:- |:- |:- |
@@ -15,45 +15,39 @@ The gateway is the single public entrypoint for the system: a reverse proxy that
 |[object](../object)|`object_PROXY_ON`|`object_HOST`|GET, POST|
 |[command](../command)|`command_PROXY_ON`|`command_HOST`|GET, POST, PUT, PATCH, DELETE|
 
-Each entry declares a per-method path regex; `postPathRegex` and `getPathRegex` are required, and `deletePathRegex` / `putPathRegex` / `patchPathRegex` are optional. A request is proxied only when both its method **and** its path match the corresponding (start-anchored) regex — anything unmatched is not forwarded.
-
-```js
-module.exports = [..., {
-	serviceOn: process.env.storage_PROXY_ON === "true",  // proxy this entry only when its <prefix>_PROXY_ON is "true"
-	log: "📂 Storage Proxied ◀",                          // printed on boot when the service is proxied
-	baseURL: process.env.storage_HOST,                   // <prefix>_HOST the matching requests are forwarded to
-	postPathRegex: /\/convert\/.../,                      // POST paths to proxy (required)
-	getPathRegex: /\/shared\/.../,                        // GET paths to proxy (required)
-	deletePathRegex: /\/camera\/\d+/                      // DELETE paths (optional; putPathRegex/patchPathRegex also supported)
-}, ...]
-```
-
-Proxied requests are forwarded with `X-Forwarded-*` headers (`xfwd`) so downstream services see the original client; the gateway itself performs no auth — each service enforces its own after the proxy hop.
+- Each entry declares per-method, start-anchored path regexes. `postPathRegex` and `getPathRegex` required; `deletePathRegex`/`putPathRegex`/`patchPathRegex` optional.
+- A request is proxied only when both its method and path match; unmatched requests are not forwarded.
+- Forwarded with `X-Forwarded-*` headers (`xfwd`) so downstream sees the original client.
+- The gateway does no auth; each service enforces its own after the proxy hop.
 
 ---
 # Ports & TLS
 
-When `gateway_ON=true`, the gateway's [server.js](server.js) runs the same Express app on two listeners:
+`gateway_ON=true` runs [server.js](server.js)'s Express app on two listeners:
 
 - `gateway_PORT` — HTTP, via [lib](../lib) `handleServerStart`.
-- `gateway_PORT_SECURE` — HTTPS, via [lib](../lib) `handleSecureServerStart`, reading the TLS key/cert from `privateKey_FILEPATH` and `certificate_FILEPATH`. This is the public HTTPS port; if either file is missing or unreadable the secure listener stays down and logs `🗺️🔒 Secure Gateway Off ❌`.
+- `gateway_PORT_SECURE` — public HTTPS, via [lib](../lib) `handleSecureServerStart`, reading the TLS key/cert from `privateKey_FILEPATH` and `certificate_FILEPATH`. If either file is missing or unreadable the secure listener stays down and logs `🗺️🔒 Secure Gateway Off ❌`.
 
-When `gateway_HTTPS_Redirect=true`, any request that is not already secure (and is not a `/.well-known/` request) is redirected to `https://<host><url>`.
+`gateway_HTTPS_Redirect=true` redirects any non-secure request (except `/.well-known/`) to `https://<host><url>`.
 
 ---
 # ACME challenges
 
-Before any proxying, the gateway statically serves `/.well-known/` from the repo-root `.well-known/` directory (dotfiles allowed), so HTTP-01 ACME challenges are answered directly and are exempt from the HTTPS redirect. `entrypoint.sh` creates `./.well-known/acme-challenge` on boot.
+Before any proxying, the gateway statically serves `/.well-known/` from the repo-root `.well-known/` directory (dotfiles allowed), so HTTP-01 challenges are answered directly and exempt from the HTTPS redirect. `entrypoint.sh` creates `./.well-known/acme-challenge` on boot.
 
 ## ▶ /.well-known
 
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|GET|/acme-challenge/:token|Serves the ACME HTTP-01 challenge file from `.well-known/acme-challenge/`|`token` (file name)|Challenge file contents|
+|GET|/acme-challenge/:token|Serves the ACME HTTP-01 challenge file|`token` (file name)|Challenge file contents|
 
 ---
-# How it fits
+# Runtime
 
-- The root [server.js](../server.js) calls `gateway.start()` last (after `command`, `storage`, `livestream`, `schedule`, `object`, and the `memory` socket); that call is unconditional, and the `gateway_ON` check lives inside the gateway's [server.js](server.js), which decides whether to actually listen. It runs in the same Node process under pm2.
-- `helmet` security headers ([lib](../lib) `helmetOptions`) are applied to every response except statically-served `/.well-known/` files, since helmet is registered after that static middleware.
-- Config keys live in [../env.example](../env.example) under the Gateway section: the `<prefix>_PROXY_ON` toggles, the per-service `<prefix>_HOST` targets, `gateway_ON`, `gateway_PORT`, `gateway_PORT_SECURE`, `privateKey_FILEPATH`, `certificate_FILEPATH`, and `gateway_HTTPS_Redirect`.
+- Root [server.js](../server.js) calls `gateway.start()` last (after `command`, `storage`, `livestream`, `schedule`, `object`, and the `memory` socket), unconditionally; the `gateway_ON` check inside the gateway's [server.js](server.js) decides whether to listen. Same Node process under pm2.
+- `helmet` headers ([lib](../lib) `helmetOptions`) apply to every response except statically-served `/.well-known/` files (helmet is registered after that static middleware).
+
+---
+# Config
+
+- `<prefix>_PROXY_ON`, `<prefix>_HOST`, `gateway_ON`, `gateway_PORT`, `gateway_PORT_SECURE`, `privateKey_FILEPATH`, `certificate_FILEPATH`, `gateway_HTTPS_Redirect`; see [../env.example](../env.example) (Gateway section).

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,47 +1,35 @@
 # Gateway <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-Reverse proxy and single public entrypoint; matches each request by method + path (`services.js`) and forwards it to that service's `<prefix>_HOST`.
+Reverse proxy and single public entrypoint; matches each request by method + path ([services.js](services.js)) and forwards it to that service's `<prefix>_HOST`.
 
 ---
 # Proxied services
 
-[services.js](services.js) is the routing table. An entry is proxied only when its `<prefix>_PROXY_ON` is `true`.
+Proxied only when `<prefix>_PROXY_ON=true`, and only when both method and path match its start-anchored regexes ([services.js](services.js)):
 
-|Service|Enable flag|Target|Methods proxied|
-| :-|:- |:- |:- |
-|[storage](../storage)|`storage_PROXY_ON`|`storage_HOST`|GET, POST, DELETE|
-|[schedule](../schedule)|`schedule_PROXY_ON`|`schedule_HOST`|GET, POST|
-|[livestream](../livestream)|`livestream_PROXY_ON`|`livestream_HOST`|GET, POST|
-|[object](../object)|`object_PROXY_ON`|`object_HOST`|GET, POST|
-|[command](../command)|`command_PROXY_ON`|`command_HOST`|GET, POST, PUT, PATCH, DELETE|
+- [storage](../storage) — GET, POST, DELETE
+- [schedule](../schedule) — GET, POST
+- [livestream](../livestream) — GET, POST
+- [object](../object) — GET, POST
+- [command](../command) — GET, POST, PUT, PATCH, DELETE
 
-- Each entry declares per-method, start-anchored path regexes. `postPathRegex` and `getPathRegex` required; `deletePathRegex`/`putPathRegex`/`patchPathRegex` optional.
-- A request is proxied only when both its method and path match; unmatched requests are not forwarded.
-- Forwarded with `X-Forwarded-*` headers (`xfwd`) so downstream sees the original client.
-- The gateway does no auth; each service enforces its own after the proxy hop.
+Forwarded with `X-Forwarded-*` (`xfwd`). The gateway does no auth — each service enforces its own after the proxy hop.
 
 ---
 # Ports & TLS
 
-`gateway_ON=true` runs [server.js](server.js)'s Express app on two listeners:
+`gateway_ON=true` runs two listeners:
+- `gateway_PORT` — HTTP.
+- `gateway_PORT_SECURE` — HTTPS, key/cert from `privateKey_FILEPATH` / `certificate_FILEPATH`; if either is unreadable the secure listener stays down.
 
-- `gateway_PORT` — HTTP, via [lib](../lib) `handleServerStart`.
-- `gateway_PORT_SECURE` — public HTTPS, via [lib](../lib) `handleSecureServerStart`, reading the TLS key/cert from `privateKey_FILEPATH` and `certificate_FILEPATH`. If either file is missing or unreadable the secure listener stays down and logs `🗺️🔒 Secure Gateway Off ❌`.
-
-`gateway_HTTPS_Redirect=true` redirects any non-secure request (except `/.well-known/`) to `https://<host><url>`.
+`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS.
 
 ---
 # ACME challenges
 
-Before any proxying, the gateway statically serves `/.well-known/` from the repo-root `.well-known/` directory (dotfiles allowed), so HTTP-01 challenge files (`/.well-known/acme-challenge/<token>`) are answered directly and exempt from the HTTPS redirect. `entrypoint.sh` creates `./.well-known/acme-challenge` on boot.
-
----
-# Runtime
-
-- Root [server.js](../server.js) calls `gateway.start()` last (after `command`, `storage`, `livestream`, `schedule`, `object`, and the `memory` socket), unconditionally; the `gateway_ON` check inside the gateway's [server.js](server.js) decides whether to listen. Same Node process under pm2.
-- `helmet` headers ([lib](../lib) `helmetOptions`) apply to every response except statically-served `/.well-known/` files (helmet is registered after that static middleware).
+Before proxying, serves `/.well-known/` from the repo-root dir (dotfiles allowed) so HTTP-01 challenge files are answered directly and skip the HTTPS redirect. `entrypoint.sh` creates the dir on boot. `helmet` ([lib](../lib) `helmetOptions`) applies to every response except these static files.
 
 ---
 # Config
 
-- `<prefix>_PROXY_ON`, `<prefix>_HOST`, `gateway_ON`, `gateway_PORT`, `gateway_PORT_SECURE`, `privateKey_FILEPATH`, `certificate_FILEPATH`, `gateway_HTTPS_Redirect`; see [../env.example](../env.example) (Gateway section).
+`<prefix>_PROXY_ON`, `<prefix>_HOST`, `gateway_ON`, `gateway_PORT`, `gateway_PORT_SECURE`, `privateKey_FILEPATH`, `certificate_FILEPATH`, `gateway_HTTPS_Redirect`; see [../env.example](../env.example).

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,68 +1,68 @@
 # Lib <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The lib is the library 📖 of shared tools that every service uses. It is not a server — it exposes no HTTP routes. Each service pulls it in as a local `file:../lib` dependency and `require("lib")` returns the exports below. Importing it loads `.env` via `dotenv`, so config is available to all consumers.
+Shared helpers every service imports as a `file:../lib` dependency; `require("lib")` returns the exports below and loads `.env` via `dotenv`. Not a server (no HTTP routes).
 
-The CommonJS entry (`index.js`) exports everything listed here. The `module` entry (`module.js`) is an ESM shim that re-exports only `formatBytes`.
+`index.js` (CommonJS) exports everything below; `module.js` (ESM) re-exports only `formatBytes`.
 
 ---
 # Exports
 
-## ▶ Auth & HTTP middleware
+## Auth & HTTP middleware
 
 |Export|Description|
 | :-|:- |
-|`auth`|`createAuthorize(pool)` builds middleware that requires a valid session — it verifies the `bearertoken` JWT cookie with `SECRETKEY` and, when a `pool` is passed, checks the `auth`/`sessions` tables (role, revoked, force-password-change). `requireAdmin` gates admin-only routes. `schedulableUrls` is the allow-list the [schedule](../schedule) service may call by sending the standard `authorization` header equal to the `scheduler_AUTH` env var.|
-|`validateBody`|Middleware that rejects requests with an empty body (`400 {error, msg:"no body"}`).|
-|`tracker`|Middleware that fires an admin `webhookAlert` per request (method, path, IP, user-agent), skipping `/feed`, `/shared`, `/res`.|
-|`tempMiddleware`|Placeholder responders `deprecation` and `construction` that reply with a stub error message.|
-|`helmetOptions`|Content-Security-Policy directives passed to `helmet` (allows `tfjs-models`, inline/eval scripts, blob media).|
+|`auth`|`createAuthorize(pool)` builds session-requiring middleware: verifies the `bearertoken` JWT cookie with `SECRETKEY`; with a `pool`, also checks the `auth`/`sessions` tables (role, revoked, force-password-change). `requireAdmin` gates admin-only routes. `schedulableUrls` is the allow-list the [schedule](../schedule) service may call by sending the `authorization` header equal to `scheduler_AUTH`.|
+|`validateBody`|Rejects requests with an empty body (`400 {error, msg:"no body"}`).|
+|`tracker`|Fires an admin `webhookAlert` per request (method, path, IP, user-agent); skips `/feed`, `/shared`, `/res`.|
+|`tempMiddleware`|Stub responders `deprecation` and `construction` that reply with a stub error.|
+|`helmetOptions`|CSP directives passed to `helmet` (allows `tfjs-models`, inline/eval scripts, blob media).|
 
-## ▶ Server bootstrap
+## Server bootstrap
 
 |Export|Description|
 | :-|:- |
 |`handleServerStart`|Starts an HTTP server via `app.listen(port, …)` with success/failure callbacks and a `SIGINT` close handler; returns the server.|
-|`handleSecureServerStart`|Starts an HTTPS server, reading the key/cert from `privateKey_FILEPATH` / `certificate_FILEPATH`; calls the failure callback if either file is unreadable.|
+|`handleSecureServerStart`|Starts an HTTPS server, reading key/cert from `privateKey_FILEPATH`/`certificate_FILEPATH`; calls the failure callback if either file is unreadable.|
 
-## ▶ Alerts & time
-
-|Export|Description|
-| :-|:- |
-|`webhookAlert`|POSTs `content` to `alert_URL` (default) or `admin_alert_URL` (level `"admin"`); reports success/failure through an optional callback.|
-|`alertTime`|`moment-timezone` helper — returns now, or parses a UTC input and converts it into the `alert_TZ` zone (defaults to UTC).|
-
-## ▶ Cameras & object detection
+## Alerts & time
 
 |Export|Description|
 | :-|:- |
-|`loadCameras`|Reads the motion conf at `storage_MOTION_CONF_FILEPATH`, resolves its `camera_dir` (relative to the conf's own location unless absolute), parses each `*.conf` in that directory, and returns the camera list (`{id, name, rtsp_url, full_url}`) sorted by id; results are cached for 10s. RTSP credentials are URL-encoded into `full_url`.|
-|`objectState`|In-process (per-instance) singleton registry for the object-detection provider: `register`, `getConfig`, `getStatus`, `setConfig`, `scan` (each delegates to the registered provider, or a no-op default).|
+|`webhookAlert`|POSTs `content` to `alert_URL` (default) or `admin_alert_URL` (level `"admin"`); reports success/failure via an optional callback.|
+|`alertTime`|`moment-timezone` helper: returns now, or parses a UTC input into the `alert_TZ` zone (default UTC).|
 
-## ▶ Formatting, IDs & rules
+## Cameras & object detection
+
+|Export|Description|
+| :-|:- |
+|`loadCameras`|Reads the motion conf at `storage_MOTION_CONF_FILEPATH`, resolves its `camera_dir` (relative to the conf unless absolute), parses each `*.conf` there, and returns cameras (`{id, name, rtsp_url, full_url}`) sorted by id; cached 10s. RTSP credentials are URL-encoded into `full_url`.|
+|`objectState`|Per-instance singleton registry for the object-detection provider: `register`, `getConfig`, `getStatus`, `setConfig`, `scan` (each delegates to the registered provider, or a no-op default).|
+
+## Formatting, IDs & rules
 
 |Export|Description|
 | :-|:- |
 |`formatBytes`|Formats a byte count as a human-readable string (e.g. `1.5 GB`).|
 |`randomID`|`generate(size=13)` returns a `nanoid` from an alphanumeric + `()` alphabet.|
-|`password`|Password-policy JSON: `{minLength: 8, requirement}` — the shared rule for password validation and UI messaging.|
+|`password`|Password-policy JSON `{minLength: 8, requirement}`; shared rule for validation and UI messaging.|
 
-## ▶ Files & processes
-
-|Export|Description|
-| :-|:- |
-|`jsonFileHanding`|JSON file helpers `readJSON`, `writeJSON`, `isStringJSON` (note: the export key is spelled `jsonFileHanding`).|
-|`subprocess`|pm2 helpers: `processListMiddleware` and `checkProcess` (query pm2 for a named process) and `restart` (restart it).|
-
-## ▶ Database & runtime
+## Files & processes
 
 |Export|Description|
 | :-|:- |
-|`pruneInterval`|`(pool, sql)` runs the given SQL on a 12-hour `setInterval` (unref'd) — used for periodic table pruning (e.g. `frame_deletes`, `task_runs`).|
-|`isPrimeInstance`|Boolean, true when running as pm2 instance `0` or outside a cluster; used to gate work that must run on only one instance.|
+|`jsonFileHanding`|JSON helpers `readJSON`, `writeJSON`, `isStringJSON` (export key spelled `jsonFileHanding`).|
+|`subprocess`|pm2 helpers: `processListMiddleware`, `checkProcess` (query pm2 for a named process), and `restart`.|
+
+## Database & runtime
+
+|Export|Description|
+| :-|:- |
+|`pruneInterval`|`(pool, sql)` runs `sql` on a 12-hour `setInterval` (unref'd) for periodic table pruning (e.g. `frame_deletes`, `task_runs`).|
+|`isPrimeInstance`|Boolean; true on pm2 instance `0` or outside a cluster; gates work that must run on one instance only.|
 
 ---
-# How it fits
+# Consumers & config
 
-- Consumed by [command](../command), [storage](../storage), [livestream](../livestream), [schedule](../schedule), [object](../object), [memory](../memory), and [gateway](../gateway) as a `file:../lib` dependency.
-- Reads config from the environment; see [../env.example](../env.example) for the keys these helpers use — `SECRETKEY` and `scheduler_AUTH` (auth), `alert_URL` / `admin_alert_URL` / `alert_TZ` (alerts), `privateKey_FILEPATH` / `certificate_FILEPATH` (TLS bootstrap), and `storage_MOTION_CONF_FILEPATH` (cameras).
-- The `auth` middleware reads the command service's `auth` and `sessions` Postgres tables; `pruneInterval` is pointed at whichever table a service maintains.
+- Imported by [command](../command), [storage](../storage), [livestream](../livestream), [schedule](../schedule), [object](../object), [memory](../memory), [gateway](../gateway).
+- Config from env; see [../env.example](../env.example): `SECRETKEY`, `scheduler_AUTH` (auth); `alert_URL`/`admin_alert_URL`/`alert_TZ` (alerts); `privateKey_FILEPATH`/`certificate_FILEPATH` (TLS); `storage_MOTION_CONF_FILEPATH` (cameras).
+- `auth` reads command's `auth`/`sessions` Postgres tables; `pruneInterval` targets whichever table a service maintains.

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,3 +1,68 @@
 # Lib <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The lib is the library 📖 of tools that other servers use.
+The lib is the library 📖 of shared tools that every service uses. It is not a server — it exposes no HTTP routes. Each service pulls it in as a local `file:../lib` dependency and `require("lib")` returns the exports below. Importing it loads `.env` via `dotenv`, so config is available to all consumers.
+
+The CommonJS entry (`index.js`) exports everything listed here. The `module` entry (`module.js`) is an ESM shim that re-exports only `formatBytes`.
+
+---
+# Exports
+
+## ▶ Auth & HTTP middleware
+
+|Export|Description|
+| :-|:- |
+|`auth`|`createAuthorize(pool)` builds middleware that requires a valid session — it verifies the `bearertoken` JWT cookie with `SECRETKEY` and, when a `pool` is passed, checks the `auth`/`sessions` tables (role, revoked, force-password-change). `requireAdmin` gates admin-only routes. `schedulableUrls` is the allow-list the [schedule](../schedule) service may call by sending the standard `authorization` header equal to the `scheduler_AUTH` env var.|
+|`validateBody`|Middleware that rejects requests with an empty body (`400 {error, msg:"no body"}`).|
+|`tracker`|Middleware that fires an admin `webhookAlert` per request (method, path, IP, user-agent), skipping `/feed`, `/shared`, `/res`.|
+|`tempMiddleware`|Placeholder responders `deprecation` and `construction` that reply with a stub error message.|
+|`helmetOptions`|Content-Security-Policy directives passed to `helmet` (allows `tfjs-models`, inline/eval scripts, blob media).|
+
+## ▶ Server bootstrap
+
+|Export|Description|
+| :-|:- |
+|`handleServerStart`|Starts an HTTP server via `app.listen(port, …)` with success/failure callbacks and a `SIGINT` close handler; returns the server.|
+|`handleSecureServerStart`|Starts an HTTPS server, reading the key/cert from `privateKey_FILEPATH` / `certificate_FILEPATH`; calls the failure callback if either file is unreadable.|
+
+## ▶ Alerts & time
+
+|Export|Description|
+| :-|:- |
+|`webhookAlert`|POSTs `content` to `alert_URL` (default) or `admin_alert_URL` (level `"admin"`); reports success/failure through an optional callback.|
+|`alertTime`|`moment-timezone` helper — returns now, or parses a UTC input and converts it into the `alert_TZ` zone (defaults to UTC).|
+
+## ▶ Cameras & object detection
+
+|Export|Description|
+| :-|:- |
+|`loadCameras`|Reads the motion conf at `storage_MOTION_CONF_FILEPATH`, resolves its `camera_dir` (relative to the conf's own location unless absolute), parses each `*.conf` in that directory, and returns the camera list (`{id, name, rtsp_url, full_url}`) sorted by id; results are cached for 10s. RTSP credentials are URL-encoded into `full_url`.|
+|`objectState`|In-process (per-instance) singleton registry for the object-detection provider: `register`, `getConfig`, `getStatus`, `setConfig`, `scan` (each delegates to the registered provider, or a no-op default).|
+
+## ▶ Formatting, IDs & rules
+
+|Export|Description|
+| :-|:- |
+|`formatBytes`|Formats a byte count as a human-readable string (e.g. `1.5 GB`).|
+|`randomID`|`generate(size=13)` returns a `nanoid` from an alphanumeric + `()` alphabet.|
+|`password`|Password-policy JSON: `{minLength: 8, requirement}` — the shared rule for password validation and UI messaging.|
+
+## ▶ Files & processes
+
+|Export|Description|
+| :-|:- |
+|`jsonFileHanding`|JSON file helpers `readJSON`, `writeJSON`, `isStringJSON` (note: the export key is spelled `jsonFileHanding`).|
+|`subprocess`|pm2 helpers: `processListMiddleware` and `checkProcess` (query pm2 for a named process) and `restart` (restart it).|
+
+## ▶ Database & runtime
+
+|Export|Description|
+| :-|:- |
+|`pruneInterval`|`(pool, sql)` runs the given SQL on a 12-hour `setInterval` (unref'd) — used for periodic table pruning (e.g. `frame_deletes`, `task_runs`).|
+|`isPrimeInstance`|Boolean, true when running as pm2 instance `0` or outside a cluster; used to gate work that must run on only one instance.|
+
+---
+# How it fits
+
+- Consumed by [command](../command), [storage](../storage), [livestream](../livestream), [schedule](../schedule), [object](../object), [memory](../memory), and [gateway](../gateway) as a `file:../lib` dependency.
+- Reads config from the environment; see [../env.example](../env.example) for the keys these helpers use — `SECRETKEY` and `scheduler_AUTH` (auth), `alert_URL` / `admin_alert_URL` / `alert_TZ` (alerts), `privateKey_FILEPATH` / `certificate_FILEPATH` (TLS bootstrap), and `storage_MOTION_CONF_FILEPATH` (cameras).
+- The `auth` middleware reads the command service's `auth` and `sessions` Postgres tables; `pruneInterval` is pointed at whichever table a service maintains.

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,68 +1,39 @@
 # Lib <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-Shared helpers every service imports as a `file:../lib` dependency; `require("lib")` returns the exports below and loads `.env` via `dotenv`. Not a server (no HTTP routes).
+Shared helpers every service imports (`require("lib")`, a `file:../lib` dep); loads `.env`. Not a server.
 
-`index.js` (CommonJS) exports everything below; `module.js` (ESM) re-exports only `formatBytes`.
+`index.js` exports all of these (CommonJS); `module.js` re-exports only `formatBytes` (ESM).
 
 ---
 # Exports
 
-## Auth & HTTP middleware
+**Middleware**
+- `auth` — session/JWT-cookie guard + `requireAdmin` RBAC; scheduler bypass via `scheduler_AUTH` on `schedulableUrls`.
+- `validateBody` — rejects empty bodies (`400`).
+- `tracker` — admin webhook alert per request.
+- `tempMiddleware` — `deprecation` / `construction` stubs.
+- `helmetOptions` — CSP for `helmet`.
 
-|Export|Description|
-| :-|:- |
-|`auth`|`createAuthorize(pool)` builds session-requiring middleware: verifies the `bearertoken` JWT cookie with `SECRETKEY`; with a `pool`, also checks the `auth`/`sessions` tables (role, revoked, force-password-change). `requireAdmin` gates admin-only routes. `schedulableUrls` is the allow-list the [schedule](../schedule) service may call by sending the `authorization` header equal to `scheduler_AUTH`.|
-|`validateBody`|Rejects requests with an empty body (`400 {error, msg:"no body"}`).|
-|`tracker`|Fires an admin `webhookAlert` per request (method, path, IP, user-agent); skips `/feed`, `/shared`, `/res`.|
-|`tempMiddleware`|Stub responders `deprecation` and `construction` that reply with a stub error.|
-|`helmetOptions`|CSP directives passed to `helmet` (allows `tfjs-models`, inline/eval scripts, blob media).|
+**Server & runtime**
+- `handleServerStart` / `handleSecureServerStart` — start HTTP / HTTPS (TLS from `*_FILEPATH`) listeners.
+- `pruneInterval` — run a SQL prune on a 12h timer.
+- `isPrimeInstance` — true on the single/prime pm2 instance.
+- `subprocess` — pm2 helpers (`checkProcess`, `restart`, …).
 
-## Server bootstrap
+**Cameras & alerts**
+- `loadCameras` — motion + camera confs → `{id, name, rtsp_url, full_url}`, cached 10s.
+- `objectState` — provider registry the object detector plugs into.
+- `webhookAlert` — POST to the alert webhook (`alert_URL` / `admin_alert_URL`).
+- `alertTime` — `moment-timezone` helper in `alert_TZ`.
 
-|Export|Description|
-| :-|:- |
-|`handleServerStart`|Starts an HTTP server via `app.listen(port, …)` with success/failure callbacks and a `SIGINT` close handler; returns the server.|
-|`handleSecureServerStart`|Starts an HTTPS server, reading key/cert from `privateKey_FILEPATH`/`certificate_FILEPATH`; calls the failure callback if either file is unreadable.|
-
-## Alerts & time
-
-|Export|Description|
-| :-|:- |
-|`webhookAlert`|POSTs `content` to `alert_URL` (default) or `admin_alert_URL` (level `"admin"`); reports success/failure via an optional callback.|
-|`alertTime`|`moment-timezone` helper: returns now, or parses a UTC input into the `alert_TZ` zone (default UTC).|
-
-## Cameras & object detection
-
-|Export|Description|
-| :-|:- |
-|`loadCameras`|Reads the motion conf at `storage_MOTION_CONF_FILEPATH`, resolves its `camera_dir` (relative to the conf unless absolute), parses each `*.conf` there, and returns cameras (`{id, name, rtsp_url, full_url}`) sorted by id; cached 10s. RTSP credentials are URL-encoded into `full_url`.|
-|`objectState`|Per-instance singleton registry for the object-detection provider: `register`, `getConfig`, `getStatus`, `setConfig`, `scan` (each delegates to the registered provider, or a no-op default).|
-
-## Formatting, IDs & rules
-
-|Export|Description|
-| :-|:- |
-|`formatBytes`|Formats a byte count as a human-readable string (e.g. `1.5 GB`).|
-|`randomID`|`generate(size=13)` returns a `nanoid` from an alphanumeric + `()` alphabet.|
-|`password`|Password-policy JSON `{minLength: 8, requirement}`; shared rule for validation and UI messaging.|
-
-## Files & processes
-
-|Export|Description|
-| :-|:- |
-|`jsonFileHanding`|JSON helpers `readJSON`, `writeJSON`, `isStringJSON` (export key spelled `jsonFileHanding`).|
-|`subprocess`|pm2 helpers: `processListMiddleware`, `checkProcess` (query pm2 for a named process), and `restart`.|
-
-## Database & runtime
-
-|Export|Description|
-| :-|:- |
-|`pruneInterval`|`(pool, sql)` runs `sql` on a 12-hour `setInterval` (unref'd) for periodic table pruning (e.g. `frame_deletes`, `task_runs`).|
-|`isPrimeInstance`|Boolean; true on pm2 instance `0` or outside a cluster; gates work that must run on one instance only.|
+**Utilities**
+- `formatBytes` — human-readable byte sizes.
+- `randomID` — `nanoid` generator.
+- `password` — shared password-policy JSON.
+- `jsonFileHanding` — JSON read/write/validate (key spelled `jsonFileHanding`).
 
 ---
 # Consumers & config
 
-- Imported by [command](../command), [storage](../storage), [livestream](../livestream), [schedule](../schedule), [object](../object), [memory](../memory), [gateway](../gateway).
-- Config from env; see [../env.example](../env.example): `SECRETKEY`, `scheduler_AUTH` (auth); `alert_URL`/`admin_alert_URL`/`alert_TZ` (alerts); `privateKey_FILEPATH`/`certificate_FILEPATH` (TLS); `storage_MOTION_CONF_FILEPATH` (cameras).
-- `auth` reads command's `auth`/`sessions` Postgres tables; `pruneInterval` targets whichever table a service maintains.
+- Imported by every service: [command](../command), [storage](../storage), [livestream](../livestream), [schedule](../schedule), [object](../object), [memory](../memory), [gateway](../gateway).
+- Env: `SECRETKEY`, `scheduler_AUTH` (auth) · `alert_URL` / `admin_alert_URL` / `alert_TZ` (alerts) · `privateKey_FILEPATH` / `certificate_FILEPATH` (TLS) · `storage_MOTION_CONF_FILEPATH` (cameras). See [../env.example](../env.example).

--- a/livestream/README.md
+++ b/livestream/README.md
@@ -1,17 +1,39 @@
 # Livestream <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The livestream server handles transcoding the RTSP camera feed into a HLS stream.
+The livestream server serves and monitors the per-camera HLS video streams. It does **not** transcode: the RTSP→HLS conversion is done by separate per-camera ffmpeg processes; this Node server serves their segments, reports each camera's stream status, and can restart a camera's stream.
 
-[ffmpeg](https://ffmpeg.org) is required to start HLS stream.
+[ffmpeg](https://ffmpeg.org) must be installed (on `PATH`) for the streams to start.
 
 ---
 # Routes
 ## ▶ /livestream
 
+`/status`, `/restart`, and `/feed` sit behind [lib](../lib) `auth.createAuthorize(pool)`, so a valid session is required; `/health` is public.
+
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|GET|/status| | | |
-|GET|/status?camera={camera number}| | | |
-|GET|/feed/{camera number}/video.m3u8|Live stream file|None|mp4|
-|POST|/restart|restart live stream file|`{ camera: Number }`|N/A|
+|GET|/status|pm2 status of every camera's HLS process (`live_stream_cam_*`)|None|`[{name, status, restarts}]`, or `204` if none running|
+|GET|/status?camera={camera id}|pm2 status of one camera's HLS process|`camera` query = camera id|`[{name, status, restarts}]`, or `204` if not running|
+|POST|/restart|Restart one camera's ffmpeg HLS process|`{ camera: Number }`|`{}` (`400` if `camera` omitted)|
+|GET|/feed/{camera id}/video.m3u8|HLS playlist for a camera (rolling `.ts` segments served alongside)|None|`video.m3u8` (HLS playlist)|
 |GET|/health|Confirms server alive|N/A|N/A|
+
+---
+# Transcoding (division of labor)
+
+When `livestream_ON=true`, pm2 ([pm2.config.js](../pm2.config.js)) spawns one ffmpeg process per configured camera — named `live_stream_cam_<id>` — reading the camera's RTSP feed over TCP and writing a rolling HLS playlist (`video.m3u8` plus short `.ts` segments) to `livestream_FOLDERPATH/feed/<id>/`. Cameras come from [cameraconf/*.conf](../cameraconf) via [lib](../lib) `loadCameras`.
+
+This Node server:
+- serves those files statically at `/livestream/feed/<id>/video.m3u8`,
+- reports each camera's ffmpeg process status via `/status` (querying pm2), and
+- restarts a camera's ffmpeg process via `/restart` (via pm2).
+
+On startup it checks for at least one `live_stream_cam` process and logs a warning if none is running.
+
+---
+# How it fits
+
+- `server.js` starts this service under pm2 when `livestream_ON=true`.
+- The [gateway](../gateway) reverse-proxies it when `livestream_PROXY_ON=true`.
+- It owns no Postgres tables; session validation reads the `sessions`/`auth` tables owned by [command](../command) through [lib](../lib) auth.
+- Config: `livestream_ON`, `livestream_PORT`, `livestream_HOST`, `livestream_FOLDERPATH`, `livestream_PROXY_ON`, plus the `ffmpeg` requirement — see [../env.example](../env.example).

--- a/livestream/README.md
+++ b/livestream/README.md
@@ -1,24 +1,25 @@
 # Livestream <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-Serves and monitors per-camera HLS video streams; RTSP→HLS transcoding runs in separate per-camera ffmpeg processes, not here.
-
-[ffmpeg](https://ffmpeg.org) must be on `PATH` for streams to start.
+Serves and monitors per-camera HLS streams. RTSP→HLS transcoding runs in separate ffmpeg processes, not here.
 
 ---
 # API
 
-Session-guarded (`authorize`) except `/health`. The API reports pm2 status for all cameras' HLS processes or a single camera, restarts a camera's ffmpeg process, and serves each camera's rolling HLS playlist (`/feed/<id>/video.m3u8`).
+Session-guarded (`authorize`) except `/livestream/health`:
+
+- pm2 status for all cameras or one
+- restart a camera's ffmpeg process
+- serve each camera's HLS playlist (`/livestream/feed/<id>/video.m3u8`)
 
 ---
-# Streams
+# Runtime
 
-- pm2 ([pm2.config.js](../pm2.config.js)) spawns one ffmpeg per configured camera (`live_stream_cam_<id>`) when `livestream_ON=true`, reading RTSP over TCP and writing rolling HLS (`video.m3u8` + `.ts`) to `livestream_FOLDERPATH/feed/<id>/`.
+- pm2 spawns one ffmpeg per camera (`live_stream_cam_<id>`) when `livestream_ON=true`: RTSP-over-TCP → rolling HLS in `livestream_FOLDERPATH/feed/<id>/`. Needs `ffmpeg` on `PATH`.
 - Cameras load from [cameraconf/*.conf](../cameraconf) via [lib](../lib) `loadCameras`.
-- On startup, warns if no `live_stream_cam` process is running.
-- Started by `server.js` under pm2 when `livestream_ON=true`; [gateway](../gateway) reverse-proxies it when `livestream_PROXY_ON=true`.
-- Owns no Postgres tables; session validation reads [command](../command)'s `sessions`/`auth` tables via [lib](../lib) `auth.createAuthorize(pool)`.
+- Started by root `server.js`; [gateway](../gateway) proxies when `livestream_PROXY_ON=true`.
+- No tables; sessions validated against [command](../command)'s `auth`/`sessions` via [lib](../lib).
 
 ---
 # Config
 
-`livestream_ON`, `livestream_PORT`, `livestream_HOST`, `livestream_FOLDERPATH`, `livestream_PROXY_ON`; requires `ffmpeg`. See [../env.example](../env.example).
+`livestream_ON`, `livestream_PORT`, `livestream_HOST`, `livestream_FOLDERPATH`, `livestream_PROXY_ON`; see [../env.example](../env.example).

--- a/livestream/README.md
+++ b/livestream/README.md
@@ -1,39 +1,33 @@
 # Livestream <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The livestream server serves and monitors the per-camera HLS video streams. It does **not** transcode: the RTSP→HLS conversion is done by separate per-camera ffmpeg processes; this Node server serves their segments, reports each camera's stream status, and can restart a camera's stream.
+Serves and monitors per-camera HLS video streams; RTSP→HLS transcoding runs in separate per-camera ffmpeg processes, not here.
 
-[ffmpeg](https://ffmpeg.org) must be installed (on `PATH`) for the streams to start.
+[ffmpeg](https://ffmpeg.org) must be on `PATH` for streams to start.
 
 ---
 # Routes
 ## ▶ /livestream
 
-`/status`, `/restart`, and `/feed` sit behind [lib](../lib) `auth.createAuthorize(pool)`, so a valid session is required; `/health` is public.
+All routes need a session (`authorize`) except `/health`.
 
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|GET|/status|pm2 status of every camera's HLS process (`live_stream_cam_*`)|None|`[{name, status, restarts}]`, or `204` if none running|
-|GET|/status?camera={camera id}|pm2 status of one camera's HLS process|`camera` query = camera id|`[{name, status, restarts}]`, or `204` if not running|
-|POST|/restart|Restart one camera's ffmpeg HLS process|`{ camera: Number }`|`{}` (`400` if `camera` omitted)|
-|GET|/feed/{camera id}/video.m3u8|HLS playlist for a camera (rolling `.ts` segments served alongside)|None|`video.m3u8` (HLS playlist)|
-|GET|/health|Confirms server alive|N/A|N/A|
+|GET|/status|pm2 status of all cameras' HLS processes (`live_stream_cam_*`)|None|`[{name, status, restarts}]`, or `204` if none running|
+|GET|/status?camera={camera id}|pm2 status of one camera|`camera` query = camera id|`[{name, status, restarts}]`, or `204` if not running|
+|POST|/restart|Restart one camera's ffmpeg process|`{ camera: Number }`|`{}` (`400` if `camera` omitted)|
+|GET|/feed/{camera id}/video.m3u8|HLS playlist (rolling `.ts` segments served alongside)|None|`video.m3u8`|
+|GET|/health|Liveness check|N/A|N/A|
 
 ---
-# Transcoding (division of labor)
+# Streams
 
-When `livestream_ON=true`, pm2 ([pm2.config.js](../pm2.config.js)) spawns one ffmpeg process per configured camera — named `live_stream_cam_<id>` — reading the camera's RTSP feed over TCP and writing a rolling HLS playlist (`video.m3u8` plus short `.ts` segments) to `livestream_FOLDERPATH/feed/<id>/`. Cameras come from [cameraconf/*.conf](../cameraconf) via [lib](../lib) `loadCameras`.
-
-This Node server:
-- serves those files statically at `/livestream/feed/<id>/video.m3u8`,
-- reports each camera's ffmpeg process status via `/status` (querying pm2), and
-- restarts a camera's ffmpeg process via `/restart` (via pm2).
-
-On startup it checks for at least one `live_stream_cam` process and logs a warning if none is running.
+- pm2 ([pm2.config.js](../pm2.config.js)) spawns one ffmpeg per configured camera (`live_stream_cam_<id>`) when `livestream_ON=true`, reading RTSP over TCP and writing rolling HLS (`video.m3u8` + `.ts`) to `livestream_FOLDERPATH/feed/<id>/`.
+- Cameras load from [cameraconf/*.conf](../cameraconf) via [lib](../lib) `loadCameras`.
+- On startup, warns if no `live_stream_cam` process is running.
+- Started by `server.js` under pm2 when `livestream_ON=true`; [gateway](../gateway) reverse-proxies it when `livestream_PROXY_ON=true`.
+- Owns no Postgres tables; session validation reads [command](../command)'s `sessions`/`auth` tables via [lib](../lib) `auth.createAuthorize(pool)`.
 
 ---
-# How it fits
+# Config
 
-- `server.js` starts this service under pm2 when `livestream_ON=true`.
-- The [gateway](../gateway) reverse-proxies it when `livestream_PROXY_ON=true`.
-- It owns no Postgres tables; session validation reads the `sessions`/`auth` tables owned by [command](../command) through [lib](../lib) auth.
-- Config: `livestream_ON`, `livestream_PORT`, `livestream_HOST`, `livestream_FOLDERPATH`, `livestream_PROXY_ON`, plus the `ffmpeg` requirement — see [../env.example](../env.example).
+`livestream_ON`, `livestream_PORT`, `livestream_HOST`, `livestream_FOLDERPATH`, `livestream_PROXY_ON`; requires `ffmpeg`. See [../env.example](../env.example).

--- a/livestream/README.md
+++ b/livestream/README.md
@@ -5,18 +5,9 @@ Serves and monitors per-camera HLS video streams; RTSP→HLS transcoding runs in
 [ffmpeg](https://ffmpeg.org) must be on `PATH` for streams to start.
 
 ---
-# Routes
-## ▶ /livestream
+# API
 
-All routes need a session (`authorize`) except `/health`.
-
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/status|pm2 status of all cameras' HLS processes (`live_stream_cam_*`)|None|`[{name, status, restarts}]`, or `204` if none running|
-|GET|/status?camera={camera id}|pm2 status of one camera|`camera` query = camera id|`[{name, status, restarts}]`, or `204` if not running|
-|POST|/restart|Restart one camera's ffmpeg process|`{ camera: Number }`|`{}` (`400` if `camera` omitted)|
-|GET|/feed/{camera id}/video.m3u8|HLS playlist (rolling `.ts` segments served alongside)|None|`video.m3u8`|
-|GET|/health|Liveness check|N/A|N/A|
+Session-guarded (`authorize`) except `/health`. The API reports pm2 status for all cameras' HLS processes or a single camera, restarts a camera's ffmpeg process, and serves each camera's rolling HLS playlist (`/feed/<id>/video.m3u8`).
 
 ---
 # Streams

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,15 +1,15 @@
 # Memory <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The memory server is a [Socket.IO](https://socket.io) server that brokers shared, cross-instance state so a pm2 cluster (`chimeraInstances > 1`) stays coordinated. It holds volatile in-process state only — nothing is persisted, so all state is lost on restart.
+[Socket.IO](https://socket.io) server that shares in-process state across a pm2 cluster (`chimeraInstances > 1`); nothing persists, so all state is lost on restart.
 
 ---
-# How it fits
+# Runtime
 
-- The root [server.js](../server.js) calls `require("memory").server()` in the boot chain, but the socket only actually listens when `memory_ON == "true"` **and** the process is the prime pm2 instance (`isPrimeInstance` from [lib](../lib) — `NODE_APP_INSTANCE` is `0` or unset). So exactly one instance runs the broker.
-- `memory_ON` is forced to `true` by [pm2.config.js](../pm2.config.js) whenever `chimeraInstances > 1` or `"max"`, because a cluster must share state.
-- It is an internal service: it is **not** exposed through the [gateway](../gateway) and has no `_PROXY_ON` toggle. Connections are authenticated by the `Authorization` request header, which must equal `memory_AUTH_TOKEN`; anything else is rejected at handshake.
-- Other services connect as clients with `require("memory").client("<LABEL>")`, which dials `memory_HOST` with the auth header attached. The label is only used in connection logging — every client shares the default namespace. Labels currently in use: `AUTH` ([command](../command)), `OBJECT` ([object](../object)), `TASK SCHEDULER` and `MEMORY-HEALTH` ([schedule](../schedule)), and `PROCESS` / `VIDEO PROCESS` / `ZIP PROCESS` ([storage](../storage)).
-- Uses no Postgres tables. Env keys: `memory_ON`, `memory_PORT`, `memory_HOST`, `memory_AUTH_TOKEN` (see [../env.example](../env.example)).
+- Boot: `server.js` calls `require("memory").server()`. Listens only when `memory_ON == "true"` and the process is the prime pm2 instance (`isPrimeInstance` from [lib](../lib); `NODE_APP_INSTANCE` is `0` or unset), so exactly one instance runs it.
+- `pm2.config.js` forces `memory_ON=true` when `chimeraInstances > 1` or `"max"`.
+- Internal only: not exposed through the [gateway](../gateway), no `_PROXY_ON` toggle. Handshake requires `Authorization` header `== memory_AUTH_TOKEN`, else rejected.
+- Clients connect via `require("memory").client("<LABEL>")`, dialing `memory_HOST` with the auth header. Label is connection-logging only; all clients share the default namespace. Labels: `AUTH` ([command](../command)), `OBJECT` ([object](../object)), `TASK SCHEDULER` + `MEMORY-HEALTH` ([schedule](../schedule)), `PROCESS`/`VIDEO PROCESS`/`ZIP PROCESS` ([storage](../storage)).
+- No Postgres tables.
 
 ---
 # Modules
@@ -18,10 +18,15 @@ Each module is a factory in [lib/](lib) that [socket.js](socket.js) wires to soc
 
 |Module|Events|Description|Emitted by|
 | :-|:- |:-|:- |
-|[loginAttempts](lib/loginAttempts.js)|`loginReserve`, `loginRelease`|Shared login rate limiter over a fixed (tumbling) window. `loginReserve(key, max, windowMs, cb)` reserves a slot within the current window and calls back with a `blocked` boolean (when the key is already at `max` it reports blocked without reserving); once the window expires the counter resets wholesale. `loginRelease(key)` refunds a slot (e.g. on a successful login). Counters live in an in-memory `Map` with size-bounded pruning. When `memory_ON` is off, [command](../command) falls back to a local, per-instance copy of the same module.|[command](../command) (`AUTH`)|
-|[scheduledTasks](lib/scheduledTasks.js)|`createTask`, `startTask`, `stopTask`, `destroyTask`, `listTask`|Registry of `node-cron` jobs keyed by task id. When a job fires it does `io.emit(task.id)`, broadcasting a tick to every connected instance; task configs are returned to callers.|[schedule](../schedule) (`TASK SCHEDULER`)|
+|[loginAttempts](lib/loginAttempts.js)|`loginReserve`, `loginRelease`|Shared login rate limiter over a fixed (tumbling) window. `loginReserve(key, max, windowMs, cb)` reserves a slot in the current window; `cb(blocked)` reports blocked without reserving when the key is at `max`. Counter resets wholesale when the window expires. `loginRelease(key)` refunds a slot (e.g. on successful login). In-memory `Map`, size-bounded pruning. When `memory_ON` is off, [command](../command) falls back to a local per-instance copy.|[command](../command) (`AUTH`)|
+|[scheduledTasks](lib/scheduledTasks.js)|`createTask`, `startTask`, `stopTask`, `destroyTask`, `listTask`|Registry of `node-cron` jobs keyed by task id. On fire, `io.emit(task.id)` broadcasts a tick to every instance; task configs are returned to callers.|[schedule](../schedule) (`TASK SCHEDULER`)|
 |[converterProcesses](lib/converterProcesses.js)|`saveProcessEnder`, `cancelProcess`|Registry of cancel functions for in-flight mp4/zip conversions, so any instance can cancel a job started on another. `saveProcessEnder(id, fn)` stores the ender; `cancelProcess(id, type)` invokes and removes it.|[storage](../storage) (`VIDEO PROCESS`, `ZIP PROCESS`, `PROCESS`)|
-|[objectState](lib/objectState.js)|`objectGetState`, `objectSetConfig`, `objectScan`|Brokers object-detection state via [lib](../lib)'s `objectState`: `objectGetState` returns `{config, status}`, `objectSetConfig(updates)` writes config, `objectScan(camera)` runs a scan and returns `{detections}` (or `{error}`).|[object](../object) (`OBJECT`)|
-|[cronTask](lib/cronTask.js)|`cron`|Registers a single `node-cron` job that emits a caller-supplied id on schedule (`io.emit(cronTaskID)`).|No confirmed emitter (see grounding notes)|
+|[objectState](lib/objectState.js)|`objectGetState`, `objectSetConfig`, `objectScan`|Object-detection state via [lib](../lib)'s `objectState`. `objectGetState` returns `{config, status}`; `objectSetConfig(updates)` writes config; `objectScan(camera)` runs a scan, returns `{detections}` or `{error}`.|[object](../object) (`OBJECT`)|
+|[cronTask](lib/cronTask.js)|`cron`|Registers one `node-cron` job that emits a caller-supplied id on schedule (`io.emit(cronTaskID)`).|—|
 
-Built-in events also handled: `log` (logs a payload server-side), `callback` (invokes the ack — used by [schedule](../schedule)'s health check as `MEMORY-HEALTH`), and `disconnect`.
+Built-in events: `log` (logs a payload server-side), `callback` (invokes the ack; used by [schedule](../schedule)'s health check as `MEMORY-HEALTH`), `disconnect`.
+
+---
+# Config
+
+`memory_ON`, `memory_PORT`, `memory_HOST`, `memory_AUTH_TOKEN`; see [../env.example](../env.example).

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,3 +1,27 @@
 # Memory <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The memory server is a socket that keeps track of events and callbacks for the other servers to call.
+The memory server is a [Socket.IO](https://socket.io) server that brokers shared, cross-instance state so a pm2 cluster (`chimeraInstances > 1`) stays coordinated. It holds volatile in-process state only — nothing is persisted, so all state is lost on restart.
+
+---
+# How it fits
+
+- The root [server.js](../server.js) calls `require("memory").server()` in the boot chain, but the socket only actually listens when `memory_ON == "true"` **and** the process is the prime pm2 instance (`isPrimeInstance` from [lib](../lib) — `NODE_APP_INSTANCE` is `0` or unset). So exactly one instance runs the broker.
+- `memory_ON` is forced to `true` by [pm2.config.js](../pm2.config.js) whenever `chimeraInstances > 1` or `"max"`, because a cluster must share state.
+- It is an internal service: it is **not** exposed through the [gateway](../gateway) and has no `_PROXY_ON` toggle. Connections are authenticated by the `Authorization` request header, which must equal `memory_AUTH_TOKEN`; anything else is rejected at handshake.
+- Other services connect as clients with `require("memory").client("<LABEL>")`, which dials `memory_HOST` with the auth header attached. The label is only used in connection logging — every client shares the default namespace. Labels currently in use: `AUTH` ([command](../command)), `OBJECT` ([object](../object)), `TASK SCHEDULER` and `MEMORY-HEALTH` ([schedule](../schedule)), and `PROCESS` / `VIDEO PROCESS` / `ZIP PROCESS` ([storage](../storage)).
+- Uses no Postgres tables. Env keys: `memory_ON`, `memory_PORT`, `memory_HOST`, `memory_AUTH_TOKEN` (see [../env.example](../env.example)).
+
+---
+# Modules
+
+Each module is a factory in [lib/](lib) that [socket.js](socket.js) wires to socket events on `connection`.
+
+|Module|Events|Description|Emitted by|
+| :-|:- |:-|:- |
+|[loginAttempts](lib/loginAttempts.js)|`loginReserve`, `loginRelease`|Shared login rate limiter over a fixed (tumbling) window. `loginReserve(key, max, windowMs, cb)` reserves a slot within the current window and calls back with a `blocked` boolean (when the key is already at `max` it reports blocked without reserving); once the window expires the counter resets wholesale. `loginRelease(key)` refunds a slot (e.g. on a successful login). Counters live in an in-memory `Map` with size-bounded pruning. When `memory_ON` is off, [command](../command) falls back to a local, per-instance copy of the same module.|[command](../command) (`AUTH`)|
+|[scheduledTasks](lib/scheduledTasks.js)|`createTask`, `startTask`, `stopTask`, `destroyTask`, `listTask`|Registry of `node-cron` jobs keyed by task id. When a job fires it does `io.emit(task.id)`, broadcasting a tick to every connected instance; task configs are returned to callers.|[schedule](../schedule) (`TASK SCHEDULER`)|
+|[converterProcesses](lib/converterProcesses.js)|`saveProcessEnder`, `cancelProcess`|Registry of cancel functions for in-flight mp4/zip conversions, so any instance can cancel a job started on another. `saveProcessEnder(id, fn)` stores the ender; `cancelProcess(id, type)` invokes and removes it.|[storage](../storage) (`VIDEO PROCESS`, `ZIP PROCESS`, `PROCESS`)|
+|[objectState](lib/objectState.js)|`objectGetState`, `objectSetConfig`, `objectScan`|Brokers object-detection state via [lib](../lib)'s `objectState`: `objectGetState` returns `{config, status}`, `objectSetConfig(updates)` writes config, `objectScan(camera)` runs a scan and returns `{detections}` (or `{error}`).|[object](../object) (`OBJECT`)|
+|[cronTask](lib/cronTask.js)|`cron`|Registers a single `node-cron` job that emits a caller-supplied id on schedule (`io.emit(cronTaskID)`).|No confirmed emitter (see grounding notes)|
+
+Built-in events also handled: `log` (logs a payload server-side), `callback` (invokes the ack — used by [schedule](../schedule)'s health check as `MEMORY-HEALTH`), and `disconnect`.

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,30 +1,26 @@
 # Memory <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-[Socket.IO](https://socket.io) server that shares in-process state across a pm2 cluster (`chimeraInstances > 1`); nothing persists, so all state is lost on restart.
+[Socket.IO](https://socket.io) server sharing in-process state across a pm2 cluster (`chimeraInstances > 1`). Nothing persists.
 
 ---
 # Runtime
 
-- Boot: `server.js` calls `require("memory").server()`. Listens only when `memory_ON == "true"` and the process is the prime pm2 instance (`isPrimeInstance` from [lib](../lib); `NODE_APP_INSTANCE` is `0` or unset), so exactly one instance runs it.
-- `pm2.config.js` forces `memory_ON=true` when `chimeraInstances > 1` or `"max"`.
-- Internal only: not exposed through the [gateway](../gateway), no `_PROXY_ON` toggle. Handshake requires `Authorization` header `== memory_AUTH_TOKEN`, else rejected.
-- Clients connect via `require("memory").client("<LABEL>")`, dialing `memory_HOST` with the auth header. Label is connection-logging only; all clients share the default namespace. Labels: `AUTH` ([command](../command)), `OBJECT` ([object](../object)), `TASK SCHEDULER` + `MEMORY-HEALTH` ([schedule](../schedule)), `PROCESS`/`VIDEO PROCESS`/`ZIP PROCESS` ([storage](../storage)).
-- No Postgres tables.
+- Runs only on the prime pm2 instance, only when `memory_ON=true` (`pm2.config.js` forces this in cluster mode). Started by root `server.js`.
+- Internal only, no gateway route. Clients (`require("memory").client("<LABEL>")`) must send `Authorization: memory_AUTH_TOKEN`.
+- Labels (logging only): `AUTH` (command), `OBJECT` (object), `TASK SCHEDULER` + `MEMORY-HEALTH` (schedule), `PROCESS` / `VIDEO PROCESS` / `ZIP PROCESS` (storage).
 
 ---
 # Modules
 
-Each module is a factory in [lib/](lib) that [socket.js](socket.js) wires to socket events on `connection`.
+Factories in [lib/](lib), wired to socket events by [socket.js](socket.js):
 
-|Module|Events|Description|Emitted by|
-| :-|:- |:-|:- |
-|[loginAttempts](lib/loginAttempts.js)|`loginReserve`, `loginRelease`|Shared login rate limiter over a fixed (tumbling) window. `loginReserve(key, max, windowMs, cb)` reserves a slot in the current window; `cb(blocked)` reports blocked without reserving when the key is at `max`. Counter resets wholesale when the window expires. `loginRelease(key)` refunds a slot (e.g. on successful login). In-memory `Map`, size-bounded pruning. When `memory_ON` is off, [command](../command) falls back to a local per-instance copy.|[command](../command) (`AUTH`)|
-|[scheduledTasks](lib/scheduledTasks.js)|`createTask`, `startTask`, `stopTask`, `destroyTask`, `listTask`|Registry of `node-cron` jobs keyed by task id. On fire, `io.emit(task.id)` broadcasts a tick to every instance; task configs are returned to callers.|[schedule](../schedule) (`TASK SCHEDULER`)|
-|[converterProcesses](lib/converterProcesses.js)|`saveProcessEnder`, `cancelProcess`|Registry of cancel functions for in-flight mp4/zip conversions, so any instance can cancel a job started on another. `saveProcessEnder(id, fn)` stores the ender; `cancelProcess(id, type)` invokes and removes it.|[storage](../storage) (`VIDEO PROCESS`, `ZIP PROCESS`, `PROCESS`)|
-|[objectState](lib/objectState.js)|`objectGetState`, `objectSetConfig`, `objectScan`|Object-detection state via [lib](../lib)'s `objectState`. `objectGetState` returns `{config, status}`; `objectSetConfig(updates)` writes config; `objectScan(camera)` runs a scan, returns `{detections}` or `{error}`.|[object](../object) (`OBJECT`)|
-|[cronTask](lib/cronTask.js)|`cron`|Registers one `node-cron` job that emits a caller-supplied id on schedule (`io.emit(cronTaskID)`).|—|
+- **loginAttempts** — shared login rate limiter (tumbling window); command falls back to a local copy when `memory_ON` is off.
+- **scheduledTasks** — `node-cron` registry; on fire, emits the task id to every instance ([schedule](../schedule)).
+- **converterProcesses** — cancel handles for in-flight mp4/zip jobs ([storage](../storage)).
+- **objectState** — object-detection config/status/scan bridge ([object](../object)).
+- **cronTask** — one `node-cron` job that emits a caller-supplied id.
 
-Built-in events: `log` (logs a payload server-side), `callback` (invokes the ack; used by [schedule](../schedule)'s health check as `MEMORY-HEALTH`), `disconnect`.
+Built-in events: `log`, `callback` (schedule's `MEMORY-HEALTH` check), `disconnect`.
 
 ---
 # Config

--- a/object/README.md
+++ b/object/README.md
@@ -1,27 +1,33 @@
 # Object <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The object server runs native [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX) inference over the camera HLS feeds, records detections to the `objects_detected` table, and fires webhook alerts via `alert_URL`. The YOLOX-Tiny ONNX model (~20MB) is fetched to `backend/model/yolox_tiny.onnx` on first boot (override the source with `object_MODEL_URL`).
+Runs YOLOX inference on the camera HLS feeds, records detections to the `objects_detected` table, and fires webhook alerts via `alert_URL`.
 
 ---
 # Routes
 ## ▶ /object
 
-Every route is mounted behind `authorize` (valid session required) except `/health`, which is public. `POST /config` and `POST /scan` additionally require an admin role (`requireAdmin`).
+All routes need a session (`authorize`) except `/health` (public); `POST /config` and `POST /scan` also need admin (`requireAdmin`).
 
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|GET|/status|Current config + per-camera worker status|None|`{config, cameras, cameraNames}`|
+|GET|/status|Config + per-camera worker status|None|`{config, cameras, cameraNames}`|
 |GET|/config|Current detection config|None|JSON|
 |POST|/config|Update detection config (admin)|`{confidence, intervalMs, classes}`|JSON|
-|POST|/scan|Force an immediate scan of one camera (admin)|`{camera}`|`{camera, detections}`|
+|POST|/scan|Scan one camera now (admin)|`{camera}`|`{camera, detections}`|
 |GET|/detections|Recent detections (`id, camera, timestamp, type, confidence, box, image`)|`camera`, `start`, `end`, `limit` (default 50, max 500)|JSON[]|
-|GET|/captures/{file}|Detection frame referenced by `image` in `/detections`|None|jpg|
-|GET|/health|Confirms server alive|N/A|N/A|
+|GET|/captures/{file}|Detection frame from `image` in `/detections`|None|jpg|
+|GET|/health|Server alive|N/A|N/A|
 
-## How it fits
+---
+# Runtime
 
-`server.js` starts this service under pm2 when `object_ON=true`; the [gateway](../gateway) proxies it when `object_PROXY_ON=true`. On the prime instance it runs per-camera scan loops every `object_INTERVAL_MS`, writing each detection to the `objects_detected` Postgres table and pruning capture images to `object_MAX_CAPTURES`. Auth middleware and camera loading come from [lib](../lib) (`auth`, `loadCameras`); when `memory_ON=true` config/status/scan are brokered through the [memory](../memory) socket (`OBJECT` namespace) so a pm2 cluster stays coordinated.
+- Started by `server.js` under pm2 when `object_ON=true`; proxied by the [gateway](../gateway) when `object_PROXY_ON=true`.
+- Prime instance scans each camera every `object_INTERVAL_MS`, writes detections to the `objects_detected` Postgres table, and prunes captures to `object_MAX_CAPTURES`.
+- Auth and camera loading come from [lib](../lib) (`auth`, `loadCameras`).
+- With `memory_ON=true`, config/status/scan route through the [memory](../memory) socket (`OBJECT` namespace) to coordinate a pm2 cluster.
+- YOLOX-Tiny ONNX model (~20MB) fetched to `backend/model/yolox_tiny.onnx` on first boot; override the source with `object_MODEL_URL`.
 
-## Env
+---
+# Config
 
-See [`env.example`](../env.example) for `object_*` keys. Loads cameras via `storage_MOTION_CONF_FILEPATH`, and reuses `livestream_FOLDERPATH`, `ffmpeg_FILEPATH`, `alert_URL`, `database_*`, and `storage_FOLDERPATH` (where `objectCaptures/` is written).
+`object_*` keys in [`env.example`](../env.example). Loads cameras via `storage_MOTION_CONF_FILEPATH`; reuses `livestream_FOLDERPATH`, `ffmpeg_FILEPATH`, `alert_URL`, `database_*`, and `storage_FOLDERPATH` (holds `objectCaptures/`).

--- a/object/README.md
+++ b/object/README.md
@@ -1,24 +1,27 @@
 # Object <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-Runs YOLOX inference on the camera HLS feeds, records detections to the `objects_detected` table, and fires webhook alerts via `alert_URL`.
+Runs YOLOX inference on the camera HLS feeds, records detections to `objects_detected`, and fires webhook alerts (`alert_URL`).
 
 ---
 # API
 
-Session-guarded (`authorize`) except `/health`; updating detection config and triggering an on-demand scan additionally require admin (`requireAdmin`).
+Session-guarded (`authorize`) except `/object/health`; config updates and on-demand scans also require admin (`requireAdmin`):
 
-The API reports current config and per-camera worker status, updates the detection config (confidence, interval, classes), scans a camera on demand, and queries recent detections along with their capture frames.
+- current config and per-camera worker status
+- update detection config (confidence, interval, classes)
+- scan a camera on demand
+- query recent detections + their capture frames
 
 ---
 # Runtime
 
-- Started by `server.js` under pm2 when `object_ON=true`; proxied by the [gateway](../gateway) when `object_PROXY_ON=true`.
-- Prime instance scans each camera every `object_INTERVAL_MS`, writes detections to the `objects_detected` Postgres table, and prunes captures to `object_MAX_CAPTURES`.
-- Auth and camera loading come from [lib](../lib) (`auth`, `loadCameras`).
-- With `memory_ON=true`, config/status/scan route through the [memory](../memory) socket (`OBJECT` namespace) to coordinate a pm2 cluster.
-- YOLOX-Tiny ONNX model (~20MB) fetched to `backend/model/yolox_tiny.onnx` on first boot; override the source with `object_MODEL_URL`.
+- Started by root `server.js` when `object_ON=true`; [gateway](../gateway) proxies when `object_PROXY_ON=true`.
+- The prime instance scans each camera every `object_INTERVAL_MS`, writes to `objects_detected`, and prunes captures to `object_MAX_CAPTURES`.
+- With `memory_ON=true`, config/status/scan route through the [memory](../memory) socket (as the `OBJECT` client).
+- YOLOX-Tiny ONNX (~20MB) fetched to `backend/model/yolox_tiny.onnx` on first boot; override with `object_MODEL_URL`.
+- Auth and camera loading from [lib](../lib).
 
 ---
 # Config
 
-`object_*` keys in [`env.example`](../env.example). Loads cameras via `storage_MOTION_CONF_FILEPATH`; reuses `livestream_FOLDERPATH`, `ffmpeg_FILEPATH`, `alert_URL`, `database_*`, and `storage_FOLDERPATH` (holds `objectCaptures/`).
+`object_*` keys in [env.example](../env.example). Loads cameras via `storage_MOTION_CONF_FILEPATH`; reuses `livestream_FOLDERPATH`, `ffmpeg_FILEPATH`, `alert_URL`, `database_*`, `storage_FOLDERPATH` (holds `objectCaptures/`).

--- a/object/README.md
+++ b/object/README.md
@@ -1,20 +1,26 @@
 # Object <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The object server runs native [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX) inference over the camera HLS feeds, records detections, and fires webhook alerts. The YOLOX-Tiny ONNX model (~20MB) is fetched to `backend/model/yolox_tiny.onnx` on first boot.
+The object server runs native [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX) inference over the camera HLS feeds, records detections to the `objects_detected` table, and fires webhook alerts via `alert_URL`. The YOLOX-Tiny ONNX model (~20MB) is fetched to `backend/model/yolox_tiny.onnx` on first boot (override the source with `object_MODEL_URL`).
 
 ---
 # Routes
 ## ▶ /object
 
+Every route is mounted behind `authorize` (valid session required) except `/health`, which is public. `POST /config` and `POST /scan` additionally require an admin role (`requireAdmin`).
+
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|GET|/status|Current config + per-camera worker status|None|JSON|
-|GET|/detections|Recent detections from the database|`camera`, `start`, `end`, `limit`|JSON|
+|GET|/status|Current config + per-camera worker status|None|`{config, cameras, cameraNames}`|
 |GET|/config|Current detection config|None|JSON|
-|POST|/config|Update detection config (admin)|`{ confidence, intervalMs, classes }`|JSON|
-|POST|/scan|Force an immediate scan (admin)|`{ camera }`|JSON|
+|POST|/config|Update detection config (admin)|`{confidence, intervalMs, classes}`|JSON|
+|POST|/scan|Force an immediate scan of one camera (admin)|`{camera}`|`{camera, detections}`|
+|GET|/detections|Recent detections (`id, camera, timestamp, type, confidence, box, image`)|`camera`, `start`, `end`, `limit` (default 50, max 500)|JSON[]|
 |GET|/captures/{file}|Detection frame referenced by `image` in `/detections`|None|jpg|
 |GET|/health|Confirms server alive|N/A|N/A|
+
+## How it fits
+
+`server.js` starts this service under pm2 when `object_ON=true`; the [gateway](../gateway) proxies it when `object_PROXY_ON=true`. On the prime instance it runs per-camera scan loops every `object_INTERVAL_MS`, writing each detection to the `objects_detected` Postgres table and pruning capture images to `object_MAX_CAPTURES`. Auth middleware and camera loading come from [lib](../lib) (`auth`, `loadCameras`); when `memory_ON=true` config/status/scan are brokered through the [memory](../memory) socket (`OBJECT` namespace) so a pm2 cluster stays coordinated.
 
 ## Env
 

--- a/object/README.md
+++ b/object/README.md
@@ -3,20 +3,11 @@
 Runs YOLOX inference on the camera HLS feeds, records detections to the `objects_detected` table, and fires webhook alerts via `alert_URL`.
 
 ---
-# Routes
-## ▶ /object
+# API
 
-All routes need a session (`authorize`) except `/health` (public); `POST /config` and `POST /scan` also need admin (`requireAdmin`).
+Session-guarded (`authorize`) except `/health`; updating detection config and triggering an on-demand scan additionally require admin (`requireAdmin`).
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/status|Config + per-camera worker status|None|`{config, cameras, cameraNames}`|
-|GET|/config|Current detection config|None|JSON|
-|POST|/config|Update detection config (admin)|`{confidence, intervalMs, classes}`|JSON|
-|POST|/scan|Scan one camera now (admin)|`{camera}`|`{camera, detections}`|
-|GET|/detections|Recent detections (`id, camera, timestamp, type, confidence, box, image`)|`camera`, `start`, `end`, `limit` (default 50, max 500)|JSON[]|
-|GET|/captures/{file}|Detection frame from `image` in `/detections`|None|jpg|
-|GET|/health|Server alive|N/A|N/A|
+The API reports current config and per-camera worker status, updates the detection config (confidence, interval, classes), scans a camera on demand, and queries recent detections along with their capture frames.
 
 ---
 # Runtime

--- a/schedule/README.md
+++ b/schedule/README.md
@@ -1,17 +1,21 @@
 # Schedule <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The schedule server runs cron-based tasks on behalf of the other servers.
+The schedule server runs cron-based tasks on behalf of the other servers. On each tick it fires an authenticated HTTP call to a whitelisted service route and records the outcome.
 
 ---
 # Routes
 ## ▶ /task
 
+Every `/task` route sits behind the shared session guard (`authorize`); the mutating routes (`/start`, `/stop`, `/destroy`) additionally require the `admin` role (`requireAdmin`).
+
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|POST|/start|Schedules a task|`{ id: String, url: String, body: JSON, cronString: String }`|`{ running: Boolean }`|
-|GET|/list|Checks details of tasks|None|`{ tasks: [TaskObj] }`|
-|POST|/stop|Stops a task|`{ id: String }`|`{ stopped: Boolean }`|
-|POST|/destroy|Destroys a task|`{ id: String }`|`{ destroyed: Boolean }`|
+|POST|/start|Schedules a task (admin). `url` must be a whitelisted target and `body` a JSON string. If an existing stopped `id` is supplied it is restarted; if it is already running the call no-ops|`{ url: String, body: JSON-String, cronString: String }` for a new task, or `{ id: String }` to restart an existing one|`{ running: Boolean }`|
+|GET|/list|Lists all scheduled tasks|None|`{ tasks: [TaskObj] }`|
+|POST|/stop|Stops a task (admin); protected tasks are rejected|`{ id: String }`|`{ stopped: Boolean }`|
+|POST|/destroy|Destroys a task (admin); protected tasks are rejected|`{ id: String }`|`{ destroyed: Boolean }`|
+|GET|/runs|Recent run history across all tasks (latest 200, newest first)|None|`{ runs: [RunObj] }`|
+|GET|/runs/:taskId|Recent run history for one task (latest 200, newest first)|`taskId` path param|`{ runs: [RunObj] }`|
 
 ```javascript
 // id = task-[RandomAlphaNumeric]
@@ -22,12 +26,45 @@ The schedule server runs cron-based tasks on behalf of the other servers.
     url: String,
     body: Object,
     cronString: String,
-    running: Boolean
+    running: Boolean,
+    protected: Boolean // true for the internal auto-cleanup task
+}
+
+//RunObj (a task_runs row)
+{
+    id: Number,
+    task_id: String,
+    url: String,
+    status: String, // "success" | "failure"
+    http_status: Number,
+    error: String,
+    ran_at: String // TIMESTAMPTZ
 }
 ```
+
+## ▶ /memory
+
+|Type|Route|Description|Parameters|Returns|
+| :-|:- |:-:|:-:|:-:|
+|GET|/status|Round-trips through the [memory](../memory) socket to confirm cross-instance coordination is responsive|None|`{}`|
 
 ## ▶ /schedule
 
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
 |GET|/health|Confirms server alive|N/A|N/A|
+
+---
+# How it fits
+
+`server.js` starts this service under pm2 when `schedule_ON=true` (listening on `schedule_PORT`), and the [gateway](../gateway) reverse-proxies it when `schedule_PROXY_ON=true`. `/schedule/health` is mounted before the auth guard and is public; everything under `/task` and `/memory` requires a valid session via [lib](../lib)'s `auth.createAuthorize(pool)`.
+
+**scheduler_AUTH.** When a cron fires, the service POSTs to `${gateway_HOST}${url}` with `scheduler_AUTH` in the `Authorization` header. [lib](../lib)'s auth middleware (`lib/utils/auth.js`) accepts that token in place of a user session, but only for a fixed allowlist of `schedulableUrls` — `/convert/createVideo`, `/convert/createZip`, `/file/pathMetrics`, `/file/pathDelete`, `/file/pathClean`, `/file/pathAutoClean`. `/task/start` refuses any `url` not on that list, so scheduled jobs can call [storage](../storage) endpoints without a login while nothing else is exposed.
+
+**Coordination.** Task configs and their cron timers live in the [memory](../memory) socket (`memory/lib/scheduledTasks.js`) via `memory.client("TASK SCHEDULER")`, so a pm2 cluster shares one authoritative task registry. When a timer ticks, memory emits the task `id` and this service's handler performs the outbound HTTP call. `/memory/status` uses the same socket as a liveness probe.
+
+**Persistence.** Every fire records a row in the `task_runs` Postgres table (`task_id`, `url`, `status`, `http_status`, `error`, `ran_at`; created by `chimera/prepareDatabase.js`) and emits a webhook alert (see `alert_URL` in [../env.example](../env.example)). On the primary pm2 instance, `startDbPruning()` runs every 12h and deletes `task_runs` rows older than 30 days.
+
+**Auto-cleanup.** On the primary instance, when `storage_MAX_GB` is set, `autoRegisterCleanup()` registers a protected hourly task (`task-auto-cleanup` → `/file/pathAutoClean`) that trims oldest footage; being protected, it cannot be stopped or destroyed through the API.
+
+Relevant env keys (see [../env.example](../env.example)): `schedule_ON`, `schedule_PORT`, `schedule_HOST`, `schedule_PROXY_ON`, `scheduler_AUTH`, `gateway_HOST`, `storage_MAX_GB`.

--- a/schedule/README.md
+++ b/schedule/README.md
@@ -1,25 +1,28 @@
 # Schedule <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-Runs cron-based tasks for the other servers: each tick fires an authenticated HTTP call to a whitelisted service route and records the outcome.
+Cron tasks for the other services: each tick fires an authenticated HTTP call to a whitelisted route and records the outcome.
 
 ---
 # API
 
-Session-guarded (`authorize`); starting, stopping, and destroying tasks additionally require admin (`requireAdmin`). `/schedule/health` is public.
+Session-guarded (`authorize`) except `/schedule/health`; start/stop/destroy also require admin (`requireAdmin`):
 
-The API schedules, lists, stops, and destroys cron tasks, and reads run history from `task_runs` (per task or across all, newest first). A new task's `url` must be whitelisted (see Behavior) and carry a JSON-string body; protected tasks — the internal auto-cleanup — can't be stopped or destroyed. A separate endpoint round-trips the [memory](../memory) socket to check cluster coordination is responsive.
+- schedule, list, stop, destroy cron tasks
+- read run history from `task_runs` (per task or all, newest first)
+- health-check the [memory](../memory) socket round-trip
+
+New tasks need a whitelisted `url` and a JSON-string body. Protected tasks (the auto-cleanup) can't be stopped or destroyed.
 
 ---
-# Behavior
+# Runtime
 
-- Runs under pm2 when `schedule_ON=true` (port `schedule_PORT`); gateway reverse-proxies when `schedule_PROXY_ON=true`.
-- `/schedule/health` mounts before the session guard ([lib](../lib) `auth.createAuthorize(pool)`), so it's public.
-- Crons POST to `${gateway_HOST}${url}` with `scheduler_AUTH` in the `Authorization` header. [lib](../lib) `auth.js` accepts this token instead of a session, but only for `schedulableUrls`: `/convert/createVideo`, `/convert/createZip`, `/file/pathMetrics`, `/file/pathDelete`, `/file/pathClean`, `/file/pathAutoClean`. `/task/start` rejects any other `url`.
-- Task configs and cron timers live in the [memory](../memory) socket (`memory/lib/scheduledTasks.js`, `memory.client("TASK SCHEDULER")`), shared across the pm2 cluster; on tick, memory emits the task `id` and this service makes the HTTP call.
-- Each fire writes a `task_runs` row (`task_id`, `url`, `status`, `http_status`, `error`, `ran_at`; created by `chimera/prepareDatabase.js`) and emits a webhook alert (`alert_URL`). On the primary instance, `startDbPruning()` runs every 12h, deleting `task_runs` rows older than 30 days.
-- On the primary instance, if `storage_MAX_GB` is set, `autoRegisterCleanup()` adds a protected hourly task (`task-auto-cleanup` → `/file/pathAutoClean`) trimming oldest footage; protected tasks can't be stopped or destroyed via the API.
+- Runs under pm2 when `schedule_ON=true`; [gateway](../gateway) proxies when `schedule_PROXY_ON=true`.
+- Crons POST to `${gateway_HOST}${url}` with `scheduler_AUTH` in `Authorization`. [lib](../lib) accepts this token (instead of a session) only for `schedulableUrls`: `/convert/createVideo`, `/convert/createZip`, `/file/pathMetrics`, `/file/pathDelete`, `/file/pathClean`, `/file/pathAutoClean`.
+- Task configs and timers live in the [memory](../memory) socket, shared across the cluster; on tick memory emits the task id and this service makes the call.
+- Each fire writes a `task_runs` row and a webhook alert. The prime instance prunes rows older than 30 days.
+- If `storage_MAX_GB` is set, the prime instance registers a protected hourly `/file/pathAutoClean` task trimming oldest footage.
 
 ---
 # Config
 
-- `schedule_ON`, `schedule_PORT`, `schedule_HOST`, `schedule_PROXY_ON`, `scheduler_AUTH`, `gateway_HOST`, `storage_MAX_GB`; see [../env.example](../env.example).
+`schedule_ON`, `schedule_PORT`, `schedule_HOST`, `schedule_PROXY_ON`, `scheduler_AUTH`, `gateway_HOST`, `storage_MAX_GB`; see [../env.example](../env.example).

--- a/schedule/README.md
+++ b/schedule/README.md
@@ -1,21 +1,21 @@
 # Schedule <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The schedule server runs cron-based tasks on behalf of the other servers. On each tick it fires an authenticated HTTP call to a whitelisted service route and records the outcome.
+Runs cron-based tasks for the other servers: each tick fires an authenticated HTTP call to a whitelisted service route and records the outcome.
 
 ---
 # Routes
 ## ▶ /task
 
-Every `/task` route sits behind the shared session guard (`authorize`); the mutating routes (`/start`, `/stop`, `/destroy`) additionally require the `admin` role (`requireAdmin`).
+All `/task` routes need a session (`authorize`); `/start`, `/stop`, `/destroy` also require `admin` (`requireAdmin`).
 
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|POST|/start|Schedules a task (admin). `url` must be a whitelisted target and `body` a JSON string. If an existing stopped `id` is supplied it is restarted; if it is already running the call no-ops|`{ url: String, body: JSON-String, cronString: String }` for a new task, or `{ id: String }` to restart an existing one|`{ running: Boolean }`|
-|GET|/list|Lists all scheduled tasks|None|`{ tasks: [TaskObj] }`|
-|POST|/stop|Stops a task (admin); protected tasks are rejected|`{ id: String }`|`{ stopped: Boolean }`|
-|POST|/destroy|Destroys a task (admin); protected tasks are rejected|`{ id: String }`|`{ destroyed: Boolean }`|
-|GET|/runs|Recent run history across all tasks (latest 200, newest first)|None|`{ runs: [RunObj] }`|
-|GET|/runs/:taskId|Recent run history for one task (latest 200, newest first)|`taskId` path param|`{ runs: [RunObj] }`|
+|POST|/start|Schedule a task. `url` must be whitelisted, `body` a JSON string. A stopped `id` restarts it; already-running no-ops|`{ url: String, body: JSON-String, cronString: String }` for a new task, or `{ id: String }` to restart|`{ running: Boolean }`|
+|GET|/list|List all scheduled tasks|None|`{ tasks: [TaskObj] }`|
+|POST|/stop|Stop a task; protected tasks rejected|`{ id: String }`|`{ stopped: Boolean }`|
+|POST|/destroy|Destroy a task; protected tasks rejected|`{ id: String }`|`{ destroyed: Boolean }`|
+|GET|/runs|Run history across all tasks (latest 200, newest first)|None|`{ runs: [RunObj] }`|
+|GET|/runs/:taskId|Run history for one task (latest 200, newest first)|`taskId` path param|`{ runs: [RunObj] }`|
 
 ```javascript
 // id = task-[RandomAlphaNumeric]
@@ -44,9 +44,11 @@ Every `/task` route sits behind the shared session guard (`authorize`); the muta
 
 ## ▶ /memory
 
+Needs a session (`authorize`).
+
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|GET|/status|Round-trips through the [memory](../memory) socket to confirm cross-instance coordination is responsive|None|`{}`|
+|GET|/status|Round-trips the [memory](../memory) socket to check coordination is responsive|None|`{}`|
 
 ## ▶ /schedule
 
@@ -55,16 +57,16 @@ Every `/task` route sits behind the shared session guard (`authorize`); the muta
 |GET|/health|Confirms server alive|N/A|N/A|
 
 ---
-# How it fits
+# Behavior
 
-`server.js` starts this service under pm2 when `schedule_ON=true` (listening on `schedule_PORT`), and the [gateway](../gateway) reverse-proxies it when `schedule_PROXY_ON=true`. `/schedule/health` is mounted before the auth guard and is public; everything under `/task` and `/memory` requires a valid session via [lib](../lib)'s `auth.createAuthorize(pool)`.
+- Runs under pm2 when `schedule_ON=true` (port `schedule_PORT`); gateway reverse-proxies when `schedule_PROXY_ON=true`.
+- `/schedule/health` mounts before the session guard ([lib](../lib) `auth.createAuthorize(pool)`), so it's public.
+- Crons POST to `${gateway_HOST}${url}` with `scheduler_AUTH` in the `Authorization` header. [lib](../lib) `auth.js` accepts this token instead of a session, but only for `schedulableUrls`: `/convert/createVideo`, `/convert/createZip`, `/file/pathMetrics`, `/file/pathDelete`, `/file/pathClean`, `/file/pathAutoClean`. `/task/start` rejects any other `url`.
+- Task configs and cron timers live in the [memory](../memory) socket (`memory/lib/scheduledTasks.js`, `memory.client("TASK SCHEDULER")`), shared across the pm2 cluster; on tick, memory emits the task `id` and this service makes the HTTP call.
+- Each fire writes a `task_runs` row (`task_id`, `url`, `status`, `http_status`, `error`, `ran_at`; created by `chimera/prepareDatabase.js`) and emits a webhook alert (`alert_URL`). On the primary instance, `startDbPruning()` runs every 12h, deleting `task_runs` rows older than 30 days.
+- On the primary instance, if `storage_MAX_GB` is set, `autoRegisterCleanup()` adds a protected hourly task (`task-auto-cleanup` → `/file/pathAutoClean`) trimming oldest footage; protected tasks can't be stopped or destroyed via the API.
 
-**scheduler_AUTH.** When a cron fires, the service POSTs to `${gateway_HOST}${url}` with `scheduler_AUTH` in the `Authorization` header. [lib](../lib)'s auth middleware (`lib/utils/auth.js`) accepts that token in place of a user session, but only for a fixed allowlist of `schedulableUrls` — `/convert/createVideo`, `/convert/createZip`, `/file/pathMetrics`, `/file/pathDelete`, `/file/pathClean`, `/file/pathAutoClean`. `/task/start` refuses any `url` not on that list, so scheduled jobs can call [storage](../storage) endpoints without a login while nothing else is exposed.
+---
+# Config
 
-**Coordination.** Task configs and their cron timers live in the [memory](../memory) socket (`memory/lib/scheduledTasks.js`) via `memory.client("TASK SCHEDULER")`, so a pm2 cluster shares one authoritative task registry. When a timer ticks, memory emits the task `id` and this service's handler performs the outbound HTTP call. `/memory/status` uses the same socket as a liveness probe.
-
-**Persistence.** Every fire records a row in the `task_runs` Postgres table (`task_id`, `url`, `status`, `http_status`, `error`, `ran_at`; created by `chimera/prepareDatabase.js`) and emits a webhook alert (see `alert_URL` in [../env.example](../env.example)). On the primary pm2 instance, `startDbPruning()` runs every 12h and deletes `task_runs` rows older than 30 days.
-
-**Auto-cleanup.** On the primary instance, when `storage_MAX_GB` is set, `autoRegisterCleanup()` registers a protected hourly task (`task-auto-cleanup` → `/file/pathAutoClean`) that trims oldest footage; being protected, it cannot be stopped or destroyed through the API.
-
-Relevant env keys (see [../env.example](../env.example)): `schedule_ON`, `schedule_PORT`, `schedule_HOST`, `schedule_PROXY_ON`, `scheduler_AUTH`, `gateway_HOST`, `storage_MAX_GB`.
+- `schedule_ON`, `schedule_PORT`, `schedule_HOST`, `schedule_PROXY_ON`, `scheduler_AUTH`, `gateway_HOST`, `storage_MAX_GB`; see [../env.example](../env.example).

--- a/schedule/README.md
+++ b/schedule/README.md
@@ -3,58 +3,11 @@
 Runs cron-based tasks for the other servers: each tick fires an authenticated HTTP call to a whitelisted service route and records the outcome.
 
 ---
-# Routes
-## ▶ /task
+# API
 
-All `/task` routes need a session (`authorize`); `/start`, `/stop`, `/destroy` also require `admin` (`requireAdmin`).
+Session-guarded (`authorize`); starting, stopping, and destroying tasks additionally require admin (`requireAdmin`). `/schedule/health` is public.
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|POST|/start|Schedule a task. `url` must be whitelisted, `body` a JSON string. A stopped `id` restarts it; already-running no-ops|`{ url: String, body: JSON-String, cronString: String }` for a new task, or `{ id: String }` to restart|`{ running: Boolean }`|
-|GET|/list|List all scheduled tasks|None|`{ tasks: [TaskObj] }`|
-|POST|/stop|Stop a task; protected tasks rejected|`{ id: String }`|`{ stopped: Boolean }`|
-|POST|/destroy|Destroy a task; protected tasks rejected|`{ id: String }`|`{ destroyed: Boolean }`|
-|GET|/runs|Run history across all tasks (latest 200, newest first)|None|`{ runs: [RunObj] }`|
-|GET|/runs/:taskId|Run history for one task (latest 200, newest first)|`taskId` path param|`{ runs: [RunObj] }`|
-
-```javascript
-// id = task-[RandomAlphaNumeric]
-
-//TaskObj
-{
-    id: String, // id
-    url: String,
-    body: Object,
-    cronString: String,
-    running: Boolean,
-    protected: Boolean // true for the internal auto-cleanup task
-}
-
-//RunObj (a task_runs row)
-{
-    id: Number,
-    task_id: String,
-    url: String,
-    status: String, // "success" | "failure"
-    http_status: Number,
-    error: String,
-    ran_at: String // TIMESTAMPTZ
-}
-```
-
-## ▶ /memory
-
-Needs a session (`authorize`).
-
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/status|Round-trips the [memory](../memory) socket to check coordination is responsive|None|`{}`|
-
-## ▶ /schedule
-
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/health|Confirms server alive|N/A|N/A|
+The API schedules, lists, stops, and destroys cron tasks, and reads run history from `task_runs` (per task or across all, newest first). A new task's `url` must be whitelisted (see Behavior) and carry a JSON-string body; protected tasks — the internal auto-cleanup — can't be stopped or destroyed. A separate endpoint round-trips the [memory](../memory) socket to check cluster coordination is responsive.
 
 ---
 # Behavior

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,8 +1,8 @@
 # Storage <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-Saves motion-detected camera frames, serves them, generates downloadable videos and zip archives, and handles file deletion, metrics, and stats.
+Saves motion-detected camera frames, serves them, builds downloadable videos/zips, and handles deletion, metrics, and stats.
 
-Run storage on the same machine as [motion](https://github.com/Motion-Project/motion), which saves RTSP frames and writes each frame's name and size to the `frame_files` table. Motion's `sql_query` can't capture file size, so `on_picture_save` shells out:
+Runs on the same machine as [motion](https://github.com/Motion-Project/motion), which saves RTSP frames and logs each to `frame_files`. Motion can't capture file size in `sql_query`, so `on_picture_save` shells out:
 
 ```
 picture_type jpeg
@@ -11,23 +11,27 @@ picture_filename %t/%Y%m%d-%H%M%S-%q
 on_picture_save SZ=$(wc -c %f | head -n1 | awk '{print $1;}'); PGPASSWORD="$database_PASSWORD" psql -h postgres -U "$database_USER" -d "$database_NAME" -c "INSERT INTO frame_files(timestamp, camera, name, size) VALUES(now(), %t, '%Y%m%d-%H%M%S-%q.jpg', $SZ);"
 ```
 
-`postgresql-client` ships in the chimera image; `database_*` come from `.env`. Full Docker-ready config: [`motion.conf.example`](../motion.conf.example). [ffmpeg](https://ffmpeg.org) is required for video generation.
+`postgresql-client` ships in the image; `database_*` from `.env`. Full config: [motion.conf.example](../motion.conf.example). Needs [ffmpeg](https://ffmpeg.org) for video generation.
 
 ---
 # API
 
-Routes are session-guarded (`authorize`); creating videos and zips, deleting files, and quota cleanup additionally require admin (`requireAdmin`). `/storage/health` is public.
+Session-guarded (`authorize`) except `/storage/health`; video/zip creation, deletion, and quota cleanup also require admin (`requireAdmin`):
 
-The API browses and serves saved frames, reports storage usage plus per-camera size/count and time-series stats, builds and manages downloadable videos and zips from frames by timestamp (then serves them for download), deletes camera files and rows, enforces the `storage_MAX_GB` quota, and checks the bundled motion process and Postgres connectivity.
+- browse and serve saved frames
+- storage usage, per-camera size/count, time-series stats
+- build/manage downloadable videos and zips by timestamp, then serve them
+- delete camera files and rows; enforce the `storage_MAX_GB` quota
+- check the motion process and Postgres connectivity
 
 ---
 # Runtime
 
-- `server.js` runs storage under pm2 when `storage_ON=true` (port `storage_PORT`); pm2 also launches the bundled `motion` process. [gateway](../gateway) proxies it when `storage_PROXY_ON=true`.
-- `frame_deletes` logs deleted size/count; on the prime pm2 instance `startDbPruning` prunes its rows older than 30 days.
-- [schedule](../schedule) periodically POSTs `/file/pathAutoClean` when `storage_MAX_GB` is set.
+- Root `server.js` runs storage + the bundled `motion` under pm2 when `storage_ON=true`; [gateway](../gateway) proxies when `storage_PROXY_ON=true`.
+- `frame_deletes` logs quota deletions; the prime instance prunes rows older than 30 days.
+- [schedule](../schedule) POSTs `/file/pathAutoClean` when `storage_MAX_GB` is set.
 
 ---
 # Config
 
-- `storage_*`, `database_*`, `storage_FOLDERPATH`, `storage_MAX_GB`, alert webhook keys; see [../env.example](../env.example).
+`storage_*`, `database_*`, `storage_FOLDERPATH`, `storage_MAX_GB`, alert webhook keys; see [../env.example](../env.example).

--- a/storage/README.md
+++ b/storage/README.md
@@ -14,92 +14,11 @@ on_picture_save SZ=$(wc -c %f | head -n1 | awk '{print $1;}'); PGPASSWORD="$data
 `postgresql-client` ships in the chimera image; `database_*` come from `.env`. Full Docker-ready config: [`motion.conf.example`](../motion.conf.example). [ffmpeg](https://ffmpeg.org) is required for video generation.
 
 ---
-# Routes
+# API
 
-`auth` = session (`authorize`); `admin` = session + admin (`requireAdmin`); `none` = public.
+Routes are session-guarded (`authorize`); creating videos and zips, deleting files, and quota cleanup additionally require admin (`requireAdmin`). `/storage/health` is public.
 
-## ▶ /
-
-Mounted at the root (`routes/events.js`).
-
-|Type|Route|Auth|Description|Parameters|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|GET|/events|auth|Paginated frames for a camera on a date|Query `camera_id`, `date` (`YYYY-MM-DD`), `page`, `per_page` (max 1000)|`{ events: [{ id, timestamp, name, size }], total, page, per_page }`|
-|GET|/frames/:camera_id/:filename|auth|Serves a frame image|Path `camera_id`, `filename`|jpg (400 if `camera_id` non-numeric or `filename` invalid; 404 if missing)|
-|GET|/usage|auth|Usage summary across cameras and artifact types|None|`{ used_gb, max_gb, cameras: [{ id, name, used_gb, frame_count }], total_frames, breakdown: { frames, videos, zips, objects, other } }`|
-|DELETE|/camera/:id|admin|Purge a camera's frames, `objects_detected` rows, and files|Path `id`|`{ deleted: true }`|
-
-## ▶ /motion
-
-|Type|Route|Auth|Description|Parameters|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|GET|/status|auth|pm2 status of the bundled motion process|None|`[{ name, status, restarts }]`, or 204 if not running|
-
-## ▶ /database
-
-|Type|Route|Auth|Description|Parameters|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|GET|/status|auth|Postgres connectivity check (`SELECT 2 + 2`)|None|200 `{}` if healthy, else 204|
-
-## ▶ /convert
-
-|Type|Route|Auth|Description|Parameters|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|POST|/createVideo|admin|Create video from frames by timestamp|`{ camera: Number, fps: Number, save: Boolean, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, skip: Number }`|`{ id: String, url: String, frameLimitMet: Boolean }`|
-|POST|/listFramesVideo|auth|List frame links for scrubbing|`{ camera: Number, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, frames: Number }`|`{ list: [ String ] }`|
-|POST|/createZip|admin|Create zip archive from frames by timestamp|`{ camera: Number, save: Boolean, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, skip: Number }`|`{ id: String, url: String, frameLimitMet: Boolean }`|
-|POST|/statusProcess|admin|Status of a video/zip process|`{ id: String }`|`{ running: Boolean, id: String }`|
-|POST|/cancelProcess|admin|Cancel a running video/zip process|`{ id: String }`|`{ cancelled: Boolean, id: String }`|
-|GET|/listProcess|auth|List all processes|None|`{ list: [ ProcessObj ] }`|
-|POST|/deleteProcess|admin|Delete a video/zip by ID|`{ id: String }`|`{ deleted: Boolean, id: String }`|
-
-### ProcessObj
-
-```javascript
-// fileName = output_[cameraNumber]_[startDateTime]_[endDateTime]_[ID].[type]
-
-// id = [RandomAlphaNumeric]-[requestDateTime]
-
-// dateTime = YYYYMMDD-hhmmss (0-23 hour clock)
-
-//ProcessObj
-{
-    link: String // gateway_HOST/shared/captures/[fileName]
-    type: String // mp4, zip, etc
-    id: String, // id
-    requested: String, //dateTime
-    camera: Number,
-    start: String,  // dateTime,
-    end: String, //dateTime,
-    running: Boolean,
-    size: Number // bytes, null if the file stat failed
-}
-```
-
-## ▶ /file
-
-|Type|Route|Auth|Description|Parameters|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|POST|/pathSize|auth|Folder or file size|`{ camera: Number }`|`{ size: String }`|
-|POST|/pathFileCount|auth|Folder file count|`{ camera: Number }`|`{ count: String }`|
-|POST|/pathDelete|admin|Delete a camera's folder and frame rows (records to `frame_deletes`)|`{ camera: Number }`|`{ deleted: Boolean }`|
-|POST|/pathClean|admin|Delete a camera's files older than N days (records to `frame_deletes`)|`{ camera: Number, days: Number }`|`{ deleted: Boolean }`|
-|GET|/pathStats|auth|Hourly totals of stored bytes per camera (all time)|None|`[{ timestamp: Number, [camera_name]: Number }]`|
-|GET|/dailyStats|auth|Per-minute totals of stored bytes per camera over last 24h|None|`[{ timestamp: Number, [camera_name]: Number }]`|
-|POST|/pathMetrics|auth|Per-camera total size and frame count|None|`{ size: { [camera_name]: String }, count: { [camera_name]: String } }`|
-|POST|/pathAutoClean|admin|Enforce `storage_MAX_GB`: when capture+object usage exceeds 90% of cap, delete oldest frames (disk + `frame_files`) until under target; alerts admin webhook if non-frame artifacts dominate|None|`{ cleaned: Boolean, deleted: Number }` / `{ skipped: true }` / `{ cleaned: false }`|
-
-## ▶ /shared
-
-|Type|Route|Auth|Description|Parameters|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|GET|/directory/example.mp4|auth|Downloads the specified file|None|mp4|
-
-## ▶ /storage
-
-|Type|Route|Auth|Description|Parameters|Returns|
-| :-|:- |:-:|:-|:-:|:-:|
-|GET|/health|none|Confirms server alive|N/A|N/A|
+The API browses and serves saved frames, reports storage usage plus per-camera size/count and time-series stats, builds and manages downloadable videos and zips from frames by timestamp (then serves them for download), deletes camera files and rows, enforces the `storage_MAX_GB` quota, and checks the bundled motion process and Postgres connectivity.
 
 ---
 # Runtime

--- a/storage/README.md
+++ b/storage/README.md
@@ -20,11 +20,29 @@ on_picture_save SZ=$(wc -c %f | head -n1 | awk '{print $1;}'); PGPASSWORD="$data
 ---
 # Routes
 
+## ▶ /
+
+Mounted at the root (`routes/events.js`).
+
+|Type|Route|Description|Parameters|Returns|
+| :-|:- |:-:|:-:|:-:|
+|GET|/events|Paginated list of saved frames for a camera on a date|Query `camera_id`, `date` (`YYYY-MM-DD`), `page`, `per_page` (max 1000)|`{ events: [{ id, timestamp, name, size }], total, page, per_page }`|
+|GET|/frames/:camera_id/:filename|Serves a saved frame image|Path `camera_id`, `filename`|jpg (400 if `camera_id` non-numeric or `filename` invalid; 404 if missing)|
+|GET|/usage|Storage usage summary across cameras and artifact types|None|`{ used_gb, max_gb, cameras: [{ id, name, used_gb, frame_count }], total_frames, breakdown: { frames, videos, zips, objects, other } }`|
+|DELETE|/camera/:id|Purge a camera's frames, detected objects, and files|Path `id`|`{ deleted: true }`|
+
 ## ▶ /motion
 
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|GET|/status| | | |
+|GET|/status|pm2 status of the bundled motion process|None|`[{ name, status, restarts }]`, or 204 if not running|
+
+## ▶ /database
+
+|Type|Route|Description|Parameters|Returns|
+| :-|:- |:-:|:-:|:-:|
+|GET|/status|Postgres connectivity check (`SELECT 2 + 2`)|None|200 `{}` if healthy, else 204|
+
 ## ▶ /convert
 
 |Type|Route|Description|Parameters|Returns|
@@ -48,14 +66,15 @@ on_picture_save SZ=$(wc -c %f | head -n1 | awk '{print $1;}'); PGPASSWORD="$data
 
 //ProcessObj
 {
-    link: String // /shared/captures/[fileName]
+    link: String // gateway_HOST/shared/captures/[fileName]
     type: String // mp4, zip, etc
     id: String, // id
     requested: String, //dateTime
     camera: Number,
     start: String,  // dateTime,
     end: String, //dateTime,
-    running: Boolean
+    running: Boolean,
+    size: Number // bytes, null if the file stat failed
 }
 ```
 
@@ -63,12 +82,14 @@ on_picture_save SZ=$(wc -c %f | head -n1 | awk '{print $1;}'); PGPASSWORD="$data
 
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
-|POST|/pathStats|Gets addition stats| | |
 |POST|/pathSize|Gets folder or file size|`{ camera: Number }`|`{ size: String }`|
-|POST|/pathFileCount|Gets folder's file count|`{ camera: Number }`|`{ count: Number }`|
-|POST|/pathMetrics| | | |
-|POST|/pathDelete|Delete folder or file by path|`{ camera: Number }`|`{ deleted: Boolean }`|
-|POST|/pathClean|Deletes older files or files in directory given a number of days|`{ camera: Number, days: Number }`|`{ deleted: Boolean }`|
+|POST|/pathFileCount|Gets folder's file count|`{ camera: Number }`|`{ count: String }`|
+|POST|/pathDelete|Delete a camera's folder and its frame rows (records to `frame_deletes`)|`{ camera: Number }`|`{ deleted: Boolean }`|
+|POST|/pathClean|Delete a camera's files older than N days (records to `frame_deletes`)|`{ camera: Number, days: Number }`|`{ deleted: Boolean }`|
+|GET|/pathStats|Hourly totals of stored bytes per camera (all time)|None|`[{ timestamp: Number, [camera_name]: Number }]`|
+|GET|/dailyStats|Per-minute totals of stored bytes per camera over the last 24h|None|`[{ timestamp: Number, [camera_name]: Number }]`|
+|POST|/pathMetrics|Per-camera total size and frame count|None|`{ size: { [camera_name]: String }, count: { [camera_name]: String } }`|
+|POST|/pathAutoClean|Enforce `storage_MAX_GB`: when capture+object usage exceeds 90% of the cap, delete the oldest frames (disk + `frame_files`) until under target; alerts the admin webhook if non-frame artifacts dominate|None|`{ cleaned: Boolean, deleted: Number }` / `{ skipped: true }` / `{ cleaned: false }`|
 
 ## ▶ /shared
 
@@ -81,3 +102,14 @@ on_picture_save SZ=$(wc -c %f | head -n1 | awk '{print $1;}'); PGPASSWORD="$data
 |Type|Route|Description|Parameters|Returns|
 | :-|:- |:-:|:-:|:-:|
 |GET|/health|Confirms server alive|N/A|N/A|
+
+---
+# How it fits
+
+`server.js` starts storage under pm2 when `storage_ON=true` (listening on `storage_PORT`); pm2 also launches the bundled `motion` process, which writes a row to `frame_files` for every saved frame. The [gateway](../gateway) proxies it when `storage_PROXY_ON=true`.
+
+Every route except `/storage/health` sits behind `auth.createAuthorize(pool)` from [lib](../lib), so a valid session is required; a subset additionally uses `requireAdmin` (`/convert` mutations — createVideo/createZip/statusProcess/cancelProcess/deleteProcess, `/file/pathDelete`, `/file/pathClean`, `/file/pathAutoClean`, and `DELETE /camera/:id`).
+
+Postgres usage: reads/writes `frame_files` (per-frame rows written by motion), writes `frame_deletes` (deletion audit of size/count) from `pathDelete`/`pathClean`, and deletes matching `objects_detected` rows when purging a camera. On the prime pm2 instance, storage prunes `frame_deletes` rows older than 30 days (`startDbPruning`). The [schedule](../schedule) service periodically POSTs `/file/pathAutoClean` when `storage_MAX_GB` is set, enforcing the quota.
+
+Config comes from `storage_*`, `database_*`, `storage_FOLDERPATH`, `storage_MAX_GB`, and the alert webhook keys — see [../env.example](../env.example).

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,12 +1,8 @@
 # Storage <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-The storage server handles file storage:
-1. Saving motion-detected camera images
-2. Generating videos and archives for download
-3. File deletion, metrics, and stats
-4. Serving those files
+Saves motion-detected camera frames, serves them, generates downloadable videos and zip archives, and handles file deletion, metrics, and stats.
 
-Run storage on the same machine as [motion](https://github.com/Motion-Project/motion), which saves RTSP frames and writes each one (with size) to the `frame_files` table. Motion's `sql_query` can't capture file size, so we shell out via `on_picture_save`:
+Run storage on the same machine as [motion](https://github.com/Motion-Project/motion), which saves RTSP frames and writes each frame's name and size to the `frame_files` table. Motion's `sql_query` can't capture file size, so `on_picture_save` shells out:
 
 ```
 picture_type jpeg
@@ -15,45 +11,47 @@ picture_filename %t/%Y%m%d-%H%M%S-%q
 on_picture_save SZ=$(wc -c %f | head -n1 | awk '{print $1;}'); PGPASSWORD="$database_PASSWORD" psql -h postgres -U "$database_USER" -d "$database_NAME" -c "INSERT INTO frame_files(timestamp, camera, name, size) VALUES(now(), %t, '%Y%m%d-%H%M%S-%q.jpg', $SZ);"
 ```
 
-`postgresql-client` ships in the chimera image; `database_*` come from `.env`. See [`motion.conf.example`](../motion.conf.example) for the full Docker-ready config. [ffmpeg](https://ffmpeg.org) is required for generating videos.
+`postgresql-client` ships in the chimera image; `database_*` come from `.env`. Full Docker-ready config: [`motion.conf.example`](../motion.conf.example). [ffmpeg](https://ffmpeg.org) is required for video generation.
 
 ---
 # Routes
+
+`auth` = session (`authorize`); `admin` = session + admin (`requireAdmin`); `none` = public.
 
 ## ▶ /
 
 Mounted at the root (`routes/events.js`).
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/events|Paginated list of saved frames for a camera on a date|Query `camera_id`, `date` (`YYYY-MM-DD`), `page`, `per_page` (max 1000)|`{ events: [{ id, timestamp, name, size }], total, page, per_page }`|
-|GET|/frames/:camera_id/:filename|Serves a saved frame image|Path `camera_id`, `filename`|jpg (400 if `camera_id` non-numeric or `filename` invalid; 404 if missing)|
-|GET|/usage|Storage usage summary across cameras and artifact types|None|`{ used_gb, max_gb, cameras: [{ id, name, used_gb, frame_count }], total_frames, breakdown: { frames, videos, zips, objects, other } }`|
-|DELETE|/camera/:id|Purge a camera's frames, detected objects, and files|Path `id`|`{ deleted: true }`|
+|Type|Route|Auth|Description|Parameters|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|GET|/events|auth|Paginated frames for a camera on a date|Query `camera_id`, `date` (`YYYY-MM-DD`), `page`, `per_page` (max 1000)|`{ events: [{ id, timestamp, name, size }], total, page, per_page }`|
+|GET|/frames/:camera_id/:filename|auth|Serves a frame image|Path `camera_id`, `filename`|jpg (400 if `camera_id` non-numeric or `filename` invalid; 404 if missing)|
+|GET|/usage|auth|Usage summary across cameras and artifact types|None|`{ used_gb, max_gb, cameras: [{ id, name, used_gb, frame_count }], total_frames, breakdown: { frames, videos, zips, objects, other } }`|
+|DELETE|/camera/:id|admin|Purge a camera's frames, `objects_detected` rows, and files|Path `id`|`{ deleted: true }`|
 
 ## ▶ /motion
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/status|pm2 status of the bundled motion process|None|`[{ name, status, restarts }]`, or 204 if not running|
+|Type|Route|Auth|Description|Parameters|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|GET|/status|auth|pm2 status of the bundled motion process|None|`[{ name, status, restarts }]`, or 204 if not running|
 
 ## ▶ /database
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/status|Postgres connectivity check (`SELECT 2 + 2`)|None|200 `{}` if healthy, else 204|
+|Type|Route|Auth|Description|Parameters|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|GET|/status|auth|Postgres connectivity check (`SELECT 2 + 2`)|None|200 `{}` if healthy, else 204|
 
 ## ▶ /convert
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|POST|/createVideo|Creates videos from images based on timestamps|`{ camera: Number, fps: Number, save: Boolean, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, skip: Number }`|`{ id: String, url: String, frameLimitMet: Boolean }`|
-|POST|/listFramesVideo|Sends a list of links to images for scrubbing|`{ camera: Number, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, frames: Number }`|`{ list: [ String ] }`|
-|POST|/createZip|Creates zip archive from images based on timestamps|`{ camera: Number, save: Boolean, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, skip: Number }`|`{ id: String, url: String, frameLimitMet: Boolean }`|
-|POST|/statusProcess|Get status of video or zip process|`{ id: String }`|`{ running: Boolean, id: String }`|
-|POST|/cancelProcess|Cancel running video or zip process|`{ id: String }`|`{ cancelled: Boolean, id: String }`|
-|GET|/listProcess|Get list of all processes|None|`{ list: [ ProcessObj ] }`|
-|POST|/deleteProcess|Delete video or zip by given ID|`{ id: String }`|`{ deleted: Boolean, id: String }`|
+|Type|Route|Auth|Description|Parameters|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|POST|/createVideo|admin|Create video from frames by timestamp|`{ camera: Number, fps: Number, save: Boolean, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, skip: Number }`|`{ id: String, url: String, frameLimitMet: Boolean }`|
+|POST|/listFramesVideo|auth|List frame links for scrubbing|`{ camera: Number, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, frames: Number }`|`{ list: [ String ] }`|
+|POST|/createZip|admin|Create zip archive from frames by timestamp|`{ camera: Number, save: Boolean, start: Date or YYYYMMDD-HHMMSS, end: Date or YYYYMMDD-HHMMSS, skip: Number }`|`{ id: String, url: String, frameLimitMet: Boolean }`|
+|POST|/statusProcess|admin|Status of a video/zip process|`{ id: String }`|`{ running: Boolean, id: String }`|
+|POST|/cancelProcess|admin|Cancel a running video/zip process|`{ id: String }`|`{ cancelled: Boolean, id: String }`|
+|GET|/listProcess|auth|List all processes|None|`{ list: [ ProcessObj ] }`|
+|POST|/deleteProcess|admin|Delete a video/zip by ID|`{ id: String }`|`{ deleted: Boolean, id: String }`|
 
 ### ProcessObj
 
@@ -80,36 +78,37 @@ Mounted at the root (`routes/events.js`).
 
 ## ▶ /file
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|POST|/pathSize|Gets folder or file size|`{ camera: Number }`|`{ size: String }`|
-|POST|/pathFileCount|Gets folder's file count|`{ camera: Number }`|`{ count: String }`|
-|POST|/pathDelete|Delete a camera's folder and its frame rows (records to `frame_deletes`)|`{ camera: Number }`|`{ deleted: Boolean }`|
-|POST|/pathClean|Delete a camera's files older than N days (records to `frame_deletes`)|`{ camera: Number, days: Number }`|`{ deleted: Boolean }`|
-|GET|/pathStats|Hourly totals of stored bytes per camera (all time)|None|`[{ timestamp: Number, [camera_name]: Number }]`|
-|GET|/dailyStats|Per-minute totals of stored bytes per camera over the last 24h|None|`[{ timestamp: Number, [camera_name]: Number }]`|
-|POST|/pathMetrics|Per-camera total size and frame count|None|`{ size: { [camera_name]: String }, count: { [camera_name]: String } }`|
-|POST|/pathAutoClean|Enforce `storage_MAX_GB`: when capture+object usage exceeds 90% of the cap, delete the oldest frames (disk + `frame_files`) until under target; alerts the admin webhook if non-frame artifacts dominate|None|`{ cleaned: Boolean, deleted: Number }` / `{ skipped: true }` / `{ cleaned: false }`|
+|Type|Route|Auth|Description|Parameters|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|POST|/pathSize|auth|Folder or file size|`{ camera: Number }`|`{ size: String }`|
+|POST|/pathFileCount|auth|Folder file count|`{ camera: Number }`|`{ count: String }`|
+|POST|/pathDelete|admin|Delete a camera's folder and frame rows (records to `frame_deletes`)|`{ camera: Number }`|`{ deleted: Boolean }`|
+|POST|/pathClean|admin|Delete a camera's files older than N days (records to `frame_deletes`)|`{ camera: Number, days: Number }`|`{ deleted: Boolean }`|
+|GET|/pathStats|auth|Hourly totals of stored bytes per camera (all time)|None|`[{ timestamp: Number, [camera_name]: Number }]`|
+|GET|/dailyStats|auth|Per-minute totals of stored bytes per camera over last 24h|None|`[{ timestamp: Number, [camera_name]: Number }]`|
+|POST|/pathMetrics|auth|Per-camera total size and frame count|None|`{ size: { [camera_name]: String }, count: { [camera_name]: String } }`|
+|POST|/pathAutoClean|admin|Enforce `storage_MAX_GB`: when capture+object usage exceeds 90% of cap, delete oldest frames (disk + `frame_files`) until under target; alerts admin webhook if non-frame artifacts dominate|None|`{ cleaned: Boolean, deleted: Number }` / `{ skipped: true }` / `{ cleaned: false }`|
 
 ## ▶ /shared
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/directory/example.mp4|Downloads the specified file|None|mp4|
+|Type|Route|Auth|Description|Parameters|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|GET|/directory/example.mp4|auth|Downloads the specified file|None|mp4|
 
 ## ▶ /storage
 
-|Type|Route|Description|Parameters|Returns|
-| :-|:- |:-:|:-:|:-:|
-|GET|/health|Confirms server alive|N/A|N/A|
+|Type|Route|Auth|Description|Parameters|Returns|
+| :-|:- |:-:|:-|:-:|:-:|
+|GET|/health|none|Confirms server alive|N/A|N/A|
 
 ---
-# How it fits
+# Runtime
 
-`server.js` starts storage under pm2 when `storage_ON=true` (listening on `storage_PORT`); pm2 also launches the bundled `motion` process, which writes a row to `frame_files` for every saved frame. The [gateway](../gateway) proxies it when `storage_PROXY_ON=true`.
+- `server.js` runs storage under pm2 when `storage_ON=true` (port `storage_PORT`); pm2 also launches the bundled `motion` process. [gateway](../gateway) proxies it when `storage_PROXY_ON=true`.
+- `frame_deletes` logs deleted size/count; on the prime pm2 instance `startDbPruning` prunes its rows older than 30 days.
+- [schedule](../schedule) periodically POSTs `/file/pathAutoClean` when `storage_MAX_GB` is set.
 
-Every route except `/storage/health` sits behind `auth.createAuthorize(pool)` from [lib](../lib), so a valid session is required; a subset additionally uses `requireAdmin` (`/convert` mutations — createVideo/createZip/statusProcess/cancelProcess/deleteProcess, `/file/pathDelete`, `/file/pathClean`, `/file/pathAutoClean`, and `DELETE /camera/:id`).
+---
+# Config
 
-Postgres usage: reads/writes `frame_files` (per-frame rows written by motion), writes `frame_deletes` (deletion audit of size/count) from `pathDelete`/`pathClean`, and deletes matching `objects_detected` rows when purging a camera. On the prime pm2 instance, storage prunes `frame_deletes` rows older than 30 days (`startDbPruning`). The [schedule](../schedule) service periodically POSTs `/file/pathAutoClean` when `storage_MAX_GB` is set, enforcing the quota.
-
-Config comes from `storage_*`, `database_*`, `storage_FOLDERPATH`, `storage_MAX_GB`, and the alert webhook keys — see [../env.example](../env.example).
+- `storage_*`, `database_*`, `storage_FOLDERPATH`, `storage_MAX_GB`, alert webhook keys; see [../env.example](../env.example).


### PR DESCRIPTION
Closes #219 (expanded scope).

PR #178 (the develop→master overhaul) shipped a new auth/RBAC layer, an SPA rewrite, and a `chimera/` bootstrap/preflight layer, but the docs were never updated. This rewrites **every** README to accurately describe the system as it exists after #178, grounded in the actual code.

## Files
| File | Change |
|---|---|
| `command/README.md` | All 13 `/authorization` routes (was 3) with per-route auth (`none`/`auth`/`admin`); stale page-route table replaced with the SPA sections + RBAC gating; documented the auth-gated `/cameras` route. |
| `README.md` (root) | Added an **Architecture** section (one Node process under pm2, Docker boot chain, Postgres side container, schema) and a **First run** admin-bootstrap note; wired in `lib` + `chimera` and `npm run preflight`. |
| `chimera/README.md` | **New.** Documents the bootstrap layer: `validateEnvVars.js`, `prepareDatabase.js` (all tables/indexes), and the `preflight.js` wizard + the `entrypoint.sh` boot chain. |
| `gateway/README.md` | Reverse-proxy model, per-service `<prefix>_PROXY_ON` routing table, ports/TLS, HTTPS redirect, ACME challenge serving; replaced the stale `services.js` snippet. |
| `lib/README.md` | Expanded from one line to a full export reference (auth middleware, `loadCameras`, `webhookAlert`, `pruneInterval`, etc.). |
| `livestream/README.md` | Clarified ffmpeg-does-the-transcoding division of labor; filled in `/status` routes + auth. |
| `memory/README.md` | Expanded to describe the Socket.IO shared-state broker, its modules/events, `memory_AUTH_TOKEN`, and prime-instance gating. |
| `object/README.md` | Verified/corrected route table + auth; noted `objects_detected` persistence and memory-socket brokering. |
| `schedule/README.md` | Documented all `/task` routes (incl. `/runs`), `scheduler_AUTH` allowlist, `task_runs` persistence, memory coordination, and the protected auto-cleanup task. |
| `storage/README.md` | Added the undocumented `events`/`database` route groups, filled blank cells, documented the `storage_MAX_GB` quota job and `frame_files`/`frame_deletes`. |

## Verification
Produced with a draft → adversarial-verify → revise pipeline (one pass per file), every route/method/middleware/env/table claim cross-checked against the source. Cross-service claims were additionally confirmed by hand: `predocker:*` runs `preflight --check` (`package.json`); the hourly `/file/pathAutoClean` quota task and the `scheduler_AUTH` allowlist (`schedule/backend/routes/lib/scheduler.js`, `lib/utils/auth.js`).