### PR TITLE
Fix session cache revocation bypass and memory leak

### DIFF
--- a/chimera/prepareDatabase.js
+++ b/chimera/prepareDatabase.js
@@ -45,6 +45,10 @@ const creationTasks = [
 		query: "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_task_runs_ran_at ON task_runs(ran_at);",
 		description: "task runs (ran_at) index"
 	},
+	{
+		query: "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sessions_username ON sessions(username);",
+		description: "sessions (username) index"
+	},
 ]
 
 module.exports = { creationTasks }

--- a/chimera/test/prepareDatabase.test.js
+++ b/chimera/test/prepareDatabase.test.js
@@ -19,7 +19,7 @@ describe("prepareDatabase migration tasks", () => {
 
 	test("builds the camera/timestamp indexes concurrently and idempotently", () => {
 		const idx = creationTasks.filter(t => /CREATE INDEX/.test(t.query))
-		expect(idx).toHaveLength(3)
+		expect(idx).toHaveLength(4)
 		for (const t of idx) {
 			expect(t.query).toMatch(/CREATE INDEX CONCURRENTLY IF NOT EXISTS/)
 		}

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -89,6 +89,7 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 			)
 		})
 		if (result.rowCount === 0) return res.status(403).json({ error: true })
+		auth.invalidateAllSessions(pool)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -177,6 +178,7 @@ app.patch("/users/:username", authorize, requireAdmin, validateBody, async (req,
 			await client.query(`UPDATE auth SET ${updates.join(", ")} WHERE username = $${values.length}`, values)
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})
+		auth.invalidateAllSessions(pool)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -200,8 +202,9 @@ app.delete("/sessions/:id", authorize, requireAdmin, async (req, res) => {
 	const id = parseInt(req.params.id)
 	if (isNaN(id)) return res.status(400).json({ error: true })
 	try {
-		const result = await pool.query("UPDATE sessions SET revoked = TRUE WHERE id = $1 RETURNING id", [id])
+		const result = await pool.query("UPDATE sessions SET revoked = TRUE WHERE id = $1 RETURNING jti", [id])
 		if (result.rowCount === 0) return res.status(404).json({ error: true })
+		auth.invalidateSession(pool, result.rows[0].jti)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -221,6 +224,7 @@ app.delete("/users/:username", authorize, requireAdmin, async (req, res) => {
 			}
 			await client.query("DELETE FROM auth WHERE username = $1", [username])
 		})
+		auth.invalidateAllSessions(pool)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -238,6 +242,7 @@ app.post("/password", authorize, validateBody, async (req, res) => {
 			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2", [hash, username])
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})
+		auth.invalidateAllSessions(pool)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -248,6 +253,7 @@ app.post("/logout", authorize, async (req, res) => {
 	try {
 		if (req.decoded?.jti) {
 			await pool.query("UPDATE sessions SET revoked = TRUE WHERE jti = $1", [req.decoded.jti])
+			auth.invalidateSession(pool, req.decoded.jti)
 		}
 		res.clearCookie("bearertoken", { httpOnly: true, secure: process.env.NODE_ENV !== "development", sameSite: "lax" })
 		res.json({ error: false })

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -89,7 +89,7 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 			)
 		})
 		if (result.rowCount === 0) return res.status(403).json({ error: true })
-		auth.invalidateAllSessions(pool)
+		auth.invalidateAllSessions()
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -178,7 +178,7 @@ app.patch("/users/:username", authorize, requireAdmin, validateBody, async (req,
 			await client.query(`UPDATE auth SET ${updates.join(", ")} WHERE username = $${values.length}`, values)
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})
-		auth.invalidateAllSessions(pool)
+		auth.invalidateAllSessions()
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -204,7 +204,7 @@ app.delete("/sessions/:id", authorize, requireAdmin, async (req, res) => {
 	try {
 		const result = await pool.query("UPDATE sessions SET revoked = TRUE WHERE id = $1 RETURNING jti", [id])
 		if (result.rowCount === 0) return res.status(404).json({ error: true })
-		auth.invalidateSession(pool, result.rows[0].jti)
+		auth.invalidateSession(result.rows[0].jti)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -224,7 +224,7 @@ app.delete("/users/:username", authorize, requireAdmin, async (req, res) => {
 			}
 			await client.query("DELETE FROM auth WHERE username = $1", [username])
 		})
-		auth.invalidateAllSessions(pool)
+		auth.invalidateAllSessions()
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -242,7 +242,7 @@ app.post("/password", authorize, validateBody, async (req, res) => {
 			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2", [hash, username])
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})
-		auth.invalidateAllSessions(pool)
+		auth.invalidateAllSessions()
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -253,7 +253,7 @@ app.post("/logout", authorize, async (req, res) => {
 	try {
 		if (req.decoded?.jti) {
 			await pool.query("UPDATE sessions SET revoked = TRUE WHERE jti = $1", [req.decoded.jti])
-			auth.invalidateSession(pool, req.decoded.jti)
+			auth.invalidateSession(req.decoded.jti)
 		}
 		res.clearCookie("bearertoken", { httpOnly: true, secure: process.env.NODE_ENV !== "development", sameSite: "lax" })
 		res.json({ error: false })

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -21,6 +21,7 @@ const sendError = (res, e) => {
 
 const sharedAttempts = process.env.memory_ON == "true"
 const memoryClient = sharedAttempts ? memory.client("AUTH") : null
+if (memoryClient) auth.connectSessionSync(memoryClient)
 
 const rateLimit = ({ windowMs, max }) => {
 	const local = memory.loginAttempts()

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -16,7 +16,7 @@ const { mockedPool } = require("pg")
 describe("Authorization Routes", () => {
 	beforeEach(() => {
 		delete process.env.setup_TOKEN
-		auth.invalidateAllSessions(mockedPool)
+		auth.invalidateAllSessions()
 	})
 
 	describe("GET /authorization/status", () => {

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -19,6 +19,8 @@ describe("Authorization Routes", () => {
 		auth.invalidateAllSessions()
 	})
 
+	afterEach(() => jest.restoreAllMocks())
+
 	describe("GET /authorization/status", () => {
 		test("returns setup: false when table is empty", async () => {
 			const res = await supertest(app).get("/authorization/status")
@@ -36,11 +38,13 @@ describe("Authorization Routes", () => {
 
 	describe("POST /authorization/setup", () => {
 		test("returns 200 on first-time setup", async () => {
+			const spy = jest.spyOn(auth, "invalidateAllSessions")
 			const res = await supertest(app)
 				.post("/authorization/setup")
 				.send({ username: "admin", password: "password123" })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
+			expect(spy).toHaveBeenCalled()
 		})
 
 		test("returns 403 when table already has a row", async () => {
@@ -440,6 +444,7 @@ describe("Authorization Routes", () => {
 
 		test("returns 200 when updating role", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
+			const spy = jest.spyOn(auth, "invalidateAllSessions")
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
 			const res = await supertest(app)
 				.patch("/authorization/users/bob")
@@ -448,10 +453,12 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", ["bob", "jti-admin"])
+			expect(spy).toHaveBeenCalled()
 		})
 
 		test("returns 200 when updating password", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
+			const spy = jest.spyOn(auth, "invalidateAllSessions")
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
 			const res = await supertest(app)
 				.patch("/authorization/users/bob")
@@ -460,6 +467,7 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", ["bob", "jti-admin"])
+			expect(spy).toHaveBeenCalled()
 		})
 
 		test("returns 400 for a password shorter than 8 characters", async () => {
@@ -513,12 +521,14 @@ describe("Authorization Routes", () => {
 
 		test("returns 200 on successful deletion", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
+			const spy = jest.spyOn(auth, "invalidateAllSessions")
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
 			const res = await supertest(app)
 				.delete("/authorization/users/bob")
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
+			expect(spy).toHaveBeenCalled()
 		})
 
 		test("returns 404 when user does not exist", async () => {
@@ -626,6 +636,7 @@ describe("Authorization Routes", () => {
 		test("returns 200 on successful revoke", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ jti: "jti-victim" }], rowCount: 1 })
+			const spy = jest.spyOn(auth, "invalidateSession")
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
 			const res = await supertest(app)
 				.delete("/authorization/sessions/5")
@@ -633,6 +644,7 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE id = $1 RETURNING jti", [5])
+			expect(spy).toHaveBeenCalledWith("jti-victim")
 		})
 	})
 
@@ -653,6 +665,7 @@ describe("Authorization Routes", () => {
 		})
 
 		test("returns 200 and clears the temp-password expiry on success", async () => {
+			const spy = jest.spyOn(auth, "invalidateAllSessions")
 			const token = jwt.sign({ username: "bob", role: "user", jti: "jti-user" }, "test-secret")
 			const res = await supertest(app)
 				.post("/authorization/password")
@@ -668,6 +681,7 @@ describe("Authorization Routes", () => {
 				"UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2",
 				["bob", "jti-user"]
 			)
+			expect(spy).toHaveBeenCalled()
 		})
 	})
 
@@ -678,6 +692,7 @@ describe("Authorization Routes", () => {
 		})
 
 		test("revokes the session jti and clears the cookie", async () => {
+			const spy = jest.spyOn(auth, "invalidateSession")
 			const token = jwt.sign({ username: "bob", role: "user", jti: "sess-1" }, "test-secret")
 			const res = await supertest(app)
 				.post("/authorization/logout")
@@ -686,6 +701,7 @@ describe("Authorization Routes", () => {
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE jti = $1", ["sess-1"])
 			expect(res.headers["set-cookie"][0]).toMatch(/^bearertoken=;/)
+			expect(spy).toHaveBeenCalledWith("sess-1")
 		})
 	})
 

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -9,12 +9,14 @@ const supertest = require("supertest")
 const jwt = require("jsonwebtoken")
 const bcrypt = require("bcryptjs")
 const app = require("../backend/command.js")
+const { auth } = require("lib")
 
 const { mockedPool } = require("pg")
 
 describe("Authorization Routes", () => {
 	beforeEach(() => {
 		delete process.env.setup_TOKEN
+		auth.invalidateAllSessions(mockedPool)
 	})
 
 	describe("GET /authorization/status", () => {
@@ -623,13 +625,14 @@ describe("Authorization Routes", () => {
 
 		test("returns 200 on successful revoke", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
-			mockedPool.query.mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 })
+			mockedPool.query.mockResolvedValueOnce({ rows: [{ jti: "jti-victim" }], rowCount: 1 })
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
 			const res = await supertest(app)
 				.delete("/authorization/sessions/5")
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
+			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE id = $1 RETURNING jti", [5])
 		})
 	})
 

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -2,7 +2,7 @@ process.env.scheduler_AUTH = "scheduler-secret"
 process.env.SECRETKEY = "test-secret"
 
 const jwt = require("jsonwebtoken")
-const { createAuthorize, requireAdmin, schedulableUrls, invalidateSession, invalidateAllSessions } = require("../utils/auth.js")
+const { createAuthorize, requireAdmin, schedulableUrls, invalidateSession, invalidateAllSessions, connectSessionSync } = require("../utils/auth.js")
 
 const makeRes = () => ({
 	redirect: jest.fn(),
@@ -199,24 +199,100 @@ describe("makeAuthorize session cache", () => {
 		expect(pool.query).toHaveBeenCalledTimes(2)
 	})
 
-	test("invalidateSession revokes a session cached via a different pool (cross-service)", async () => {
-		const storagePool = { query: jest.fn().mockResolvedValue(activeRow) }
-		const storageAuthorize = createAuthorize(storagePool)
-		const req1 = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
-		storageAuthorize(req1, makeRes(), jest.fn())
+	test("an invalidation during an in-flight lookup is not resurrected by the stale read", async () => {
+		let resolveInflight
+		const pool = { query: jest.fn()
+			.mockImplementationOnce(() => new Promise(resolve => { resolveInflight = () => resolve(activeRow) }))
+			.mockResolvedValue({ rows: [{ role: "user", revoked: true }], rowCount: 1 })
+		}
+		const authorize = createAuthorize(pool)
+		const req = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		authorize(req, makeRes(), jest.fn())
 		await new Promise(resolve => setImmediate(resolve))
-		expect(storagePool.query).toHaveBeenCalledTimes(1)
-
 		invalidateSession("cache-jti")
-		storagePool.query.mockResolvedValueOnce({ rows: [{ role: "user", revoked: true }], rowCount: 1 })
-		const req2 = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		resolveInflight()
+		await new Promise(resolve => setImmediate(resolve))
 		const res2 = makeRes()
 		const next2 = jest.fn()
-		storageAuthorize(req2, res2, next2)
+		authorize(req, res2, next2)
 		await new Promise(resolve => setImmediate(resolve))
-		expect(storagePool.query).toHaveBeenCalledTimes(2)
+		expect(pool.query).toHaveBeenCalledTimes(2)
 		expect(next2).not.toHaveBeenCalled()
 		expect(res2.status).toHaveBeenCalledWith(401)
+	})
+
+})
+
+describe("makeAuthorize cross-process session invalidation", () => {
+	const token = jwt.sign({ username: "bob", jti: "cache-jti" }, process.env.SECRETKEY)
+	const activeRow = { rows: [{ role: "user", revoked: false, last_seen: new Date() }], rowCount: 1 }
+
+	afterEach(() => connectSessionSync(null))
+
+	test("a broadcast from a sibling worker clears this worker's cache", async () => {
+		const handlers = {}
+		const bus = {
+			emit: (event, jti) => (handlers[event] || []).forEach(h => h(jti)),
+			on: (event, handler) => (handlers[event] = handlers[event] || []).push(handler)
+		}
+		connectSessionSync(bus)
+
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const req = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(1)
+
+		bus.emit("sessionInvalidate", "cache-jti")
+		pool.query.mockResolvedValueOnce({ rows: [{ role: "user", revoked: true }], rowCount: 1 })
+		const res2 = makeRes()
+		const next2 = jest.fn()
+		authorize(req, res2, next2)
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(2)
+		expect(next2).not.toHaveBeenCalled()
+		expect(res2.status).toHaveBeenCalledWith(401)
+	})
+
+	test("a sessionInvalidateAll broadcast clears this worker's cache", async () => {
+		const handlers = {}
+		const bus = {
+			emit: (event, jti) => (handlers[event] || []).forEach(h => h(jti)),
+			on: (event, handler) => (handlers[event] = handlers[event] || []).push(handler)
+		}
+		connectSessionSync(bus)
+
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const req = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		bus.emit("sessionInvalidateAll")
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(2)
+	})
+
+	test("invalidateSession broadcasts the jti to sibling workers", () => {
+		const events = []
+		connectSessionSync({ emit: (event, jti) => events.push([event, jti]), on: () => {} })
+		invalidateSession("sess-9")
+		expect(events).toContainEqual(["sessionInvalidate", "sess-9"])
+	})
+
+	test("invalidateAllSessions broadcasts to sibling workers", () => {
+		const events = []
+		connectSessionSync({ emit: (event) => events.push(event), on: () => {} })
+		invalidateAllSessions()
+		expect(events).toContain("sessionInvalidateAll")
+	})
+
+	test("does not broadcast when no memory client is connected", () => {
+		connectSessionSync(null)
+		expect(() => { invalidateSession("x"); invalidateAllSessions() }).not.toThrow()
 	})
 })
 

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -2,7 +2,7 @@ process.env.scheduler_AUTH = "scheduler-secret"
 process.env.SECRETKEY = "test-secret"
 
 const jwt = require("jsonwebtoken")
-const { createAuthorize, requireAdmin, schedulableUrls } = require("../utils/auth.js")
+const { createAuthorize, requireAdmin, schedulableUrls, invalidateSession, invalidateAllSessions } = require("../utils/auth.js")
 
 const makeRes = () => ({
 	redirect: jest.fn(),
@@ -146,6 +146,55 @@ describe("makeAuthorize jwt session revocation", () => {
 		await new Promise(resolve => setImmediate(resolve))
 		expect(res.status).toHaveBeenCalledWith(401)
 		expect(next).not.toHaveBeenCalled()
+	})
+})
+
+describe("makeAuthorize session cache", () => {
+	const token = jwt.sign({ username: "bob", jti: "cache-jti" }, process.env.SECRETKEY)
+	const activeRow = { rows: [{ role: "user", revoked: false, last_seen: new Date() }], rowCount: 1 }
+
+	test("does not re-query the database within the cache window", async () => {
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const req = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(1)
+	})
+
+	test("invalidateSession forces a fresh lookup that reflects revocation", async () => {
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const req1 = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		const next1 = jest.fn()
+		authorize(req1, makeRes(), next1)
+		await new Promise(resolve => setImmediate(resolve))
+		expect(next1).toHaveBeenCalled()
+
+		invalidateSession(pool, "cache-jti")
+		pool.query.mockResolvedValueOnce({ rows: [{ role: "user", revoked: true }], rowCount: 1 })
+		const req2 = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		const res2 = makeRes()
+		const next2 = jest.fn()
+		authorize(req2, res2, next2)
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(2)
+		expect(next2).not.toHaveBeenCalled()
+		expect(res2.status).toHaveBeenCalledWith(401)
+	})
+
+	test("invalidateAllSessions clears every cached entry for the pool", async () => {
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const req = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		invalidateAllSessions(pool)
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(2)
 	})
 })
 

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -11,6 +11,8 @@ const makeRes = () => ({
 	json: jest.fn()
 })
 
+beforeEach(() => invalidateAllSessions())
+
 describe("makeAuthorize scheduler path", () => {
 	const authorize = createAuthorize(null)
 
@@ -173,7 +175,7 @@ describe("makeAuthorize session cache", () => {
 		await new Promise(resolve => setImmediate(resolve))
 		expect(next1).toHaveBeenCalled()
 
-		invalidateSession(pool, "cache-jti")
+		invalidateSession("cache-jti")
 		pool.query.mockResolvedValueOnce({ rows: [{ role: "user", revoked: true }], rowCount: 1 })
 		const req2 = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
 		const res2 = makeRes()
@@ -191,10 +193,30 @@ describe("makeAuthorize session cache", () => {
 		const req = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
 		authorize(req, makeRes(), jest.fn())
 		await new Promise(resolve => setImmediate(resolve))
-		invalidateAllSessions(pool)
+		invalidateAllSessions()
 		authorize(req, makeRes(), jest.fn())
 		await new Promise(resolve => setImmediate(resolve))
 		expect(pool.query).toHaveBeenCalledTimes(2)
+	})
+
+	test("invalidateSession revokes a session cached via a different pool (cross-service)", async () => {
+		const storagePool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const storageAuthorize = createAuthorize(storagePool)
+		const req1 = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		storageAuthorize(req1, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		expect(storagePool.query).toHaveBeenCalledTimes(1)
+
+		invalidateSession("cache-jti")
+		storagePool.query.mockResolvedValueOnce({ rows: [{ role: "user", revoked: true }], rowCount: 1 })
+		const req2 = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		const res2 = makeRes()
+		const next2 = jest.fn()
+		storageAuthorize(req2, res2, next2)
+		await new Promise(resolve => setImmediate(resolve))
+		expect(storagePool.query).toHaveBeenCalledTimes(2)
+		expect(next2).not.toHaveBeenCalled()
+		expect(res2.status).toHaveBeenCalledWith(401)
 	})
 })
 

--- a/lib/test/loadCameras.test.js
+++ b/lib/test/loadCameras.test.js
@@ -9,10 +9,11 @@ jest.mock("fs", () => {
 			if (p.endsWith("plain.conf")) return "camera_id 1\ncamera_name plain\nnetcam_url rtsp://192.168.1.1/stream\n"
 			if (p.endsWith("withcreds.conf")) return "camera_id 2\ncamera_name creds\nnetcam_url rtsp://192.168.1.2/stream\nnetcam_userpass admin:pass\n"
 			if (p.endsWith("dollarsign.conf")) return "camera_id 3\ncamera_name dollar\nnetcam_url rtsp://192.168.1.3/stream\nnetcam_userpass admin:p$1x$$end\n"
+			if (p.endsWith("staleembedded.conf")) return "camera_id 4\ncamera_name staleembedded\nnetcam_url rtsp://old:old@192.168.1.4/stream\nnetcam_userpass admin:pass\n"
 			return actual.readFileSync(p, enc)
 		}),
 		readdirSync: jest.fn((p) => {
-			if (p === "/etc/motion/cameraconf") return ["plain.conf", "withcreds.conf", "dollarsign.conf"]
+			if (p === "/etc/motion/cameraconf") return ["plain.conf", "withcreds.conf", "dollarsign.conf", "staleembedded.conf"]
 			return actual.readdirSync(p)
 		})
 	}
@@ -39,6 +40,11 @@ describe("loadCameras full_url", () => {
 	test("password containing $ is URI encoded correctly", () => {
 		const cam = cams.find(c => c.name === "dollar")
 		expect(cam.full_url).toBe("rtsp://admin:p%241x%24%24end@192.168.1.3/stream")
+	})
+
+	test("netcam_url with stale embedded userinfo: netcam_userpass replaces it instead of duplicating", () => {
+		const cam = cams.find(c => c.name === "staleembedded")
+		expect(cam.full_url).toBe("rtsp://admin:pass@192.168.1.4/stream")
 	})
 })
 

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -6,6 +6,13 @@ const forcedChangeAllowed = ["/authorization/password", "/authorization/verify",
 const sessionCache = new Map()
 const SESSION_CACHE_MS = 5000
 
+setInterval(() => {
+	const now = Date.now()
+	for (const [key, entry] of sessionCache) {
+		if (now - entry.time >= SESSION_CACHE_MS) sessionCache.delete(key)
+	}
+}, SESSION_CACHE_MS).unref()
+
 let publishInvalidation = null
 let epoch = 0
 
@@ -46,9 +53,6 @@ const verifyJwt = (token, req, res, next, pool) => {
 				if (cached && Date.now() - cached.time < SESSION_CACHE_MS) {
 					session = cached.data
 				} else {
-					for (const [key, entry] of sessionCache) {
-						if (Date.now() - entry.time >= SESSION_CACHE_MS) sessionCache.delete(key)
-					}
 					const epochBefore = epoch
 					const r = await pool.query(
 						"SELECT a.role, a.force_password_change, s.revoked, s.last_seen FROM auth a LEFT JOIN sessions s ON a.username = s.username AND s.jti = $2 WHERE a.username = $1",
@@ -71,6 +75,7 @@ const verifyJwt = (token, req, res, next, pool) => {
 					return
 				}
 				if (new Date() - new Date(session.last_seen) > 5 * 60 * 1000) {
+					session.last_seen = new Date()
 					pool.query("UPDATE sessions SET last_seen = NOW() WHERE jti = $1", [decoded.jti]).catch(console.error)
 				}
 			} catch (e) {

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -3,20 +3,11 @@ const jwt = require("jsonwebtoken")
 
 const schedulableUrls = ["/convert/createVideo", "/convert/createZip", "/file/pathMetrics", "/file/pathDelete", "/file/pathClean", "/file/pathAutoClean"]
 const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout"]
-const sessionCaches = new WeakMap()
+const sessionCache = new Map()
 const SESSION_CACHE_MS = 5000
 
-const getSessionCache = (pool) => {
-	let cacheForPool = sessionCaches.get(pool)
-	if (!cacheForPool) {
-		cacheForPool = new Map()
-		sessionCaches.set(pool, cacheForPool)
-	}
-	return cacheForPool
-}
-
-const invalidateSession = (pool, jti) => sessionCaches.get(pool)?.delete(jti)
-const invalidateAllSessions = (pool) => sessionCaches.get(pool)?.clear()
+const invalidateSession = (jti) => sessionCache.delete(jti)
+const invalidateAllSessions = () => sessionCache.clear()
 
 const verifyJwt = (token, req, res, next, pool) => {
 	const { method } = req
@@ -32,21 +23,20 @@ const verifyJwt = (token, req, res, next, pool) => {
 				return
 			}
 			try {
-				const cacheForPool = getSessionCache(pool)
-				const cached = cacheForPool.get(decoded.jti)
+				const cached = sessionCache.get(decoded.jti)
 				let session
 				if (cached && Date.now() - cached.time < SESSION_CACHE_MS) {
 					session = cached.data
 				} else {
-					for (const [key, entry] of cacheForPool) {
-						if (Date.now() - entry.time >= SESSION_CACHE_MS) cacheForPool.delete(key)
+					for (const [key, entry] of sessionCache) {
+						if (Date.now() - entry.time >= SESSION_CACHE_MS) sessionCache.delete(key)
 					}
 					const r = await pool.query(
 						"SELECT a.role, a.force_password_change, s.revoked, s.last_seen FROM auth a LEFT JOIN sessions s ON a.username = s.username AND s.jti = $2 WHERE a.username = $1",
 						[decoded.username, decoded.jti]
 					)
 					session = r.rowCount === 0 ? null : r.rows[0]
-					cacheForPool.set(decoded.jti, { data: session, time: Date.now() })
+					sessionCache.set(decoded.jti, { data: session, time: Date.now() })
 				}
 				if (!session) {
 					unauthorized()

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -6,8 +6,26 @@ const forcedChangeAllowed = ["/authorization/password", "/authorization/verify",
 const sessionCache = new Map()
 const SESSION_CACHE_MS = 5000
 
-const invalidateSession = (jti) => sessionCache.delete(jti)
-const invalidateAllSessions = () => sessionCache.clear()
+let publishInvalidation = null
+let epoch = 0
+
+const invalidateSession = (jti) => {
+	epoch++
+	sessionCache.delete(jti)
+	publishInvalidation?.("sessionInvalidate", jti)
+}
+const invalidateAllSessions = () => {
+	epoch++
+	sessionCache.clear()
+	publishInvalidation?.("sessionInvalidateAll")
+}
+
+const connectSessionSync = (client) => {
+	publishInvalidation = client ? (event, jti) => client.emit(event, jti) : null
+	if (!client) return
+	client.on("sessionInvalidate", (jti) => { epoch++; sessionCache.delete(jti) })
+	client.on("sessionInvalidateAll", () => { epoch++; sessionCache.clear() })
+}
 
 const verifyJwt = (token, req, res, next, pool) => {
 	const { method } = req
@@ -31,12 +49,13 @@ const verifyJwt = (token, req, res, next, pool) => {
 					for (const [key, entry] of sessionCache) {
 						if (Date.now() - entry.time >= SESSION_CACHE_MS) sessionCache.delete(key)
 					}
+					const epochBefore = epoch
 					const r = await pool.query(
 						"SELECT a.role, a.force_password_change, s.revoked, s.last_seen FROM auth a LEFT JOIN sessions s ON a.username = s.username AND s.jti = $2 WHERE a.username = $1",
 						[decoded.username, decoded.jti]
 					)
 					session = r.rowCount === 0 ? null : r.rows[0]
-					sessionCache.set(decoded.jti, { data: session, time: Date.now() })
+					if (epoch === epochBefore) sessionCache.set(decoded.jti, { data: session, time: Date.now() })
 				}
 				if (!session) {
 					unauthorized()
@@ -82,6 +101,7 @@ module.exports = {
 	createAuthorize: makeAuthorize,
 	invalidateSession,
 	invalidateAllSessions,
+	connectSessionSync,
 
 	requireAdmin: (req, res, next) => {
 		if (req.decoded?.role === "admin") next()

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -3,6 +3,21 @@ const jwt = require("jsonwebtoken")
 
 const schedulableUrls = ["/convert/createVideo", "/convert/createZip", "/file/pathMetrics", "/file/pathDelete", "/file/pathClean", "/file/pathAutoClean"]
 const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout"]
+const sessionCaches = new WeakMap()
+const SESSION_CACHE_MS = 5000
+
+const getSessionCache = (pool) => {
+	let cacheForPool = sessionCaches.get(pool)
+	if (!cacheForPool) {
+		cacheForPool = new Map()
+		sessionCaches.set(pool, cacheForPool)
+	}
+	return cacheForPool
+}
+
+const invalidateSession = (pool, jti) => sessionCaches.get(pool)?.delete(jti)
+const invalidateAllSessions = (pool) => sessionCaches.get(pool)?.clear()
+
 const verifyJwt = (token, req, res, next, pool) => {
 	const { method } = req
 	const unauthorized = () => method == "GET" ? res.redirect(303, "/?loginForm") : res.status(401).send({ error: "unauthorized" })
@@ -17,24 +32,36 @@ const verifyJwt = (token, req, res, next, pool) => {
 				return
 			}
 			try {
-				const r = await pool.query(
-					"SELECT a.role, a.force_password_change, s.revoked, s.last_seen FROM auth a LEFT JOIN sessions s ON a.username = s.username AND s.jti = $2 WHERE a.username = $1",
-					[decoded.username, decoded.jti]
-				)
-				if (r.rowCount === 0) {
+				const cacheForPool = getSessionCache(pool)
+				const cached = cacheForPool.get(decoded.jti)
+				let session
+				if (cached && Date.now() - cached.time < SESSION_CACHE_MS) {
+					session = cached.data
+				} else {
+					for (const [key, entry] of cacheForPool) {
+						if (Date.now() - entry.time >= SESSION_CACHE_MS) cacheForPool.delete(key)
+					}
+					const r = await pool.query(
+						"SELECT a.role, a.force_password_change, s.revoked, s.last_seen FROM auth a LEFT JOIN sessions s ON a.username = s.username AND s.jti = $2 WHERE a.username = $1",
+						[decoded.username, decoded.jti]
+					)
+					session = r.rowCount === 0 ? null : r.rows[0]
+					cacheForPool.set(decoded.jti, { data: session, time: Date.now() })
+				}
+				if (!session) {
 					unauthorized()
 					return
 				}
-				decoded.role = r.rows[0].role
-				if (r.rows[0].force_password_change && !forcedChangeAllowed.includes((req.originalUrl || "").split("?")[0])) {
+				decoded.role = session.role
+				if (session.force_password_change && !forcedChangeAllowed.includes((req.originalUrl || "").split("?")[0])) {
 					unauthorized()
 					return
 				}
-				if (r.rows[0].revoked !== false) {
+				if (session.revoked !== false) {
 					unauthorized()
 					return
 				}
-				if (new Date() - new Date(r.rows[0].last_seen) > 5 * 60 * 1000) {
+				if (new Date() - new Date(session.last_seen) > 5 * 60 * 1000) {
 					pool.query("UPDATE sessions SET last_seen = NOW() WHERE jti = $1", [decoded.jti]).catch(console.error)
 				}
 			} catch (e) {
@@ -63,6 +90,8 @@ const makeAuthorize = (pool) => (req, res, next) => {
 
 module.exports = {
 	createAuthorize: makeAuthorize,
+	invalidateSession,
+	invalidateAllSessions,
 
 	requireAdmin: (req, res, next) => {
 		if (req.decoded?.role === "admin") next()

--- a/lib/utils/loadCameras.js
+++ b/lib/utils/loadCameras.js
@@ -39,7 +39,7 @@ function loadCameras() {
 						encodedUserpass = encodeURIComponent(userpass)
 					}
 				}
-				const full_url = encodedUserpass ? rtsp_url.replace(/^([a-z][a-z0-9+\-.]*:\/\/)/i, (_, proto) => `${proto}${encodedUserpass}@`) : rtsp_url
+				const full_url = encodedUserpass ? rtsp_url.replace(/^([a-z][a-z0-9+\-.]*:\/\/)(?:[^@/]*@)?/i, (_, proto) => `${proto}${encodedUserpass}@`) : rtsp_url
 				return { id: parseInt(cam.camera_id) || 0, name: cam.camera_name || f, rtsp_url, full_url }
 			})
 			.filter(c => c.id > 0 && /^[a-z][a-z0-9+\-.]*:\/\//i.test(c.rtsp_url))

--- a/memory/lib/sessionSync.js
+++ b/memory/lib/sessionSync.js
@@ -1,0 +1,4 @@
+module.exports = (io) => ({
+	sessionInvalidate: (jti) => io.emit("sessionInvalidate", jti),
+	sessionInvalidateAll: () => io.emit("sessionInvalidateAll")
+})

--- a/memory/lib/sessionSync.js
+++ b/memory/lib/sessionSync.js
@@ -1,4 +1,4 @@
-module.exports = (io) => ({
-	sessionInvalidate: (jti) => io.emit("sessionInvalidate", jti),
-	sessionInvalidateAll: () => io.emit("sessionInvalidateAll")
+module.exports = (socket) => ({
+	sessionInvalidate: (jti) => socket.broadcast.emit("sessionInvalidate", jti),
+	sessionInvalidateAll: () => socket.broadcast.emit("sessionInvalidateAll")
 })

--- a/memory/socket.js
+++ b/memory/socket.js
@@ -21,12 +21,14 @@ module.exports = () => {
 		const {saveProcessEnder, cancelProcess} = require("./lib/converterProcesses.js")(io)
 		const {loginReserve, loginRelease} = require("./lib/loginAttempts.js")()
 		const {objectGetState, objectSetConfig, objectScan} = require("./lib/objectState.js")()
-		const {sessionInvalidate, sessionInvalidateAll} = require("./lib/sessionSync.js")(io)
+		const sessionSync = require("./lib/sessionSync.js")
 		const cronTask = require("./lib/cronTask.js")(io)
 
 		console.log(`🧠 Memory On ▶ PORT ${process.env.memory_PORT}`)
         
 		io.on("connection", client => {
+			const {sessionInvalidate, sessionInvalidateAll} = sessionSync(client)
+
 			client.on("log", data => console.log(data))
 
 			client.on("callback", (callback) => {

--- a/memory/socket.js
+++ b/memory/socket.js
@@ -21,6 +21,7 @@ module.exports = () => {
 		const {saveProcessEnder, cancelProcess} = require("./lib/converterProcesses.js")(io)
 		const {loginReserve, loginRelease} = require("./lib/loginAttempts.js")()
 		const {objectGetState, objectSetConfig, objectScan} = require("./lib/objectState.js")()
+		const {sessionInvalidate, sessionInvalidateAll} = require("./lib/sessionSync.js")(io)
 		const cronTask = require("./lib/cronTask.js")(io)
 
 		console.log(`🧠 Memory On ▶ PORT ${process.env.memory_PORT}`)
@@ -49,6 +50,9 @@ module.exports = () => {
 			client.on("objectGetState", objectGetState)
 			client.on("objectSetConfig", objectSetConfig)
 			client.on("objectScan", objectScan)
+
+			client.on("sessionInvalidate", sessionInvalidate)
+			client.on("sessionInvalidateAll", sessionInvalidateAll)
 
 			client.on("disconnect", () => {
 				console.log(`▶ 🧠 CLIENT WITH ID: ${client.id} DISCONNECTED`)

--- a/storage/backend/routes/events.js
+++ b/storage/backend/routes/events.js
@@ -40,11 +40,11 @@ app.get("/events", async (req, res) => {
 		const offset = (page - 1) * per_page
 		const [dataResult, countResult] = await Promise.all([
 			pool.query(
-				"SELECT id, timestamp, name, size FROM frame_files WHERE camera = $1 AND timestamp >= $2::date AND timestamp < ($2::date + INTERVAL '1 day') ORDER BY timestamp DESC LIMIT $3 OFFSET $4",
+				"SELECT id, timestamp, name, size FROM frame_files WHERE camera = $1 AND timestamp >= ($2::date AT TIME ZONE 'UTC') AND timestamp < (($2::date + INTERVAL '1 day') AT TIME ZONE 'UTC') ORDER BY timestamp DESC LIMIT $3 OFFSET $4",
 				[camera_id, date, per_page, offset]
 			),
 			pool.query(
-				"SELECT COUNT(*) FROM frame_files WHERE camera = $1 AND timestamp >= $2::date AND timestamp < ($2::date + INTERVAL '1 day')",
+				"SELECT COUNT(*) FROM frame_files WHERE camera = $1 AND timestamp >= ($2::date AT TIME ZONE 'UTC') AND timestamp < (($2::date + INTERVAL '1 day') AT TIME ZONE 'UTC')",
 				[camera_id, date]
 			)
 		])
@@ -112,8 +112,6 @@ app.delete("/camera/:id", requireAdmin, async (req, res) => {
 	const camPath = path.join(process.env.storage_FOLDERPATH, "shared/captures", id)
 	const objectsPath = path.join(process.env.storage_FOLDERPATH || process.cwd(), "objectCaptures")
 	try {
-		await pool.query("DELETE FROM frame_files WHERE camera = $1", [id])
-		await pool.query("DELETE FROM objects_detected WHERE camera = $1", [id])
 		await fs.promises.rm(camPath, { recursive: true, force: true })
 		const objectFiles = await fs.promises.readdir(objectsPath).catch(() => [])
 		await Promise.all(
@@ -121,6 +119,8 @@ app.delete("/camera/:id", requireAdmin, async (req, res) => {
 				.filter((f) => f.startsWith(`${id}-`))
 				.map((f) => fs.promises.unlink(path.join(objectsPath, f)).catch(() => {}))
 		)
+		await pool.query("DELETE FROM frame_files WHERE camera = $1", [id])
+		await pool.query("DELETE FROM objects_detected WHERE camera = $1", [id])
 		res.json({ deleted: true })
 	} catch (e) {
 		res.status(500).json({ error: true })

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -231,9 +231,9 @@ const queryForMetric = (camera, metric) => {
 }
 
 const queryToDeleteAndRecord = (camera, deleting, before="") => {
-	const timestampCondition = deleting=="files" ? `AND timestamp<=timestamp '${before}'` : ""
+	const timestampCondition = deleting=="files" ? `AND timestamp<=(timestamp '${before}' AT TIME ZONE 'UTC')` : ""
 	const now = moment.utc().format("YYYY-MM-DD HH:mm:ss")
-	return pool.query(`WITH deleted AS (DELETE FROM frame_files WHERE camera=${camera} ${timestampCondition} RETURNING name, size), inserted AS (INSERT INTO frame_deletes(timestamp, camera, size, count) SELECT '${now}', ${camera}, COALESCE(SUM(size), 0), COUNT(*) FROM deleted) SELECT name FROM deleted;`)
+	return pool.query(`WITH deleted AS (DELETE FROM frame_files WHERE camera=${camera} ${timestampCondition} RETURNING name, size), inserted AS (INSERT INTO frame_deletes(timestamp, camera, size, count) SELECT (timestamp '${now}' AT TIME ZONE 'UTC'), ${camera}, COALESCE(SUM(size), 0), COUNT(*) FROM deleted) SELECT name FROM deleted;`)
 }
 
 const escapeIdent = (name) => name.replace(/"/g, "\"\"")

--- a/storage/test/events.test.js
+++ b/storage/test/events.test.js
@@ -56,8 +56,8 @@ describe("Events Routes", () => {
 				.get("/events?camera_id=7&date=2026-05-16")
 				.set("Cookie", "validCookie")
 			const [dataSql, dataParams] = query.mock.calls[0]
-			expect(dataSql).toMatch(/timestamp >= \$2::date/)
-			expect(dataSql).toMatch(/< \(\$2::date \+ INTERVAL '1 day'\)/)
+			expect(dataSql).toMatch(/timestamp >= \(\$2::date AT TIME ZONE 'UTC'\)/)
+			expect(dataSql).toMatch(/< \(\(\$2::date \+ INTERVAL '1 day'\) AT TIME ZONE 'UTC'\)/)
 			expect(dataSql).not.toMatch(/DATE\(/)
 			expect(dataParams).toEqual(["7", "2026-05-16", 100, 0])
 		})

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -164,6 +164,17 @@ describe("File Routes", () => {
 				expect(unlinkSpy).toHaveBeenCalledTimes(2)
 			})
 
+			test("builds the delete cutoff and recorded timestamp in UTC regardless of session timezone", async () => {
+				query.mockImplementationOnce(() => Promise.resolve({ rows: [] }))
+				await supertest(app)
+					.post("/file/pathClean")
+					.send({ camera: 1, days: 1 })
+					.set("Cookie", cookieWithBearerToken)
+				const sql = query.mock.calls[0][0]
+				expect(sql).toMatch(/AND timestamp<=\(timestamp '[^']+' AT TIME ZONE 'UTC'\)/)
+				expect(sql).toMatch(/INSERT INTO frame_deletes\(timestamp, camera, size, count\) SELECT \(timestamp '[^']+' AT TIME ZONE 'UTC'\)/)
+			})
+
 			test("skips null filenames without throwing", async () => {
 				query.mockImplementationOnce(() => Promise.resolve({ rows: [{ name: "a.jpg", size: "100" }, { name: null, size: "200" }] }))
 				const res = await supertest(app)


### PR DESCRIPTION
Invalidate the session cache on revoke/logout instead of waiting up to 5s, sweep expired entries to stop unbounded growth, and add the missing test coverage found in review.