### PR TITLE
Fix Tier 1 auth/security merge blockers (#227)

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -13,7 +13,7 @@ Three access levels: public, session (`authorize`), admin (`requireAdmin`). Auth
 - theme and password changes
 - list cameras (RTSP credentials stripped) for the web app
 
-`setup_TOKEN` is required — the service won't boot without it ([server.js](server.js)). A valid token bootstraps the first admin (empty `auth` table) or resets an existing one (recovery). `/setup` is public but rate-limited.
+`setup_TOKEN` is required — the service won't boot without it ([server.js](server.js)). A valid token bootstraps the first admin only when no admin exists; it cannot reset or take over an existing account. `/setup` is public but rate-limited.
 
 ---
 # Web app

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -87,7 +87,7 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 			if (process.env.setup_TOKEN) {
 				const noAdmin = (await client.query("SELECT 1 FROM auth WHERE role = 'admin' LIMIT 1")).rowCount === 0
 				const target = (await client.query("SELECT role FROM auth WHERE username = $1", [username])).rows[0]
-				const allowed = target ? target.role === "admin" : noAdmin
+				const allowed = noAdmin && !target
 				if (!allowed) return { rowCount: 0 }
 				const upsert = await client.query(
 					"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
@@ -235,12 +235,15 @@ app.delete("/users/:username", authorize, requireAdmin, async (req, res) => {
 })
 
 app.post("/password", authorize, validateBody, async (req, res) => {
-	const { password } = req.body
+	const { password, currentPassword } = req.body
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	const username = req.decoded.username
 	try {
 		const hash = await hashPassword(password)
 		await withTransaction(async (client) => {
+			const current = (await client.query("SELECT hash, force_password_change FROM auth WHERE username = $1", [username])).rows[0]
+			if (!current) throw new HttpError(404)
+			if (!current.force_password_change && !(await bcrypt.compare(currentPassword ?? "", current.hash))) throw new HttpError(400, "Current password is incorrect")
 			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2", [hash, username])
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})
@@ -257,7 +260,7 @@ app.post("/logout", authorize, async (req, res) => {
 			await pool.query("UPDATE sessions SET revoked = TRUE WHERE jti = $1", [req.decoded.jti])
 			auth.invalidateSession(req.decoded.jti)
 		}
-		res.clearCookie("bearertoken", { httpOnly: true, secure: process.env.NODE_ENV !== "development", sameSite: "lax" })
+		res.clearCookie("bearertoken", { httpOnly: true, secure: req.secure, sameSite: "lax" })
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -78,7 +78,7 @@ module.exports = {
 				res.cookie("bearertoken", `Bearer ${token}`, {
 					maxAge: 2592000000,
 					httpOnly: true,
-					secure: process.env.NODE_ENV !== "development",
+					secure: req.secure,
 					sameSite: "lax"
 				})
 				res.send({ error: false, role: req.userRole, forcePasswordChange: req.forcePasswordChange, theme: req.userTheme })

--- a/command/frontend/hooks/useStorageUsage.js
+++ b/command/frontend/hooks/useStorageUsage.js
@@ -8,7 +8,7 @@ const useStorageUsage = () => {
 		setData(d => ({ ...d, loading: true }))
 		request("/usage", { method: "GET" }, prom =>
 			jsonProcessing(prom, (res) => {
-				if (res && !res.error) {
+				if (res && !res.error && Array.isArray(res.cameras)) {
 					setData({ ...res, loading: false })
 				} else {
 					setData(d => ({ ...d, loading: false }))

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -72,19 +72,19 @@ describe("Authorization Routes", () => {
 			expect(res.body).toEqual({ error: false })
 		})
 
-		test("resets the password of an existing admin with a valid setup_TOKEN", async () => {
+		test("rejects resetting an existing admin while an admin exists", async () => {
 			process.env.setup_TOKEN = "recovery-token"
 			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
 			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
 			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // an admin already exists
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin" }] }) // target is that admin
-			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // upsert (ON CONFLICT)
 			const res = await supertest(app)
 				.post("/authorization/setup")
 				.send({ username: "existingadmin", password: "newpassword123", token: "recovery-token" })
-			expect(res.status).toBe(200)
-			expect(res.body).toEqual({ error: false })
-			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1", ["existingadmin"])
+			expect(res.status).toBe(403)
+			expect(res.body).toEqual({ error: true })
+			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
+			expect(mockedPool.query).not.toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1", ["existingadmin"])
 		})
 
 		test("rejects taking over an existing non-admin account when no admin exists", async () => {
@@ -308,8 +308,13 @@ describe("Authorization Routes", () => {
 	})
 
 	describe("GET /authorization/users", () => {
-		test("redirects to login with no token", async () => {
+		test("returns 401 with no token", async () => {
 			const res = await supertest(app).get("/authorization/users")
+			expect(res.status).toBe(401)
+		})
+
+		test("redirects a browser navigation with no token", async () => {
+			const res = await supertest(app).get("/authorization/users").set("Sec-Fetch-Mode", "navigate")
 			expect(res.status).toBe(303)
 		})
 
@@ -592,9 +597,9 @@ describe("Authorization Routes", () => {
 	})
 
 	describe("GET /authorization/users/:username/sessions", () => {
-		test("redirects to login with no token", async () => {
+		test("returns 401 with no token", async () => {
 			const res = await supertest(app).get("/authorization/users/bob/sessions")
-			expect(res.status).toBe(303)
+			expect(res.status).toBe(401)
 		})
 
 		test("returns 403 for non-admin token", async () => {
@@ -685,13 +690,13 @@ describe("Authorization Routes", () => {
 			expect(res.body).toEqual({ error: true, errors: "Password must be at least 8 characters." })
 		})
 
-		test("returns 200 and clears the temp-password expiry on success", async () => {
+		test("returns 200 for a voluntary change with the correct current password", async () => {
 			const spy = jest.spyOn(auth, "invalidateUser")
 			const token = jwt.sign({ username: "bob", role: "user", jti: "jti-user" }, "test-secret")
 			const res = await supertest(app)
 				.post("/authorization/password")
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
-				.send({ password: "newpassword" })
+				.send({ password: "newpassword", currentPassword: "mockedPassword" })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith(
@@ -703,6 +708,34 @@ describe("Authorization Routes", () => {
 				["bob", "jti-user"]
 			)
 			expect(spy).toHaveBeenCalled()
+		})
+
+		test("returns 400 for a voluntary change with a wrong current password", async () => {
+			const token = jwt.sign({ username: "bob", role: "user", jti: "jti-user" }, "test-secret")
+			const res = await supertest(app)
+				.post("/authorization/password")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.send({ password: "newpassword", currentPassword: "wrongpass" })
+			expect(res.status).toBe(400)
+			expect(res.body).toEqual({ error: true, errors: "Current password is incorrect" })
+			expect(mockedPool.query).not.toHaveBeenCalledWith(
+				"UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2",
+				expect.anything()
+			)
+		})
+
+		test("allows a forced change without the current password", async () => {
+			const token = jwt.sign({ username: "bob", role: "user", jti: "jti-user" }, "test-secret")
+			mockedPool.query
+				.mockResolvedValueOnce({ rows: [{ role: "user", force_password_change: true, revoked: false, last_seen: new Date() }], rowCount: 1 }) // authorize session lookup
+				.mockResolvedValueOnce({}) // BEGIN
+				.mockResolvedValueOnce({ rows: [{ hash: "irrelevant", force_password_change: true }], rowCount: 1 }) // SELECT current
+			const res = await supertest(app)
+				.post("/authorization/password")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.send({ password: "newpassword" })
+			expect(res.status).toBe(200)
+			expect(res.body).toEqual({ error: false })
 		})
 	})
 
@@ -888,7 +921,10 @@ describe("Authorization Routes", () => {
 		})
 
 		test("allows the password-change route through", async () => {
-			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "user", force_password_change: true, revoked: false }], rowCount: 1 })
+			mockedPool.query
+				.mockResolvedValueOnce({ rows: [{ role: "user", force_password_change: true, revoked: false }], rowCount: 1 }) // authorize lookup
+				.mockResolvedValueOnce({}) // BEGIN
+				.mockResolvedValueOnce({ rows: [{ hash: "irrelevant", force_password_change: true }], rowCount: 1 }) // SELECT current
 			const res = await supertest(app)
 				.post("/authorization/password")
 				.set("Cookie", `bearertoken=Bearer%20${token}`)

--- a/command/test/cameras.test.js
+++ b/command/test/cameras.test.js
@@ -34,9 +34,9 @@ const { mockedPool } = require("pg")
 
 describe("Cameras Route", () => {
 	describe("GET /cameras", () => {
-		test("redirects to login with no token", async () => {
+		test("returns 401 with no token", async () => {
 			const res = await supertest(app).get("/cameras/")
-			expect(res.status).toBe(303)
+			expect(res.status).toBe(401)
 		})
 
 		test("returns 200 with id+name+rtsp_url list and strips embedded credentials", async () => {

--- a/env.example
+++ b/env.example
@@ -40,7 +40,7 @@ gateway_HTTPS_Redirect = (true | false) ***
 command_ON = (true | false)
 command_PORT = Port to run command server for http
 command_HOST = https://command.server.example or http://127.0.0.1:8080
-setup_TOKEN = required token to gate /authorization/setup first time admin creation
+setup_TOKEN = required token gating /authorization/setup; only creates the first admin when none exists, cannot reset an existing admin
 
 ##################################################################
 # Schedule

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -54,6 +54,38 @@ describe("makeAuthorize scheduler path", () => {
 	})
 })
 
+describe("unauthorized response shape", () => {
+	const authorize = createAuthorize(null)
+	const run = (headers) => {
+		const req = { method: "GET", path: "/x", headers, cookies: {} }
+		const res = makeRes()
+		authorize(req, res, jest.fn())
+		return res
+	}
+
+	test("GET XHR without navigation headers returns 401", () => {
+		const res = run({})
+		expect(res.status).toHaveBeenCalledWith(401)
+		expect(res.redirect).not.toHaveBeenCalled()
+	})
+
+	test("GET browser navigation redirects to the login form", () => {
+		const res = run({ "sec-fetch-mode": "navigate" })
+		expect(res.redirect).toHaveBeenCalledWith(303, "/?loginForm")
+	})
+
+	test("GET document request (text/html accept, no sec-fetch-mode) redirects", () => {
+		const res = run({ accept: "text/html,application/xhtml+xml" })
+		expect(res.redirect).toHaveBeenCalledWith(303, "/?loginForm")
+	})
+
+	test("GET fetch (sec-fetch-mode cors) returns 401 even with an html accept header", () => {
+		const res = run({ "sec-fetch-mode": "cors", accept: "text/html" })
+		expect(res.status).toHaveBeenCalledWith(401)
+		expect(res.redirect).not.toHaveBeenCalled()
+	})
+})
+
 describe("makeAuthorize jwt pool path", () => {
 	test("rejects a token without a jti", async () => {
 		const token = jwt.sign({ username: "bob" }, process.env.SECRETKEY)

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -46,9 +46,14 @@ const connectSessionSync = (client) => {
 	client.on("sessionInvalidateAll", () => { epoch++; sessionCache.clear() })
 }
 
+const respondUnauthorized = (req, res) => {
+	const mode = req.headers["sec-fetch-mode"]
+	const isNavigation = req.method === "GET" && (mode === "navigate" || (!mode && (req.headers.accept || "").includes("text/html")))
+	return isNavigation ? res.redirect(303, "/?loginForm") : res.status(401).send({ error: "unauthorized" })
+}
+
 const verifyJwt = (token, req, res, next, pool) => {
-	const { method } = req
-	const unauthorized = () => method == "GET" ? res.redirect(303, "/?loginForm") : res.status(401).send({ error: "unauthorized" })
+	const unauthorized = () => respondUnauthorized(req, res)
 	jwt.verify(token, secretKey, async (err, decoded) => {
 		if (err) {
 			unauthorized()
@@ -101,8 +106,7 @@ const verifyJwt = (token, req, res, next, pool) => {
 }
 
 const makeAuthorize = (pool) => (req, res, next) => {
-	const { method } = req
-	const unauthorized = () => method == "GET" ? res.redirect(303, "/?loginForm") : res.status(401).send({ error: "unauthorized" })
+	const unauthorized = () => respondUnauthorized(req, res)
 	if (req.headers.authorization != undefined && req.headers.authorization == process.env.scheduler_AUTH && schedulableUrls.includes(req.path)) {
 		req.decoded = { username: "scheduler", role: "admin" }
 		next()


### PR DESCRIPTION
Fixes all five Tier-1 auth/security merge blockers from the PR #178 review.

Closes #227
Closes #228
Closes #229
Closes #230
Closes #231
Closes #232

## Fixes

**#228 — `setup_TOKEN` standing admin-takeover** (`authorization.js`)
`allowed = target ? target.role === "admin" : noAdmin` let the token reset an existing admin at any time. Changed to `allowed = noAdmin && !target`: the token now only bootstraps the first admin when **no admin exists** and the username is new. This preserves the intended recovery-when-no-admin path (#210/#216) while closing the takeover. Docs (`env.example`, `command/README.md`) corrected to match.

**#229 — password change with no proof of current password** (`authorization.js`)
`POST /password` now reads `currentPassword` and `bcrypt.compare`s it for voluntary changes. The forced/temp-password flow (`force_password_change = TRUE`) stays exempt, so the only real caller (the mandatory-reset screen) is unaffected. No frontend change — there is no voluntary-change UI.

**#230 — `secure` cookie keyed on `NODE_ENV`** (`lib/auth.js`, `authorization.js`)
Swapped `secure: process.env.NODE_ENV !== "development"` for `secure: req.secure` on both the login `cookie` and logout `clearCookie`. `trust proxy` + the gateway's `xfwd` make `req.secure` reflect the client's real protocol, so plain-HTTP LAN logins stop silently dropping the cookie.

**#231 — unauthorized GETs return login HTML (303) instead of 401** (`lib/utils/auth.js`)
Extracted a shared `respondUnauthorized`: it redirects (303) only for genuine top-level navigations (`Sec-Fetch-Mode: navigate`, or `Accept: text/html` when the header is absent) and returns 401 for all XHR/fetch/media requests. SPA routes are served statically without auth, so every GET that reaches `authorize` is an API call that now correctly 401s.

**#232 — redirect-to-HTML `/usage` crashes Stats** (`useStorageUsage.js`)
Root cause is #231; also added a defense-in-depth shape guard (`Array.isArray(res.cameras)`) so a non-array body can never spread into state and blow up `[...usage.cameras]`.

## Tests
- Flipped the "resets existing admin" test to assert the takeover is now rejected (403).
- Added voluntary-change (correct/wrong current password) and forced-change coverage for `/password`.
- Updated unauthenticated GET expectations to 401; added navigation-vs-XHR discrimination coverage.
- Full suite green: **41 suites / 360 tests**.
