### PR TITLE
Fix issue 233 tier-2 correctness bugs

### DIFF
--- a/command/backend/routes/cameras.js
+++ b/command/backend/routes/cameras.js
@@ -15,7 +15,7 @@ const stripCreds = (url) => {
 		}
 		return u.toString()
 	} catch {
-		return url.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^/?#]*@/i, "$1")
+		return url
 	}
 }
 

--- a/command/backend/routes/cameras.js
+++ b/command/backend/routes/cameras.js
@@ -6,7 +6,6 @@ const app = express.Router()
 const SENSITIVE_PARAM = /^(username|user|usr|password|passwd|pass|pwd|pw|auth|token|secret|u|p)$/i
 
 const stripCreds = (url) => {
-	let out = url
 	try {
 		const u = new URL(url)
 		u.username = ""
@@ -14,11 +13,10 @@ const stripCreds = (url) => {
 		for (const key of [...u.searchParams.keys()]) {
 			if (SENSITIVE_PARAM.test(key)) u.searchParams.set(key, "***")
 		}
-		out = u.toString()
-	} catch {}
-	return /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*@/i.test(url)
-		? out.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^?#]*@/i, "$1")
-		: out
+		return u.toString()
+	} catch {
+		return url.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^/?#]*@/i, "$1")
+	}
 }
 
 app.get("/", (req, res) => {

--- a/command/frontend/app/ScheduleDashboard.jsx
+++ b/command/frontend/app/ScheduleDashboard.jsx
@@ -108,7 +108,7 @@ const ScheduleDashboardMini = ({ withButton }) => {
 							<div className="flex shrink-0 items-center gap-2">
 								<Switch
 									checked={item.running}
-									disabled={busyId === item.id}
+									disabled={busyId === item.id || item.protected}
 									onCheckedChange={() => { setBusyId(item.id); item.running ? stopTask(item.id) : restartTask(item.id) }}
 								/>
 								{!item.protected && (
@@ -221,7 +221,7 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 											<div className="flex shrink-0 items-center gap-2">
 												<Switch
 													checked={task.running}
-													disabled={busyId === task.id}
+													disabled={busyId === task.id || task.protected}
 													onCheckedChange={() => { setBusyId(task.id); task.running ? stopTask(task.id) : restartTask(task.id) }}
 												/>
 												{!task.protected && (
@@ -260,7 +260,7 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 														<div className="flex justify-end items-center gap-2">
 															<Switch
 																checked={task.running}
-																disabled={busyId === task.id}
+																disabled={busyId === task.id || task.protected}
 																onCheckedChange={() => { setBusyId(task.id); task.running ? stopTask(task.id) : restartTask(task.id) }}
 															/>
 															{!task.protected && (

--- a/command/frontend/hooks/useLiveVideo.js
+++ b/command/frontend/hooks/useLiveVideo.js
@@ -19,7 +19,7 @@ const listVideos = (cameras, setState) => {
 				loading: false,
 				lastUpdated: moment().format("h:mm:ss a"),
 				videoList: nums.map((num, idx) => {
-					const cam = cameras.find((c) => c.id === num) || cameras[idx]
+					const cam = cameras.find((c) => c.id === num)
 					return {
 						camera: cam ? cam.name : `Camera ${num}`,
 						online: true,

--- a/command/frontend/js/letterbox.js
+++ b/command/frontend/js/letterbox.js
@@ -12,7 +12,7 @@ const detectGrayPad = (img) => {
 		ctx.drawImage(img, 0, 0)
 		const isGray = (data) => {
 			for (let i = 0; i < data.length; i += 4)
-				if (Math.abs(data[i] - GRAY) > GRAY_TOL) return false
+				if (Math.abs(data[i] - GRAY) > GRAY_TOL || Math.abs(data[i + 1] - GRAY) > GRAY_TOL || Math.abs(data[i + 2] - GRAY) > GRAY_TOL) return false
 			return true
 		}
 		while (out.top < h / 2 && isGray(ctx.getImageData(0, out.top, w, 1).data)) out.top++

--- a/command/test/cameras.test.js
+++ b/command/test/cameras.test.js
@@ -12,10 +12,11 @@ jest.mock("fs", () => {
 			if (p.endsWith("cam3.conf")) return "camera_id 3\ncamera_name gate\nnetcam_url rtsp://user:p@ss@3.3.3.3/cam\n"
 			if (p.endsWith("cam4.conf")) return "camera_id 4\ncamera_name yard\nnetcam_url rtsp://4.4.4.4/cam?user=admin&p=secret\n"
 			if (p.endsWith("cam5.conf")) return "camera_id 5\ncamera_name shed\nnetcam_url rtsp://admin:p@ss/word@5.5.5.5/cam\n"
+			if (p.endsWith("cam6.conf")) return "camera_id 6\ncamera_name front\nnetcam_url rtsp://user:pass@192.168.1.5/cam@1/stream\n"
 			return actual.readFileSync(p, enc)
 		}),
 		readdirSync: jest.fn((p) => {
-			if (p === "/etc/motion/cameraconf") return ["cam1.conf", "cam2.conf", "cam3.conf", "cam4.conf", "cam5.conf"]
+			if (p === "/etc/motion/cameraconf") return ["cam1.conf", "cam2.conf", "cam3.conf", "cam4.conf", "cam5.conf", "cam6.conf"]
 			return actual.readdirSync(p)
 		})
 	}
@@ -51,7 +52,8 @@ describe("Cameras Route", () => {
 				{ id: 2, name: "outdoor", rtsp_url: "rtsp://2.2.2.2/cam" },
 				{ id: 3, name: "gate", rtsp_url: "rtsp://3.3.3.3/cam" },
 				{ id: 4, name: "yard", rtsp_url: "rtsp://4.4.4.4/cam?user=***&p=***" },
-				{ id: 5, name: "shed", rtsp_url: "rtsp://5.5.5.5/cam" }
+				{ id: 5, name: "shed", rtsp_url: "rtsp://ss/word@5.5.5.5/cam" },
+				{ id: 6, name: "front", rtsp_url: "rtsp://192.168.1.5/cam@1/stream" }
 			])
 		})
 	})

--- a/command/test/cameras.test.js
+++ b/command/test/cameras.test.js
@@ -8,11 +8,11 @@ jest.mock("fs", () => {
 		readFileSync: jest.fn((p, enc) => {
 			if (p === "/etc/motion/motion.conf") return "camera_dir /etc/motion/cameraconf\n"
 			if (p.endsWith("cam1.conf")) return "camera_id 1\ncamera_name indoor\nnetcam_url rtsp://1.1.1.1/cam\n"
-			if (p.endsWith("cam2.conf")) return "camera_id 2\ncamera_name outdoor\nnetcam_url rtsp://user:secret@2.2.2.2/cam\n"
+			if (p.endsWith("cam2.conf")) return "camera_id 2\ncamera_name outdoor\nnetcam_url rtsp://2.2.2.2/cam\nnetcam_userpass user:secret\n"
 			if (p.endsWith("cam3.conf")) return "camera_id 3\ncamera_name gate\nnetcam_url rtsp://user:p@ss@3.3.3.3/cam\n"
 			if (p.endsWith("cam4.conf")) return "camera_id 4\ncamera_name yard\nnetcam_url rtsp://4.4.4.4/cam?user=admin&p=secret\n"
 			if (p.endsWith("cam5.conf")) return "camera_id 5\ncamera_name shed\nnetcam_url rtsp://admin:p@ss/word@5.5.5.5/cam\n"
-			if (p.endsWith("cam6.conf")) return "camera_id 6\ncamera_name front\nnetcam_url rtsp://user:pass@192.168.1.5/cam@1/stream\n"
+			if (p.endsWith("cam6.conf")) return "camera_id 6\ncamera_name front\nnetcam_url rtsp://192.168.1.5/cam@1/stream\n"
 			return actual.readFileSync(p, enc)
 		}),
 		readdirSync: jest.fn((p) => {
@@ -40,7 +40,8 @@ describe("Cameras Route", () => {
 			expect(res.status).toBe(401)
 		})
 
-		test("returns 200 with id+name+rtsp_url list and strips embedded credentials", async () => {
+		test("excludes cameras with embedded credentials and scrubs query-param creds", async () => {
+			const spy = jest.spyOn(console, "error").mockImplementation(() => {})
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "user", revoked: false }], rowCount: 1 })
 			const token = jwt.sign({ username: "test", role: "user", jti: "jti-user" }, "test-secret")
 			const res = await supertest(app)
@@ -50,11 +51,10 @@ describe("Cameras Route", () => {
 			expect(res.body).toEqual([
 				{ id: 1, name: "indoor", rtsp_url: "rtsp://1.1.1.1/cam" },
 				{ id: 2, name: "outdoor", rtsp_url: "rtsp://2.2.2.2/cam" },
-				{ id: 3, name: "gate", rtsp_url: "rtsp://3.3.3.3/cam" },
 				{ id: 4, name: "yard", rtsp_url: "rtsp://4.4.4.4/cam?user=***&p=***" },
-				{ id: 5, name: "shed", rtsp_url: "rtsp://ss/word@5.5.5.5/cam" },
 				{ id: 6, name: "front", rtsp_url: "rtsp://192.168.1.5/cam@1/stream" }
 			])
+			spy.mockRestore()
 		})
 	})
 })

--- a/lib/test/loadCameras.test.js
+++ b/lib/test/loadCameras.test.js
@@ -9,11 +9,10 @@ jest.mock("fs", () => {
 			if (p.endsWith("plain.conf")) return "camera_id 1\ncamera_name plain\nnetcam_url rtsp://192.168.1.1/stream\n"
 			if (p.endsWith("withcreds.conf")) return "camera_id 2\ncamera_name creds\nnetcam_url rtsp://192.168.1.2/stream\nnetcam_userpass admin:pass\n"
 			if (p.endsWith("dollarsign.conf")) return "camera_id 3\ncamera_name dollar\nnetcam_url rtsp://192.168.1.3/stream\nnetcam_userpass admin:p$1x$$end\n"
-			if (p.endsWith("staleembedded.conf")) return "camera_id 4\ncamera_name staleembedded\nnetcam_url rtsp://old:old@192.168.1.4/stream\nnetcam_userpass admin:pass\n"
 			return actual.readFileSync(p, enc)
 		}),
 		readdirSync: jest.fn((p) => {
-			if (p === "/etc/motion/cameraconf") return ["plain.conf", "withcreds.conf", "dollarsign.conf", "staleembedded.conf"]
+			if (p === "/etc/motion/cameraconf") return ["plain.conf", "withcreds.conf", "dollarsign.conf"]
 			return actual.readdirSync(p)
 		})
 	}
@@ -40,11 +39,6 @@ describe("loadCameras full_url", () => {
 	test("password containing $ is URI encoded correctly", () => {
 		const cam = cams.find(c => c.name === "dollar")
 		expect(cam.full_url).toBe("rtsp://admin:p%241x%24%24end@192.168.1.3/stream")
-	})
-
-	test("netcam_url with stale embedded userinfo: netcam_userpass replaces it instead of duplicating", () => {
-		const cam = cams.find(c => c.name === "staleembedded")
-		expect(cam.full_url).toBe("rtsp://admin:pass@192.168.1.4/stream")
 	})
 })
 
@@ -82,15 +76,26 @@ describe("loadCameras URL filter", () => {
 			if (p.endsWith("nourl.conf")) return "camera_id 2\ncamera_name nourl\n"
 			if (p.endsWith("badurl.conf")) return "camera_id 3\ncamera_name badurl\nnetcam_url not-a-url\n"
 			if (p.endsWith("badport.conf")) return "camera_id 4\ncamera_name badport\nnetcam_url rtsp://1.1.1.1:99999/stream\n"
+			if (p.endsWith("embeddedcreds.conf")) return "camera_id 5\ncamera_name embeddedcreds\nnetcam_url rtsp://user:pass@1.1.1.1/stream\n"
 			return ""
 		})
-		readdirSync.mockImplementation((p) => (p === "/etc/motion/cameraconf" ? ["valid.conf", "nourl.conf", "badurl.conf", "badport.conf"] : []))
+		readdirSync.mockImplementation((p) => (p === "/etc/motion/cameraconf" ? ["valid.conf", "nourl.conf", "badurl.conf", "badport.conf", "embeddedcreds.conf"] : []))
 	})
 
 	test("excludes cameras with missing or invalid netcam_url", () => {
+		const spy = jest.spyOn(console, "error").mockImplementation(() => {})
 		const cams = loadCameras()
 		expect(cams).toHaveLength(1)
 		expect(cams[0].name).toBe("valid")
+		spy.mockRestore()
+	})
+
+	test("excludes camera with credentials embedded in netcam_url", () => {
+		const spy = jest.spyOn(console, "error").mockImplementation(() => {})
+		const cams = loadCameras()
+		expect(cams.find(c => c.name === "embeddedcreds")).toBeUndefined()
+		expect(spy).toHaveBeenCalledWith(expect.stringContaining("netcam_userpass"))
+		spy.mockRestore()
 	})
 
 	test("excludes camera whose url passes the scheme regex but fails new URL()", () => {

--- a/lib/utils/loadCameras.js
+++ b/lib/utils/loadCameras.js
@@ -24,11 +24,12 @@ function buildFullUrl(rtsp_url, userpass) {
 			? encodeURIComponent(userpass.slice(0, idx)) + ":" + encodeURIComponent(userpass.slice(idx + 1))
 			: encodeURIComponent(userpass)
 	}
-	return encodedUserpass ? rtsp_url.replace(/^([a-z][a-z0-9+\-.]*:\/\/)(?:[^@/]*@)?/i, (_, proto) => `${proto}${encodedUserpass}@`) : rtsp_url
+	return encodedUserpass ? rtsp_url.replace(/^([a-z][a-z0-9+\-.]*:\/\/)/i, (_, proto) => `${proto}${encodedUserpass}@`) : rtsp_url
 }
 
 function urlProblem(rtsp_url, full_url) {
 	if (!rtsp_url || !/^[a-z][a-z0-9+\-.]*:\/\//i.test(rtsp_url)) return "missing or invalid scheme (e.g. rtsp://)"
+	if (/^[a-z][a-z0-9+\-.]*:\/\/[^/?#]*@/i.test(rtsp_url)) return "credentials must be set via netcam_userpass, not embedded in netcam_url"
 	try {
 		new URL(rtsp_url)
 		new URL(full_url)

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -94,7 +94,7 @@ module.exports = {
 		const tracked = await mapLimit(names, FS_CONCURRENCY, name =>
 			fs.promises.unlink(path.join(dir, path.basename(name))).then(() => true).catch((e) => e.code === "ENOENT")
 		)
-		if (req.beforeDate && req.numberOfFilesDeletedInDatabase > 0) {
+		if (req.beforeDate) {
 			const cutoff = moment.utc(req.beforeDate).valueOf()
 			const known = new Set(names.map(n => path.basename(n)))
 			const entries = await fs.promises.readdir(dir).catch(() => [])

--- a/storage/backend/routes/lib/zip.js
+++ b/storage/backend/routes/lib/zip.js
@@ -47,12 +47,19 @@ const zip = (archive, camera, frames, start, end, save, req, res) => {
 			const txtPath = path.join(imgDir, `zip_${rand}.txt`)
 			var output = fs.createWriteStream(zipPath)
 			let cancelled = false
+			let alerted = false
+			const alertFailure = () => {
+				if(alerted) return
+				alerted = true
+				webhookAlert(`Your zip (${rand}) could not be completed.`)
+			}
 
 			output.on("error", (err) => {
 				cancelled = true
 				console.log("ZIP OUTPUT ERROR: " + err.message)
 				fs.unlink(txtPath, () => {})
 				fs.unlink(zipPath, () => {})
+				alertFailure()
 			})
 
 			console.log("SENDING START ALERT")
@@ -74,7 +81,7 @@ const zip = (archive, camera, frames, start, end, save, req, res) => {
 				console.log("An error occurred: " + err.message)
 				fs.unlink(txtPath, () => {
 					if(!cancelled){
-						webhookAlert(`Your zip (${rand}) could not be completed.`)
+						alertFailure()
 					}
 					fs.unlink(zipPath, () => {})
 				})

--- a/storage/backend/routes/lib/zip.js
+++ b/storage/backend/routes/lib/zip.js
@@ -113,6 +113,7 @@ const zip = (archive, camera, frames, start, end, save, req, res) => {
 }
 
 module.exports = {
+	zip,
 	createZip: (req, res) => {
 		let { camera, start, end, save, skip } = req.body
 

--- a/storage/test/convert.test.js
+++ b/storage/test/convert.test.js
@@ -306,4 +306,30 @@ describe("Convert Routes", () => {
 				.expect(200, { deleted: false, id }, done)
 		})
 	})
+
+	describe("zip save-path output error", () => {
+		const { EventEmitter } = require("events")
+		const fs = require("fs")
+		const lib = require("lib")
+		const { zip } = require("../backend/routes/lib/zip.js")
+
+		test("alerts exactly once when the output stream errors and dedups repeats", () => {
+			lib.webhookAlert.mockClear()
+			const output = new EventEmitter()
+			const writeStreamSpy = jest.spyOn(fs, "createWriteStream").mockReturnValue(output)
+			const writeFileSpy = jest.spyOn(fs, "writeFile").mockImplementation((p, d, cb) => cb && cb())
+			const archive = Object.assign(new EventEmitter(), { pipe: jest.fn(), finalize: jest.fn(), abort: jest.fn() })
+
+			zip(archive, 1, 5, "20210101-000000", "20210102-000000", true, { body: {} }, { send: jest.fn() })
+
+			output.emit("error", new Error("ENOSPC: no space left on device"))
+			output.emit("error", new Error("ENOSPC: no space left on device"))
+
+			const failureCalls = lib.webhookAlert.mock.calls.filter(c => /could not be completed/.test(c[0]))
+			expect(failureCalls).toHaveLength(1)
+
+			writeStreamSpy.mockRestore()
+			writeFileSpy.mockRestore()
+		})
+	})
 })

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -205,18 +205,19 @@ describe("File Routes", () => {
 				readdirSpy.mockRestore()
 			})
 
-			test("does not sweep orphans when the database delete matched no rows", async () => {
+			test("sweeps orphans past the cutoff even when the database delete matched no rows", async () => {
 				query.mockImplementationOnce(() => Promise.resolve({ rows: [] }))
 				const dir = path.join("/tmp/storage-file-test", "./shared/captures/", "1")
 				const readdirSpy = jest.spyOn(fs.promises, "readdir")
-					.mockResolvedValue(["20200101-000000-00.jpg"])
+					.mockResolvedValue(["20200101-000000-00.jpg", "20991231-235959-00.jpg"])
 				const res = await supertest(app)
 					.post("/file/pathClean")
 					.send({ camera: 1, days: 1 })
 					.set("Cookie", cookieWithBearerToken)
 				expect(res.status).toBe(200)
 				expect(res.body).toEqual({ deleted: false })
-				expect(unlinkSpy).not.toHaveBeenCalledWith(path.join(dir, "20200101-000000-00.jpg"))
+				expect(unlinkSpy).toHaveBeenCalledWith(path.join(dir, "20200101-000000-00.jpg"))
+				expect(unlinkSpy).not.toHaveBeenCalledWith(path.join(dir, "20991231-235959-00.jpg"))
 				readdirSpy.mockRestore()
 			})
 


### PR DESCRIPTION
Fixes the six Tier-2 functional-correctness bugs tracked in #233.

Closes #234, closes #235, closes #236, closes #237, closes #238, closes #239.

## Changes

- **#234 `command/backend/routes/cameras.js` + `lib/utils/loadCameras.js`** — credentials embedded directly in `netcam_url` are now **rejected at load** (`urlProblem`), forcing credentials through the `netcam_userpass` field, which `buildFullUrl` already percent-encodes. `stripCreds` collapses to query-param scrubbing only. This makes the `new URL()` credential misparse structurally impossible: previously a password containing an unencoded `/` (e.g. `rtsp://admin:p@ss/word@5.5.5.5/cam`) parsed to `rtsp://ss/word@5.5.5.5/cam`, disclosing a password fragment and burying the real host in the path. Credential-less RTSP paths containing `@` (e.g. `.../cam@1/stream`) now display intact.
- **#235 `storage/backend/routes/lib/file.js`** — the on-disk orphan `.jpg` sweep is now gated only on `beforeDate`, not on `numberOfFilesDeletedInDatabase > 0`, so true orphans are reclaimable even after the DB rows are already gone.
- **#236 `command/frontend/app/ScheduleDashboard.jsx`** — the running-toggle `Switch` is now `disabled` for `protected` tasks in all three renders (mini / mobile / table), so protected tasks no longer show an enabled toggle that silently 400s and snaps back.
- **#237 `command/frontend/js/letterbox.js`** — gray-pad detection now requires all three channels (R/G/B) within `GRAY ± GRAY_TOL`, not just red, so reddish/olive edges no longer produce a false `contentPad` and mis-scaled boxes.
- **#238 `storage/backend/routes/lib/zip.js`** — added a deduped `alertFailure()` helper fired from `output.on("error")` (and reused by `archive.on("error")`), so a genuine output write error (e.g. ENOSPC) now delivers exactly one failure webhook.
- **#239 `command/frontend/hooks/useLiveVideo.js`** — dropped the positional `|| cameras[idx]` fallback; unmatched feeds now fall through to the existing neutral `Camera ${num}` label instead of borrowing an unrelated camera's name.

## Tests

- `command/test/cameras.test.js` — cameras with credentials embedded in `netcam_url` (cam3, cam5) are now excluded; cam2 supplies its creds via `netcam_userpass`; cam6 is a credential-less path-`@` URL (`rtsp://192.168.1.5/cam@1/stream`) that displays intact.
- `lib/test/loadCameras.test.js` — dropped the stale-embedded-userinfo tolerance test (that config is now rejected) and added an embedded-creds rejection test asserting the camera is excluded with a `netcam_userpass` hint.
- `storage/test/convert.test.js` — exported `zip()` and added an output-error test that emits `output.on("error")` twice, asserting exactly one failure webhook and `alerted` dedup (#238 coverage).
- `storage/test/file.test.js` — flipped the orphan-sweep test to assert the orphan **is** now swept past the cutoff (#235).
- Full suite: 41 suites / 361 tests pass.
