### PR TITLE
Fix PR 178 review findings

### DIFF
--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -102,7 +102,7 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 			)
 		})
 		if (result.rowCount === 0) return res.status(403).json({ error: true })
-		auth.invalidateAllSessions()
+		auth.invalidateUser(username)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -185,7 +185,7 @@ app.patch("/users/:username", authorize, requireAdmin, validateBody, async (req,
 			await client.query(`UPDATE auth SET ${updates.join(", ")} WHERE username = $${values.length}`, values)
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})
-		auth.invalidateAllSessions()
+		auth.invalidateUser(username)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -227,7 +227,7 @@ app.delete("/users/:username", authorize, requireAdmin, async (req, res) => {
 			if (target.role === "admin") await assertNotLastAdmin(client, "cannot delete last admin")
 			await client.query("DELETE FROM auth WHERE username = $1", [username])
 		})
-		auth.invalidateAllSessions()
+		auth.invalidateUser(username)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)
@@ -244,7 +244,7 @@ app.post("/password", authorize, validateBody, async (req, res) => {
 			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2", [hash, username])
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})
-		auth.invalidateAllSessions()
+		auth.invalidateUser(username)
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)

--- a/command/backend/routes/cameras.js
+++ b/command/backend/routes/cameras.js
@@ -6,6 +6,7 @@ const app = express.Router()
 const SENSITIVE_PARAM = /^(username|user|usr|password|passwd|pass|pwd|pw|auth|token|secret|u|p)$/i
 
 const stripCreds = (url) => {
+	let out = url
 	try {
 		const u = new URL(url)
 		u.username = ""
@@ -13,10 +14,11 @@ const stripCreds = (url) => {
 		for (const key of [...u.searchParams.keys()]) {
 			if (SENSITIVE_PARAM.test(key)) u.searchParams.set(key, "***")
 		}
-		return u.toString()
-	} catch {
-		return url.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^@]*@/i, "$1")
-	}
+		out = u.toString()
+	} catch {}
+	return /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*@/i.test(url)
+		? out.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^?#]*@/i, "$1")
+		: out
 }
 
 app.get("/", (req, res) => {

--- a/command/backend/routes/cameras.js
+++ b/command/backend/routes/cameras.js
@@ -3,9 +3,21 @@ const { loadCameras } = require("lib")
 
 const app = express.Router()
 
-const stripCreds = (url) => url
-	.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^/]*@/i, "$1")
-	.replace(/([?&](?:username|user|usr|password|passwd|pass|pwd|pw|auth|token|secret|u|p)=)[^&#]*/gi, "$1***")
+const SENSITIVE_PARAM = /^(username|user|usr|password|passwd|pass|pwd|pw|auth|token|secret|u|p)$/i
+
+const stripCreds = (url) => {
+	try {
+		const u = new URL(url)
+		u.username = ""
+		u.password = ""
+		for (const key of [...u.searchParams.keys()]) {
+			if (SENSITIVE_PARAM.test(key)) u.searchParams.set(key, "***")
+		}
+		return u.toString()
+	} catch {
+		return url.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^@]*@/i, "$1")
+	}
+}
 
 app.get("/", (req, res) => {
 	res.json(loadCameras().map(({ id, name, rtsp_url }) => ({ id, name, rtsp_url: stripCreds(rtsp_url) })))

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -38,7 +38,7 @@ describe("Authorization Routes", () => {
 
 	describe("POST /authorization/setup", () => {
 		test("returns 200 on first-time setup", async () => {
-			const spy = jest.spyOn(auth, "invalidateAllSessions")
+			const spy = jest.spyOn(auth, "invalidateUser")
 			const res = await supertest(app)
 				.post("/authorization/setup")
 				.send({ username: "admin", password: "password123" })
@@ -465,7 +465,7 @@ describe("Authorization Routes", () => {
 
 		test("returns 200 when updating role", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
-			const spy = jest.spyOn(auth, "invalidateAllSessions")
+			const spy = jest.spyOn(auth, "invalidateUser")
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
 			const res = await supertest(app)
 				.patch("/authorization/users/bob")
@@ -479,7 +479,7 @@ describe("Authorization Routes", () => {
 
 		test("returns 200 when updating password", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
-			const spy = jest.spyOn(auth, "invalidateAllSessions")
+			const spy = jest.spyOn(auth, "invalidateUser")
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
 			const res = await supertest(app)
 				.patch("/authorization/users/bob")
@@ -542,7 +542,7 @@ describe("Authorization Routes", () => {
 
 		test("returns 200 on successful deletion", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
-			const spy = jest.spyOn(auth, "invalidateAllSessions")
+			const spy = jest.spyOn(auth, "invalidateUser")
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
 			const res = await supertest(app)
 				.delete("/authorization/users/bob")
@@ -686,7 +686,7 @@ describe("Authorization Routes", () => {
 		})
 
 		test("returns 200 and clears the temp-password expiry on success", async () => {
-			const spy = jest.spyOn(auth, "invalidateAllSessions")
+			const spy = jest.spyOn(auth, "invalidateUser")
 			const token = jwt.sign({ username: "bob", role: "user", jti: "jti-user" }, "test-secret")
 			const res = await supertest(app)
 				.post("/authorization/password")

--- a/command/test/cameras.test.js
+++ b/command/test/cameras.test.js
@@ -11,10 +11,11 @@ jest.mock("fs", () => {
 			if (p.endsWith("cam2.conf")) return "camera_id 2\ncamera_name outdoor\nnetcam_url rtsp://user:secret@2.2.2.2/cam\n"
 			if (p.endsWith("cam3.conf")) return "camera_id 3\ncamera_name gate\nnetcam_url rtsp://user:p@ss@3.3.3.3/cam\n"
 			if (p.endsWith("cam4.conf")) return "camera_id 4\ncamera_name yard\nnetcam_url rtsp://4.4.4.4/cam?user=admin&p=secret\n"
+			if (p.endsWith("cam5.conf")) return "camera_id 5\ncamera_name shed\nnetcam_url rtsp://admin:p@ss/word@5.5.5.5/cam\n"
 			return actual.readFileSync(p, enc)
 		}),
 		readdirSync: jest.fn((p) => {
-			if (p === "/etc/motion/cameraconf") return ["cam1.conf", "cam2.conf", "cam3.conf", "cam4.conf"]
+			if (p === "/etc/motion/cameraconf") return ["cam1.conf", "cam2.conf", "cam3.conf", "cam4.conf", "cam5.conf"]
 			return actual.readdirSync(p)
 		})
 	}
@@ -49,7 +50,8 @@ describe("Cameras Route", () => {
 				{ id: 1, name: "indoor", rtsp_url: "rtsp://1.1.1.1/cam" },
 				{ id: 2, name: "outdoor", rtsp_url: "rtsp://2.2.2.2/cam" },
 				{ id: 3, name: "gate", rtsp_url: "rtsp://3.3.3.3/cam" },
-				{ id: 4, name: "yard", rtsp_url: "rtsp://4.4.4.4/cam?user=***&p=***" }
+				{ id: 4, name: "yard", rtsp_url: "rtsp://4.4.4.4/cam?user=***&p=***" },
+				{ id: 5, name: "shed", rtsp_url: "rtsp://5.5.5.5/cam" }
 			])
 		})
 	})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - chimera-storage:/mnt/storage
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - ./motion.conf:/etc/motion/motion.conf:ro
-      - ./cameraconf:/etc/motion/cameraconf:ro
+      - ./cameraconf:/etc/motion/cameraconf
     depends_on:
       postgres:
         condition: service_healthy

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = {
 	helmetOptions: require("./utils/helmetOptions.js"),
 	loadCameras: require("./utils/loadCameras.js").loadCameras,
 	cameraConfDir: require("./utils/loadCameras.js").cameraConfDir,
+	cameraConfFiles: require("./utils/loadCameras.js").cameraConfFiles,
 	pruneInterval: require("./utils/pruneInterval.js"),
 	isPrimeInstance: !("NODE_APP_INSTANCE" in process.env) || process.env.NODE_APP_INSTANCE === "0"
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ module.exports = {
 	randomID: require("./utils/randomID.js"),
 	helmetOptions: require("./utils/helmetOptions.js"),
 	loadCameras: require("./utils/loadCameras.js").loadCameras,
+	cameraConfDir: require("./utils/loadCameras.js").cameraConfDir,
 	pruneInterval: require("./utils/pruneInterval.js"),
 	isPrimeInstance: !("NODE_APP_INSTANCE" in process.env) || process.env.NODE_APP_INSTANCE === "0"
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ module.exports = {
 	password: require("./utils/password.json"),
 	subprocess: require("./utils/subprocess.js"),
 	formatBytes: require("./utils/formatBytes.js"),
+	mapLimit: require("./utils/mapLimit.js"),
 	tempMiddleware: require("./utils/tempMiddleware.js"),
 	jsonFileHanding: require("./utils/jsonFileHandling.js"),
 	randomID: require("./utils/randomID.js"),

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -2,7 +2,7 @@ process.env.scheduler_AUTH = "scheduler-secret"
 process.env.SECRETKEY = "test-secret"
 
 const jwt = require("jsonwebtoken")
-const { createAuthorize, requireAdmin, schedulableUrls, invalidateSession, invalidateAllSessions, connectSessionSync } = require("../utils/auth.js")
+const { createAuthorize, requireAdmin, schedulableUrls, invalidateSession, invalidateUser, invalidateAllSessions, connectSessionSync } = require("../utils/auth.js")
 
 const makeRes = () => ({
 	redirect: jest.fn(),
@@ -199,6 +199,25 @@ describe("makeAuthorize session cache", () => {
 		expect(pool.query).toHaveBeenCalledTimes(2)
 	})
 
+	test("invalidateUser evicts only the target user's cached entries", async () => {
+		const aliceToken = jwt.sign({ username: "alice", jti: "alice-jti" }, process.env.SECRETKEY)
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const bobReq = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+		const aliceReq = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${aliceToken}` } }
+		authorize(bobReq, makeRes(), jest.fn())
+		authorize(aliceReq, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(2)
+
+		invalidateUser("bob")
+
+		authorize(bobReq, makeRes(), jest.fn())
+		authorize(aliceReq, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(3)
+	})
+
 	test("an invalidation during an in-flight lookup is not resurrected by the stale read", async () => {
 		let resolveInflight
 		const pool = { query: jest.fn()
@@ -288,6 +307,33 @@ describe("makeAuthorize cross-process session invalidation", () => {
 		connectSessionSync({ emit: (event) => events.push(event), on: () => {} })
 		invalidateAllSessions()
 		expect(events).toContain("sessionInvalidateAll")
+	})
+
+	test("invalidateUser broadcasts the username to sibling workers", () => {
+		const events = []
+		connectSessionSync({ emit: (event, arg) => events.push([event, arg]), on: () => {} })
+		invalidateUser("bob")
+		expect(events).toContainEqual(["sessionInvalidateUser", "bob"])
+	})
+
+	test("a sessionInvalidateUser broadcast clears this worker's cache", async () => {
+		const handlers = {}
+		const bus = {
+			emit: (event, arg) => (handlers[event] || []).forEach(h => h(arg)),
+			on: (event, handler) => (handlers[event] = handlers[event] || []).push(handler)
+		}
+		connectSessionSync(bus)
+
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const req = { method: "POST", path: "/x", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
+
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		bus.emit("sessionInvalidateUser", "bob")
+		authorize(req, makeRes(), jest.fn())
+		await new Promise(resolve => setImmediate(resolve))
+		expect(pool.query).toHaveBeenCalledTimes(2)
 	})
 
 	test("does not broadcast when no memory client is connected", () => {

--- a/lib/test/loadCameras.test.js
+++ b/lib/test/loadCameras.test.js
@@ -20,7 +20,7 @@ jest.mock("fs", () => {
 })
 
 const path = require("path")
-const { loadCameras } = require("../utils/loadCameras")
+const { loadCameras, cameraConfFiles } = require("../utils/loadCameras")
 
 describe("loadCameras full_url", () => {
 	let cams
@@ -99,5 +99,27 @@ describe("loadCameras URL filter", () => {
 		expect(cams.find(c => c.name === "badport")).toBeUndefined()
 		expect(spy).toHaveBeenCalledWith(expect.stringContaining("Invalid URL for camera badport"))
 		spy.mockRestore()
+	})
+})
+
+describe("cameraConfFiles", () => {
+	beforeEach(() => {
+		process.env.storage_MOTION_CONF_FILEPATH = "/etc/motion/motion.conf"
+		const { readFileSync, readdirSync } = require("fs")
+		readFileSync.mockImplementation((p) => {
+			if (p === "/etc/motion/motion.conf") return "camera_dir /etc/motion/cameraconf\n"
+			if (p.endsWith("frontdoor.conf")) return "camera_id 7\ncamera_name front\nnetcam_url rtsp://1.1.1.1/s\n"
+			if (p.endsWith("cam2.conf")) return "camera_id 2\ncamera_name two\nnetcam_url rtsp://2.2.2.2/s\n"
+			return ""
+		})
+		readdirSync.mockImplementation((p) => (p === "/etc/motion/cameraconf" ? ["frontdoor.conf", "cam2.conf"] : []))
+	})
+
+	test("matches a conf by its in-file camera_id, not its filename", () => {
+		expect(cameraConfFiles(7)).toEqual([path.join("/etc/motion/cameraconf", "frontdoor.conf")])
+	})
+
+	test("returns [] when no conf declares that camera_id", () => {
+		expect(cameraConfFiles(99)).toEqual([])
 	})
 })

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -16,10 +16,21 @@ setInterval(() => {
 let publishInvalidation = null
 let epoch = 0
 
+const dropUserEntries = (username) => {
+	for (const [jti, entry] of sessionCache) {
+		if (entry.username === username) sessionCache.delete(jti)
+	}
+}
+
 const invalidateSession = (jti) => {
 	epoch++
 	sessionCache.delete(jti)
 	publishInvalidation?.("sessionInvalidate", jti)
+}
+const invalidateUser = (username) => {
+	epoch++
+	dropUserEntries(username)
+	publishInvalidation?.("sessionInvalidateUser", username)
 }
 const invalidateAllSessions = () => {
 	epoch++
@@ -28,9 +39,10 @@ const invalidateAllSessions = () => {
 }
 
 const connectSessionSync = (client) => {
-	publishInvalidation = client ? (event, jti) => client.emit(event, jti) : null
+	publishInvalidation = client ? (event, arg) => client.emit(event, arg) : null
 	if (!client) return
 	client.on("sessionInvalidate", (jti) => { epoch++; sessionCache.delete(jti) })
+	client.on("sessionInvalidateUser", (username) => { epoch++; dropUserEntries(username) })
 	client.on("sessionInvalidateAll", () => { epoch++; sessionCache.clear() })
 }
 
@@ -59,7 +71,7 @@ const verifyJwt = (token, req, res, next, pool) => {
 						[decoded.username, decoded.jti]
 					)
 					session = r.rowCount === 0 ? null : r.rows[0]
-					if (epoch === epochBefore) sessionCache.set(decoded.jti, { data: session, time: Date.now() })
+					if (epoch === epochBefore) sessionCache.set(decoded.jti, { data: session, username: decoded.username, time: Date.now() })
 				}
 				if (!session) {
 					unauthorized()
@@ -105,6 +117,7 @@ const makeAuthorize = (pool) => (req, res, next) => {
 module.exports = {
 	createAuthorize: makeAuthorize,
 	invalidateSession,
+	invalidateUser,
 	invalidateAllSessions,
 	connectSessionSync,
 

--- a/lib/utils/loadCameras.js
+++ b/lib/utils/loadCameras.js
@@ -38,14 +38,24 @@ function urlProblem(rtsp_url, full_url) {
 	}
 }
 
+function cameraConfDir() {
+	try {
+		const confPath = process.env.storage_MOTION_CONF_FILEPATH
+		if (!confPath) return null
+		const main = parseConf(fs.readFileSync(confPath, "utf8"))
+		if (!main.camera_dir) return null
+		return path.isAbsolute(main.camera_dir) ? main.camera_dir : path.resolve(path.dirname(confPath), main.camera_dir)
+	} catch (e) {
+		console.error("Failed to resolve camera conf dir:", e)
+		return null
+	}
+}
+
 function loadCameras() {
 	if (cache && Date.now() - cacheTime < 10000 && process.env.NODE_ENV !== "test") return cache.map(c => ({ ...c }))
 	try {
-		const confPath = process.env.storage_MOTION_CONF_FILEPATH
-		if (!confPath) return []
-		const main = parseConf(fs.readFileSync(confPath, "utf8"))
-		if (!main.camera_dir) return []
-		const cameraDir = path.isAbsolute(main.camera_dir) ? main.camera_dir : path.resolve(path.dirname(confPath), main.camera_dir)
+		const cameraDir = cameraConfDir()
+		if (!cameraDir) return []
 		const res = fs.readdirSync(cameraDir)
 			.filter(f => f.endsWith(".conf"))
 			.map(f => {
@@ -73,4 +83,4 @@ function loadCameras() {
 	}
 }
 
-module.exports = { parseConf, loadCameras, buildFullUrl, urlProblem }
+module.exports = { parseConf, loadCameras, buildFullUrl, urlProblem, cameraConfDir }

--- a/lib/utils/loadCameras.js
+++ b/lib/utils/loadCameras.js
@@ -51,6 +51,20 @@ function cameraConfDir() {
 	}
 }
 
+function cameraConfFiles(id) {
+	const dir = cameraConfDir()
+	if (!dir) return []
+	try {
+		return fs.readdirSync(dir)
+			.filter(f => f.endsWith(".conf"))
+			.filter(f => parseInt(parseConf(fs.readFileSync(path.join(dir, f), "utf8")).camera_id) === parseInt(id))
+			.map(f => path.join(dir, f))
+	} catch (e) {
+		console.error("Failed to resolve camera conf files:", e)
+		return []
+	}
+}
+
 function loadCameras() {
 	if (cache && Date.now() - cacheTime < 10000 && process.env.NODE_ENV !== "test") return cache.map(c => ({ ...c }))
 	try {
@@ -83,4 +97,4 @@ function loadCameras() {
 	}
 }
 
-module.exports = { parseConf, loadCameras, buildFullUrl, urlProblem, cameraConfDir }
+module.exports = { parseConf, loadCameras, buildFullUrl, urlProblem, cameraConfDir, cameraConfFiles }

--- a/lib/utils/mapLimit.js
+++ b/lib/utils/mapLimit.js
@@ -1,0 +1,14 @@
+const mapLimit = async (items, limit, fn) => {
+	const results = new Array(items.length)
+	let next = 0
+	const worker = async () => {
+		while (next < items.length) {
+			const i = next++
+			results[i] = await fn(items[i], i)
+		}
+	}
+	await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
+	return results
+}
+
+module.exports = mapLimit

--- a/livestream/__mocks__/lib.js
+++ b/livestream/__mocks__/lib.js
@@ -3,6 +3,11 @@ let lib = jest.requireActual("lib")
 lib.auth.authorize = jest.fn().mockImplementation((req={headers:{}}, res, next) => {
 	const {method} = req
 	if(req.headers.cookie == "validCookie"){
+		req.decoded = { username: "test", role: "admin" }
+		next()
+	}
+	else if(req.headers.cookie == "userCookie"){
+		req.decoded = { username: "test", role: "user" }
 		next()
 	}
 	else{

--- a/livestream/backend/routes/livestream.js
+++ b/livestream/backend/routes/livestream.js
@@ -1,6 +1,7 @@
 var express    = require("express")
 const path = require("path")
-const { subprocess } = require("lib")
+const { subprocess, auth } = require("lib")
+const { requireAdmin } = auth
 
 const app = express.Router()
 
@@ -21,7 +22,7 @@ app.get("/status", (req, res, next) => {
 	next()
 }, subprocess.processListMiddleware)
 
-app.post("/restart", (req, res, next) => {
+app.post("/restart", requireAdmin, (req, res, next) => {
 	const {camera} = req.body
 	if(camera){
 		req.processName = `live_stream_cam_${camera}`

--- a/livestream/test/livestream.test.js
+++ b/livestream/test/livestream.test.js
@@ -43,4 +43,22 @@ describe("Livestream Routes", () => {
 				.expect(204, {}, done)
 		})
 	})
+
+	describe("POST /restart admin gating", () => {
+		test("non-admin user is forbidden", (done) => {
+			supertest(app)
+				.post("/livestream/restart")
+				.set("Cookie", "userCookie")
+				.send({ camera: 1 })
+				.expect(403, done)
+		})
+
+		test("admin passes the gate (400 without a camera)", (done) => {
+			supertest(app)
+				.post("/livestream/restart")
+				.set("Cookie", "validCookie")
+				.send({})
+				.expect(400, done)
+		})
+	})
 })

--- a/memory/lib/sessionSync.js
+++ b/memory/lib/sessionSync.js
@@ -1,4 +1,5 @@
 module.exports = (socket) => ({
 	sessionInvalidate: (jti) => socket.broadcast.emit("sessionInvalidate", jti),
+	sessionInvalidateUser: (username) => socket.broadcast.emit("sessionInvalidateUser", username),
 	sessionInvalidateAll: () => socket.broadcast.emit("sessionInvalidateAll")
 })

--- a/memory/socket.js
+++ b/memory/socket.js
@@ -26,7 +26,7 @@ module.exports = () => {
 		console.log(`🧠 Memory On ▶ PORT ${process.env.memory_PORT}`)
         
 		io.on("connection", client => {
-			const {sessionInvalidate, sessionInvalidateAll} = sessionSync(client)
+			const {sessionInvalidate, sessionInvalidateUser, sessionInvalidateAll} = sessionSync(client)
 
 			client.on("log", data => console.log(data))
 
@@ -49,6 +49,7 @@ module.exports = () => {
 			client.on("loginRelease", loginRelease)
 
 			client.on("sessionInvalidate", sessionInvalidate)
+			client.on("sessionInvalidateUser", sessionInvalidateUser)
 			client.on("sessionInvalidateAll", sessionInvalidateAll)
 
 			client.on("disconnect", () => {

--- a/object/backend/lib/model.js
+++ b/object/backend/lib/model.js
@@ -6,7 +6,6 @@ const MODEL_DIR = path.join(__dirname, "..", "model")
 const MODEL_PATH = path.join(MODEL_DIR, "yolox_tiny.onnx")
 const DEFAULT_URL = "https://github.com/jjjpanda/Chimera/releases/download/v6_resources/yolox_tiny.onnx"
 const DEFAULT_SHA256 = "427cc366d34e27ff7a03e2899b5e3671425c262ea2291f88bb942bc1cc70b0f7"
-const MIN_BYTES = 20000000
 
 const getFileHash = (filePath) => new Promise((resolve, reject) => {
 	const hash = crypto.createHash("sha256")
@@ -21,29 +20,20 @@ const getHash = (buffer) => crypto.createHash("sha256").update(buffer).digest("h
 const ensureModel = async () => {
 	const customUrl = process.env.object_MODEL_URL
 	const customSha = process.env.object_MODEL_SHA256
-	const expectedSha256 = customSha ? customSha.toLowerCase() : (customUrl ? null : DEFAULT_SHA256)
+	if (customUrl && !customSha) {
+		throw new Error("object_MODEL_URL requires object_MODEL_SHA256 to verify model integrity")
+	}
+	const expectedSha256 = (customSha || DEFAULT_SHA256).toLowerCase()
 
 	if (fs.existsSync(MODEL_PATH)) {
-		if (expectedSha256) {
-			try {
-				const hash = await getFileHash(MODEL_PATH)
-				if (hash === expectedSha256) {
-					return MODEL_PATH
-				}
-				console.log("🔍 Existing model failed SHA256 check, redownloading...")
-			} catch (err) {
-				console.log("🔍 Existing model unreadable, removing and redownloading...", err.message)
-				try { fs.unlinkSync(MODEL_PATH) } catch (e) { console.warn("Could not remove corrupt model file", e.message) }
+		try {
+			const hash = await getFileHash(MODEL_PATH)
+			if (hash === expectedSha256) {
+				return MODEL_PATH
 			}
-		} else {
-			try {
-				if (fs.statSync(MODEL_PATH).size > MIN_BYTES) {
-					return MODEL_PATH
-				}
-				console.log("🔍 Existing model failed size check, redownloading...")
-			} catch (err) {
-				console.log("🔍 Existing model size check failed or unreadable, removing and redownloading...", err.message)
-			}
+			console.log("🔍 Existing model failed SHA256 check, redownloading...")
+		} catch (err) {
+			console.log("🔍 Existing model unreadable, removing and redownloading...", err.message)
 			try { fs.unlinkSync(MODEL_PATH) } catch (e) { console.warn("Could not remove corrupt model file", e.message) }
 		}
 	}
@@ -52,13 +42,9 @@ const ensureModel = async () => {
 	const res = await fetch(url)
 	if (!res.ok) throw new Error(`model download failed: ${res.status}`)
 	const buffer = Buffer.from(await res.arrayBuffer())
-	
-	if (expectedSha256) {
-		if (getHash(buffer) !== expectedSha256) throw new Error("downloaded model failed SHA256 integrity check")
-	} else {
-		if (buffer.length < MIN_BYTES) throw new Error("downloaded model too small")
-	}
-	
+
+	if (getHash(buffer) !== expectedSha256) throw new Error("downloaded model failed SHA256 integrity check")
+
 	fs.mkdirSync(MODEL_DIR, { recursive: true })
 	fs.writeFileSync(MODEL_PATH, buffer)
 	console.log(`🔍 Model saved (${(buffer.length / 1e6).toFixed(1)} MB)`)

--- a/object/test/model.test.js
+++ b/object/test/model.test.js
@@ -96,38 +96,25 @@ describe("ensureModel", () => {
 		await expect(ensureModel()).rejects.toThrow("downloaded model failed SHA256 integrity check")
 	})
 
-	test("skips SHA check and uses size check if custom URL provided without SHA", async () => {
-		fs.existsSync.mockReturnValue(true)
+	test("throws if custom URL provided without SHA256", async () => {
+		fs.existsSync.mockReturnValue(false)
 		process.env.object_MODEL_URL = "http://custom.url"
-		fs.statSync.mockReturnValue({ size: 21000000 }) // > MIN_BYTES
-		
-		const result = await ensureModel()
-		expect(result).toBe(MODEL_PATH)
+
+		await expect(ensureModel()).rejects.toThrow("object_MODEL_URL requires object_MODEL_SHA256")
 		expect(fetch).not.toHaveBeenCalled()
 	})
 
-	test("redownloads if custom URL existing file fails size check", async () => {
-		fs.existsSync.mockReturnValue(true)
+	test("downloads from custom URL and verifies SHA256", async () => {
+		fs.existsSync.mockReturnValue(false)
+		const goodBuffer = Buffer.from("custom model data")
 		process.env.object_MODEL_URL = "http://custom.url"
-		fs.statSync.mockReturnValue({ size: 100 }) // < MIN_BYTES
-		
-		const goodBuffer = Buffer.alloc(21000000)
+		process.env.object_MODEL_SHA256 = crypto.createHash("sha256").update(goodBuffer).digest("hex")
 		mockFetch(goodBuffer)
-		
+
 		const result = await ensureModel()
 		expect(result).toBe(MODEL_PATH)
 		expect(fetch).toHaveBeenCalledWith("http://custom.url")
 		expect(fs.writeFileSync).toHaveBeenCalledWith(MODEL_PATH, expect.any(Buffer))
-	})
-
-	test("throws error if downloaded custom URL file fails size check", async () => {
-		fs.existsSync.mockReturnValue(false)
-		process.env.object_MODEL_URL = "http://custom.url"
-		
-		const smallBuffer = Buffer.alloc(100)
-		mockFetch(smallBuffer)
-		
-		await expect(ensureModel()).rejects.toThrow("downloaded model too small")
 	})
 
 	test("throws error if fetch fails with HTTP error", async () => {

--- a/storage/__mocks__/lib.js
+++ b/storage/__mocks__/lib.js
@@ -19,6 +19,8 @@ lib.auth.createAuthorize = jest.fn().mockReturnValue(lib.auth.authorize)
 
 lib.loadCameras = jest.fn(lib.loadCameras)
 
+lib.cameraConfDir = jest.fn(lib.cameraConfDir)
+
 lib.webhookAlert = jest.fn()
 
 module.exports = lib

--- a/storage/__mocks__/lib.js
+++ b/storage/__mocks__/lib.js
@@ -19,7 +19,7 @@ lib.auth.createAuthorize = jest.fn().mockReturnValue(lib.auth.authorize)
 
 lib.loadCameras = jest.fn(lib.loadCameras)
 
-lib.cameraConfDir = jest.fn(lib.cameraConfDir)
+lib.cameraConfFiles = jest.fn(lib.cameraConfFiles)
 
 lib.webhookAlert = jest.fn()
 

--- a/storage/backend/routes/events.js
+++ b/storage/backend/routes/events.js
@@ -1,33 +1,35 @@
 var express = require("express")
 var path = require("path")
 var fs = require("fs")
-var { auth, loadCameras, cameraConfDir } = require("lib")
+var { auth, loadCameras, cameraConfDir, mapLimit } = require("lib")
 const { requireAdmin } = auth
 
 const pool = require("../lib/pool")
 
 const app = express.Router()
 
+const FS_CONCURRENCY = 64
+
 const dirFileBytes = async (dir) => {
 	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
-	const sizes = await Promise.all(entries.map(async (entry) => {
-		if (!entry.isFile()) return 0
+	const files = entries.filter((entry) => entry.isFile())
+	const sizes = await mapLimit(files, FS_CONCURRENCY, async (entry) => {
 		const { size } = await fs.promises.stat(path.join(dir, entry.name)).catch(() => ({ size: 0 }))
 		return size
-	}))
+	})
 	return sizes.reduce((sum, size) => sum + size, 0)
 }
 
 const captureBreakdown = async (capturesPath, frameBytes) => {
 	let videos = 0, zips = 0, other = 0
 	const entries = await fs.promises.readdir(capturesPath, { withFileTypes: true }).catch(() => [])
-	await Promise.all(entries.map(async (entry) => {
-		if (!entry.isFile()) return
+	const files = entries.filter((entry) => entry.isFile())
+	await mapLimit(files, FS_CONCURRENCY, async (entry) => {
 		const { size } = await fs.promises.stat(path.join(capturesPath, entry.name)).catch(() => ({ size: 0 }))
 		if (entry.name.endsWith(".mp4")) videos += size
 		else if (entry.name.endsWith(".zip")) zips += size
 		else other += size
-	}))
+	})
 	const objects = await dirFileBytes(path.join(process.env.storage_FOLDERPATH || process.cwd(), "objectCaptures"))
 	return { frames: frameBytes, videos, zips, objects, other }
 }

--- a/storage/backend/routes/events.js
+++ b/storage/backend/routes/events.js
@@ -1,7 +1,7 @@
 var express = require("express")
 var path = require("path")
 var fs = require("fs")
-var { auth, loadCameras, cameraConfDir, mapLimit } = require("lib")
+var { auth, loadCameras, cameraConfFiles, mapLimit } = require("lib")
 const { requireAdmin } = auth
 
 const pool = require("../lib/pool")
@@ -125,10 +125,9 @@ app.delete("/camera/:id", requireAdmin, async (req, res) => {
 		)
 		await pool.query("DELETE FROM frame_files WHERE camera = $1", [id])
 		await pool.query("DELETE FROM objects_detected WHERE camera = $1", [id])
-		const confDir = cameraConfDir()
-		if (confDir) {
-			await fs.promises.unlink(path.join(confDir, `cam${id}.conf`)).catch((e) => {
-				if (e.code !== "ENOENT") console.log(`STORAGE: failed to remove cam${id}.conf; camera may resurrect on reload`, e.message)
+		for (const file of cameraConfFiles(id)) {
+			await fs.promises.unlink(file).catch((e) => {
+				if (e.code !== "ENOENT") console.log(`STORAGE: failed to remove ${path.basename(file)}; camera may resurrect on reload`, e.message)
 			})
 		}
 		res.json({ deleted: true })

--- a/storage/backend/routes/events.js
+++ b/storage/backend/routes/events.js
@@ -1,7 +1,7 @@
 var express = require("express")
 var path = require("path")
 var fs = require("fs")
-var { auth, loadCameras } = require("lib")
+var { auth, loadCameras, cameraConfDir } = require("lib")
 const { requireAdmin } = auth
 
 const pool = require("../lib/pool")
@@ -123,6 +123,12 @@ app.delete("/camera/:id", requireAdmin, async (req, res) => {
 		)
 		await pool.query("DELETE FROM frame_files WHERE camera = $1", [id])
 		await pool.query("DELETE FROM objects_detected WHERE camera = $1", [id])
+		const confDir = cameraConfDir()
+		if (confDir) {
+			await fs.promises.unlink(path.join(confDir, `cam${id}.conf`)).catch((e) => {
+				if (e.code !== "ENOENT") console.log(`STORAGE: failed to remove cam${id}.conf; camera may resurrect on reload`, e.message)
+			})
+		}
 		res.json({ deleted: true })
 	} catch (e) {
 		res.status(500).json({ error: true })

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -2,7 +2,7 @@ const path = require("path")
 const fs = require("fs")
 const rimraf = require("rimraf")
 const moment = require("moment")
-const { loadCameras, webhookAlert } = require("lib")
+const { loadCameras, webhookAlert, mapLimit } = require("lib")
 
 const Pool = require("pg").Pool
 const pool = new Pool({
@@ -18,19 +18,6 @@ pool.on("error", (err) => {
 })
 
 const FS_CONCURRENCY = 64
-
-const mapLimit = async (items, limit, fn) => {
-	const results = new Array(items.length)
-	let next = 0
-	const worker = async () => {
-		while (next < items.length) {
-			const i = next++
-			results[i] = await fn(items[i], i)
-		}
-	}
-	await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
-	return results
-}
 
 const topLevelFileBytes = async (dir) => {
 	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -17,13 +17,28 @@ pool.on("error", (err) => {
 	console.log("STORAGE FILE POOL ERROR", err)
 })
 
+const FS_CONCURRENCY = 64
+
+const mapLimit = async (items, limit, fn) => {
+	const results = new Array(items.length)
+	let next = 0
+	const worker = async () => {
+		while (next < items.length) {
+			const i = next++
+			results[i] = await fn(items[i], i)
+		}
+	}
+	await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
+	return results
+}
+
 const topLevelFileBytes = async (dir) => {
 	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
-	const sizes = await Promise.all(entries.map(async (entry) => {
-		if (!entry.isFile()) return 0
+	const files = entries.filter((entry) => entry.isFile())
+	const sizes = await mapLimit(files, FS_CONCURRENCY, async (entry) => {
 		const { size } = await fs.promises.stat(path.join(dir, entry.name)).catch(() => ({ size: 0 }))
 		return size
-	}))
+	})
 	return sizes.reduce((sum, size) => sum + size, 0)
 }
 
@@ -89,19 +104,18 @@ module.exports = {
 	deleteFilesBeforeDateGlob: async (req, res) => {
 		const dir = req.body.appendedPath
 		const names = (req.deletedFileNames || []).filter(Boolean)
-		const tracked = await Promise.all(names.map(name =>
+		const tracked = await mapLimit(names, FS_CONCURRENCY, name =>
 			fs.promises.unlink(path.join(dir, path.basename(name))).then(() => true).catch((e) => e.code === "ENOENT")
-		))
+		)
 		if (req.beforeDate && req.numberOfFilesDeletedInDatabase > 0) {
 			const cutoff = moment.utc(req.beforeDate).valueOf()
 			const known = new Set(names.map(n => path.basename(n)))
 			const entries = await fs.promises.readdir(dir).catch(() => [])
-			await Promise.all(entries
-				.filter(f => f.endsWith(".jpg") && !known.has(f))
-				.map(async (f) => {
-					const captured = moment.utc(f.slice(0, 15), "YYYYMMDD-HHmmss", true)
-					if (captured.isValid() && captured.valueOf() < cutoff) await fs.promises.unlink(path.join(dir, f)).catch(() => {})
-				}))
+			const stale = entries.filter(f => f.endsWith(".jpg") && !known.has(f))
+			await mapLimit(stale, FS_CONCURRENCY, async (f) => {
+				const captured = moment.utc(f.slice(0, 15), "YYYYMMDD-HHmmss", true)
+				if (captured.isValid() && captured.valueOf() < cutoff) await fs.promises.unlink(path.join(dir, f)).catch(() => {})
+			})
 		}
 		const failed = tracked.filter(ok => !ok).length
 		if (failed) console.log(`STORAGE FILE UNLINK FAILED for ${failed} file(s) after DB rows deleted; orphans will be swept on next clean`)
@@ -183,9 +197,9 @@ module.exports = {
 					freed += parseInt(row.size) || 0
 				}
 
-				await Promise.all(batch.map(row =>
+				await mapLimit(batch, FS_CONCURRENCY, row =>
 					fs.promises.unlink(path.join(capturesPath, row.camera.toString(), row.name)).catch(() => {})
-				))
+				)
 				await pool.query("DELETE FROM frame_files WHERE id = ANY($1::int[])", [batch.map(r => r.id)])
 				deleted += batch.length
 

--- a/storage/test/events.test.js
+++ b/storage/test/events.test.js
@@ -103,14 +103,15 @@ describe("Events Routes", () => {
 			expect(res.status).toBe(400)
 		})
 
-		test("removes the camera's .conf so it does not resurrect on reload", async () => {
-			lib.cameraConfDir.mockReturnValueOnce("/etc/motion/cameraconf")
+		test("removes the camera's .conf (matched by camera_id, any filename) so it does not resurrect on reload", async () => {
+			lib.cameraConfFiles.mockReturnValueOnce(["/etc/motion/cameraconf/frontdoor.conf"])
 			const res = await supertest(app)
 				.delete("/camera/1")
 				.set("Cookie", "validCookie")
 			expect(res.status).toBe(200)
+			expect(lib.cameraConfFiles).toHaveBeenCalledWith("1")
 			const unlinked = fs.promises.unlink.mock.calls.map((c) => c[0])
-			expect(unlinked.some((p) => p.endsWith("cam1.conf"))).toBe(true)
+			expect(unlinked).toContain("/etc/motion/cameraconf/frontdoor.conf")
 		})
 
 		test("clears objects_detected rows and prefixed objectCaptures files", async () => {

--- a/storage/test/events.test.js
+++ b/storage/test/events.test.js
@@ -103,6 +103,16 @@ describe("Events Routes", () => {
 			expect(res.status).toBe(400)
 		})
 
+		test("removes the camera's .conf so it does not resurrect on reload", async () => {
+			lib.cameraConfDir.mockReturnValueOnce("/etc/motion/cameraconf")
+			const res = await supertest(app)
+				.delete("/camera/1")
+				.set("Cookie", "validCookie")
+			expect(res.status).toBe(200)
+			const unlinked = fs.promises.unlink.mock.calls.map((c) => c[0])
+			expect(unlinked.some((p) => p.endsWith("cam1.conf"))).toBe(true)
+		})
+
 		test("clears objects_detected rows and prefixed objectCaptures files", async () => {
 			fs.promises.readdir.mockResolvedValueOnce(["1-100.jpg", "1-200.jpg", "12-300.jpg", "2-400.jpg"])
 			const res = await supertest(app)


### PR DESCRIPTION
## Fixes
| Issue | Fix |
|-------|-----|
| `stripCreds` clobbered single-letter `u`/`p` params | Parse with WHATWG `URL`, strip userinfo + sensitive params |
| RTSP password containing `/` or `@` leaked to client | Same URL-based stripping; fallback regex strips to the **last** `@` before `?`/`#` (`[^?#]*@`), so passwords with embedded `/`/`@` are fully redacted (tradeoff: a path containing `@` is over-stripped) |
| `/restart` missing admin gate | Added `requireAdmin` |
| Model integrity bypass when custom URL lacks SHA256 | Fail startup unless `object_MODEL_SHA256` is set |
| Deleted cameras resurrected from leftover `.conf` | Unlink the camera's `.conf` on delete, matched by in-file `camera_id` (any filename, not just `cam<id>.conf`); `cameraconf` volume remounted read-write so the container can delete it |
| Unbounded fs concurrency in storage cleanup fan-out (`routes/lib/file.js` and `routes/events.js`) | Cap via `mapLimit` (concurrency 64); helper deduped into `lib/utils/mapLimit.js` |
| Single-user change wiped entire session cache | Targeted `invalidateUser` (jti→username tracking), relayed across cluster workers via `sessionInvalidateUser` |
