### PR TITLE
Fix review findings: UI fetch races, hook order, backend cleanup

### DIFF
--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -19,6 +19,19 @@ const sendError = (res, e) => {
 	res.status(500).json({ error: true })
 }
 
+const hashPassword = async (pw) => bcrypt.hash(pw, await bcrypt.genSalt(10))
+
+const getUserOr404 = async (client, username) => {
+	const target = await client.query("SELECT role FROM auth WHERE username = $1", [username])
+	if (target.rowCount === 0) throw new HttpError(404)
+	return target.rows[0]
+}
+
+const assertNotLastAdmin = async (client, message) => {
+	const admins = await client.query("SELECT username FROM auth WHERE role = 'admin' FOR UPDATE")
+	if (admins.rows.length <= 1) throw new HttpError(400, message)
+}
+
 const sharedAttempts = process.env.memory_ON == "true"
 const memoryClient = sharedAttempts ? memory.client("AUTH") : null
 if (memoryClient) auth.connectSessionSync(memoryClient)
@@ -68,8 +81,7 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(username)) return res.status(400).json({ error: true, errors: "Username must be 3-50 characters and contain only letters, numbers, dashes, dots, and underscores." })
 	try {
-		const salt = await bcrypt.genSalt(10)
-		const hash = await bcrypt.hash(password, salt)
+		const hash = await hashPassword(password)
 		const result = await withTransaction(async (client) => {
 			await client.query("SELECT pg_advisory_xact_lock(1)")
 			if (process.env.setup_TOKEN) {
@@ -135,8 +147,7 @@ app.post("/users", authorize, requireAdmin, validateBody, async (req, res) => {
 	if (!["admin", "user"].includes(role)) return res.status(400).json({ error: true })
 	try {
 		const tempPassword = randomBytes(16).toString("hex")
-		const salt = await bcrypt.genSalt(10)
-		const hash = await bcrypt.hash(tempPassword, salt)
+		const hash = await hashPassword(tempPassword)
 		await pool.query("INSERT INTO auth(username, hash, role, force_password_change, temp_password_expires) VALUES($1, $2, $3, TRUE, NOW() + INTERVAL '24 hours')", [username, hash, role])
 		res.json({ error: false, tempPassword })
 	} catch (e) {
@@ -154,16 +165,11 @@ app.patch("/users/:username", authorize, requireAdmin, validateBody, async (req,
 	let hash
 	try {
 		if (password !== undefined) {
-			const salt = await bcrypt.genSalt(10)
-			hash = await bcrypt.hash(password, salt)
+			hash = await hashPassword(password)
 		}
 		await withTransaction(async (client) => {
-			const target = await client.query("SELECT role FROM auth WHERE username = $1", [username])
-			if (target.rowCount === 0) throw new HttpError(404)
-			if (target.rows[0].role === "admin" && role === "user") {
-				const adminRows = await client.query("SELECT username FROM auth WHERE role = 'admin' FOR UPDATE")
-				if (adminRows.rows.length <= 1) throw new HttpError(400, "cannot demote last admin")
-			}
+			const target = await getUserOr404(client, username)
+			if (target.role === "admin" && role === "user") await assertNotLastAdmin(client, "cannot demote last admin")
 			const updates = []
 			const values = []
 			if (role !== undefined) {
@@ -217,12 +223,8 @@ app.delete("/users/:username", authorize, requireAdmin, async (req, res) => {
 	if (username === req.decoded.username) return res.status(400).json({ error: true })
 	try {
 		await withTransaction(async (client) => {
-			const target = await client.query("SELECT role FROM auth WHERE username = $1", [username])
-			if (target.rowCount === 0) throw new HttpError(404)
-			if (target.rows[0].role === "admin") {
-				const adminRows = await client.query("SELECT username FROM auth WHERE role = 'admin' FOR UPDATE")
-				if (adminRows.rows.length <= 1) throw new HttpError(400, "cannot delete last admin")
-			}
+			const target = await getUserOr404(client, username)
+			if (target.role === "admin") await assertNotLastAdmin(client, "cannot delete last admin")
 			await client.query("DELETE FROM auth WHERE username = $1", [username])
 		})
 		auth.invalidateAllSessions()
@@ -237,8 +239,7 @@ app.post("/password", authorize, validateBody, async (req, res) => {
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	const username = req.decoded.username
 	try {
-		const salt = await bcrypt.genSalt(10)
-		const hash = await bcrypt.hash(password, salt)
+		const hash = await hashPassword(password)
 		await withTransaction(async (client) => {
 			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2", [hash, username])
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -236,8 +236,7 @@ const ClipMakerMini = () => {
 	)
 }
 
-const ClipMaker = ({ mini } = {}) => {
-	if (mini) return <ClipMakerMini />
+const ClipMakerFull = () => {
 	const isDesktop = useMediaQuery({ query: "(min-width: 601px)" })
 	const role = useRole()
 	const isAdmin = role === "admin"
@@ -270,6 +269,8 @@ const ClipMaker = ({ mini } = {}) => {
 
 	const canvasRef = useRef(null)
 	const imageCache = useRef({})
+	const loadSeq = useRef(0)
+	const navTimer = useRef(null)
 
 	// multi-cam state
 	const [multiCam, setMultiCam] = useState(false)
@@ -283,6 +284,8 @@ const ClipMaker = ({ mini } = {}) => {
 	useEffect(() => {
 		if (!isDesktop && multiCam) toggleMultiCam()
 	}, [isDesktop])
+
+	useEffect(() => () => { if (navTimer.current) clearTimeout(navTimer.current) }, [])
 
 	useEffect(() => {
 		if (!multiCam && camera != null && cameras.length > 0 && frames.length === 0 && !fetching) loadPreview()
@@ -594,6 +597,21 @@ const ClipMaker = ({ mini } = {}) => {
 			jsonProcessing(prom, data => setDetections(Array.isArray(data) ? data : [])))
 	}
 
+	const framesBody = (camId, start, end) => JSON.stringify({
+		camera: String(camId),
+		start: moment(start).utc().format("YYYYMMDD-HHmmss"),
+		end: moment(end).utc().format("YYYYMMDD-HHmmss"),
+		frames: number
+	})
+
+	const createBody = (camId, type) => JSON.stringify({
+		camera: String(camId),
+		start: moment(trimStart).utc().format("YYYYMMDD-HHmmss"),
+		end: moment(trimEnd).utc().format("YYYYMMDD-HHmmss"),
+		save: true,
+		...(type === "video" ? { fps, skip } : { skip })
+	})
+
 	const loadPreview = (overrideStart, overrideEnd, camIdx = camera) => {
 		if (loading) return
 		if (cameras[camIdx]?.id == null) return toast("No camera selected")
@@ -607,16 +625,13 @@ const ClipMaker = ({ mini } = {}) => {
 		setTrimming(false)
 		const camId = cameras[camIdx].id
 		loadDetections(camId, start, end)
+		const seq = ++loadSeq.current
 		request("/convert/listFramesVideo", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				camera: String(camId),
-				start: start.utc().format("YYYYMMDD-HHmmss"),
-				end: end.utc().format("YYYYMMDD-HHmmss"),
-				frames: number
-			})
+			body: framesBody(camId, start, end)
 		}, prom => jsonProcessing(prom, data => {
+			if (seq !== loadSeq.current) return
 			setFrames(data?.list ?? [])
 			setScrubIdx(0)
 			setFetching(false)
@@ -635,17 +650,14 @@ const ClipMaker = ({ mini } = {}) => {
 		setTrimming(false)
 		const camIds = selectedCams.map(idx => cameras[idx].id)
 		setCamStates(Object.fromEntries(camIds.map(id => [id, { frames: [], imagesLoaded: 0, fetching: true }])))
+		const seq = ++loadSeq.current
 		camIds.forEach(camId => {
 			request("/convert/listFramesVideo", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					camera: String(camId),
-					start: start.utc().format("YYYYMMDD-HHmmss"),
-					end: end.utc().format("YYYYMMDD-HHmmss"),
-					frames: number
-				})
+				body: framesBody(camId, start, end)
 			}, prom => jsonProcessing(prom, data => {
+				if (seq !== loadSeq.current) return
 				setCamStates(s => ({ ...s, [camId]: { frames: data?.list ?? [], imagesLoaded: 0, fetching: false } }))
 			}))
 		})
@@ -697,13 +709,7 @@ const ClipMaker = ({ mini } = {}) => {
 		request(endpoint, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				camera: String(camId),
-				start: moment(trimStart).utc().format("YYYYMMDD-HHmmss"),
-				end: moment(trimEnd).utc().format("YYYYMMDD-HHmmss"),
-				save: true,
-				...(type === "video" ? { fps, skip } : { skip })
-			})
+			body: createBody(camId, type)
 		}, prom => jsonProcessing(prom, data => {
 			setGenerating(null)
 			if (!data || data.error) {
@@ -714,7 +720,7 @@ const ClipMaker = ({ mini } = {}) => {
 				toast("No frames found")
 			} else {
 				toast(`${type === "video" ? "Video" : "Archive"} queued`)
-				setTimeout(() => navigate("/recordings"), 1500)
+				navTimer.current = setTimeout(() => navigate("/recordings"), 1500)
 			}
 		}))
 	}
@@ -729,13 +735,7 @@ const ClipMaker = ({ mini } = {}) => {
 			request(endpoint, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					camera: String(camId),
-					start: moment(trimStart).utc().format("YYYYMMDD-HHmmss"),
-					end: moment(trimEnd).utc().format("YYYYMMDD-HHmmss"),
-					save: true,
-					...(type === "video" ? { fps, skip } : { skip })
-				})
+				body: createBody(camId, type)
 			}, prom => jsonProcessing(prom, data => {
 				setMultiGenerating(g => ({ ...g, [camId]: null }))
 				if (!data || data.error || !data.url) {
@@ -744,7 +744,7 @@ const ClipMaker = ({ mini } = {}) => {
 			}))
 		})
 		toast(`${type === "video" ? "Videos" : "Archives"} queued`)
-		setTimeout(() => navigate("/recordings"), 1500)
+		navTimer.current = setTimeout(() => navigate("/recordings"), 1500)
 	}
 
 	const setDatePart = (setter, part, val) => {
@@ -1146,5 +1146,7 @@ const ClipMaker = ({ mini } = {}) => {
 		</div>
 	)
 }
+
+const ClipMaker = ({ mini } = {}) => mini ? <ClipMakerMini /> : <ClipMakerFull />
 
 export default ClipMaker

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -631,7 +631,7 @@ const ClipMakerFull = () => {
 			headers: { "Content-Type": "application/json" },
 			body: framesBody(camId, start, end)
 		}, prom => jsonProcessing(prom, data => {
-			if (seq !== loadSeq.current) return
+			if (seq !== loadSeq.current) return setFetching(false)
 			setFrames(data?.list ?? [])
 			setScrubIdx(0)
 			setFetching(false)

--- a/command/frontend/app/ObjectDetections.jsx
+++ b/command/frontend/app/ObjectDetections.jsx
@@ -130,7 +130,7 @@ const ObjectDetectionsMini = () => {
 						className={`relative overflow-hidden ${g ? "bg-black" : "bg-muted/20"}`}
 					>
 						{g ? (
-							<DetectionImage image={g.image} boxes={g.boxes} cover />
+							<DetectionImage key={g.image} image={g.image} boxes={g.boxes} cover />
 						) : (
 							<div className="absolute inset-0 flex items-center justify-center">
 								<ImageOff className="size-5 opacity-30 text-muted" />
@@ -153,9 +153,7 @@ const ObjectDetectionsMini = () => {
 	)
 }
 
-const ObjectDetections = ({ mini, mobile = false }) => {
-	if (mini) return <ObjectDetectionsMini />
-
+const ObjectDetectionsFull = () => {
 	const role = useRole()
 	const { status, detections, loadStatus, loadDetections, scan } = useObjectDetections()
 	const groups = useMemo(() => groupDetections(detections), [detections])
@@ -239,7 +237,7 @@ const ObjectDetections = ({ mini, mobile = false }) => {
 			</div>
 
 			{currentGroup ? (
-				<DetectionImage image={currentGroup.image} boxes={currentGroup.boxes} height={previewHeight} />
+				<DetectionImage key={currentGroup.image} image={currentGroup.image} boxes={currentGroup.boxes} height={previewHeight} />
 			) : (
 				<div className="flex items-center justify-center bg-muted/10" style={{ height: previewHeight }}>
 					<ImageOff className="size-8 opacity-20 text-muted" />
@@ -314,5 +312,7 @@ const ObjectDetections = ({ mini, mobile = false }) => {
 		</div>
 	)
 }
+
+const ObjectDetections = ({ mini }) => mini ? <ObjectDetectionsMini /> : <ObjectDetectionsFull />
 
 export default ObjectDetections

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -23,6 +23,7 @@ const pruneCaptures = async () => {
 		try { acc.push({ f, t: fs.statSync(path.join(CAPTURES_DIR, f)).mtimeMs }) } catch (e) {}
 		return acc
 	}, [])
+	if (files.length <= MAX_CAPTURES) return
 
 	const { rows } = await pool.query(
 		"SELECT image, MAX(confidence) AS confidence FROM objects_detected WHERE image = ANY($1) GROUP BY image",

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -19,7 +19,10 @@ const confTier = (conf) => conf == null ? 0 : conf < 0.6 ? 1 : conf < 0.7 ? 2 : 
 const pruneCaptures = async () => {
 	const names = fs.readdirSync(CAPTURES_DIR)
 	if (names.length <= MAX_CAPTURES) return
-	const files = names.map((f) => ({ f, t: fs.statSync(path.join(CAPTURES_DIR, f)).mtimeMs }))
+	const files = names.reduce((acc, f) => {
+		try { acc.push({ f, t: fs.statSync(path.join(CAPTURES_DIR, f)).mtimeMs }) } catch (e) {}
+		return acc
+	}, [])
 
 	const { rows } = await pool.query(
 		"SELECT image, MAX(confidence) AS confidence FROM objects_detected WHERE image = ANY($1) GROUP BY image",

--- a/object/test/prune-vanish.test.js
+++ b/object/test/prune-vanish.test.js
@@ -1,0 +1,34 @@
+process.env.object_MAX_CAPTURES = "4"
+
+jest.mock("lib", () => ({ isPrimeInstance: true, objectState: { register: jest.fn() }, loadCameras: jest.fn(() => [{ id: 1, name: "a" }]) }))
+jest.mock("child_process", () => ({ execFile: jest.fn() }))
+jest.mock("fs", () => ({ mkdirSync: jest.fn(), readFileSync: jest.fn(), unlinkSync: jest.fn(), writeFileSync: jest.fn(), readdirSync: jest.fn(), statSync: jest.fn() }))
+jest.mock("../backend/lib/pool.js", () => ({ query: jest.fn() }))
+jest.mock("../backend/lib/webhook.js", () => jest.fn())
+jest.mock("../backend/lib/detector.js", () => ({ INPUT: 4, detect: jest.fn() }))
+
+const path = require("path")
+const fs = require("fs")
+const pool = require("../backend/lib/pool.js")
+const worker = require("../backend/lib/worker.js")
+
+beforeEach(() => {
+	jest.clearAllMocks()
+	pool.query.mockResolvedValue({ rows: [] })
+})
+
+describe("pruneCaptures when files vanish mid-sweep", () => {
+	test("does not delete survivors when statSync failures drop the count below MAX_CAPTURES", async () => {
+		fs.readdirSync.mockReturnValue(["a.jpg", "b.jpg", "c.jpg", "d.jpg", "e.jpg"])
+		const gone = new Set(["d.jpg", "e.jpg"])
+		fs.statSync.mockImplementation((p) => {
+			if (gone.has(path.basename(p))) { const err = new Error("ENOENT"); err.code = "ENOENT"; throw err }
+			return { mtimeMs: 100 }
+		})
+
+		await worker.pruneCaptures()
+
+		expect(fs.unlinkSync).not.toHaveBeenCalled()
+		expect(pool.query.mock.calls.some((c) => String(c[0]).startsWith("DELETE"))).toBe(false)
+	})
+})

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -202,21 +202,13 @@ module.exports = {
 	cameraMetrics: (req, res) => {
 		const cameras = loadCameras()
 
-		const sizePromises = Promise.all(cameras.map(({ id }) => {
-			return queryForMetric(id, "size").then(extractValueForMetric("size"))
-		}))
-
-		const countPromises = Promise.all(cameras.map(({ id }) => {
-			return queryForMetric(id, "count").then(extractValueForMetric("count"))
-		}))
-
-		Promise.all([sizePromises, countPromises]).then(values => {
-			let sizes = values[0]
-			let counts = values[1]
-			let metrics = { size: {}, count: {} }
-			cameras.forEach(({ name }, index) => {
-				metrics.size[name] = sizes[index] ? sizes[index] : 0
-				metrics.count[name] = counts[index] ? counts[index] : 0
+		pool.query("SELECT camera, COUNT(*) AS count, COALESCE(SUM(size), 0) AS size FROM frame_files GROUP BY camera").then(({ rows }) => {
+			const byCamera = new Map(rows.map((r) => [String(r.camera), r]))
+			const metrics = { size: {}, count: {} }
+			cameras.forEach(({ id, name }) => {
+				const row = byCamera.get(String(id))
+				metrics.size[name] = row ? parseInt(row.size) || 0 : 0
+				metrics.count[name] = row ? parseInt(row.count) || 0 : 0
 			})
 			res.send(metrics)
 		}).catch(err => {

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -40,14 +40,12 @@ describe("File Routes", () => {
 
 		test("maps per-camera size and count metrics", async () => {
 			loadCameras.mockReturnValue([{ id: 1, name: "cam1" }])
-			query
-				.mockImplementationOnce(() => Promise.resolve({ rows: [{ sum: "500" }] }))
-				.mockImplementationOnce(() => Promise.resolve({ rows: [{ count: "7" }] }))
+			query.mockImplementationOnce(() => Promise.resolve({ rows: [{ camera: "1", count: "7", size: "500" }] }))
 			const res = await supertest(app)
 				.post("/file/pathMetrics")
 				.set("Cookie", cookieWithBearerToken)
 			expect(res.status).toBe(200)
-			expect(res.body).toEqual({ size: { cam1: "500" }, count: { cam1: "7" } })
+			expect(res.body).toEqual({ size: { cam1: 500 }, count: { cam1: 7 } })
 		})
 
 		test("returns 500 when a metric query fails instead of hanging", async () => {


### PR DESCRIPTION
Addresses the surviving review findings from #178 — correctness fixes plus behavior-preserving cleanups. No schema or API changes.

### Correctness
- **ClipMaker fetch races** — guard `/listFramesVideo` replies with a `loadSeq` ref so out-of-order responses can't paint the wrong camera, and clear the `fetching` flag on a stale reply so the single-cam Load button can't wedge on "Fetching…".
- **Stale letterbox** — `key={image}` on `DetectionImage` so scrubbing across cameras remounts instead of drawing boxes with the previous frame's padding.
- **Orphaned nav timer** — the post-generate `navigate("/recordings")` timeout is now tracked in a ref and cleared on unmount.
- **Rules-of-Hooks** — split ClipMaker/ObjectDetections into a dispatcher + `*Full` component so hooks run unconditionally.
- **`pruneCaptures`** — skip captures that vanish mid-sweep (concurrent `DELETE /camera/:id`) instead of aborting the cycle, and re-check the count afterward so it can't negative-slice and mass-delete valid captures.

### Cleanup
- **`cameraMetrics`** — single `GROUP BY` instead of 2×N queries.
- **Auth** — extracted `hashPassword` / `getUserOr404` / `assertNotLastAdmin`.
- **ClipMaker** — shared `framesBody` / `createBody` body builders.

### Verification
All backend suites pass (command, storage, object); added a `pruneCaptures` regression test for the vanishing-file path. `vite build` succeeds.
