### PR TITLE
Fix issue 240 tier-3 UX / resilience defects

### DIFF
--- a/command/frontend/app/AdminPanel.jsx
+++ b/command/frontend/app/AdminPanel.jsx
@@ -10,12 +10,15 @@ import AddUserDialog from "./AddUserDialog.jsx"
 const AdminPanel = ({ withButton } = {}) => {
 	const [users, setUsers] = useState([])
 	const [loading, setLoading] = useState(false)
+	const [error, setError] = useState(false)
 
 	const fetchUsers = () => {
 		setLoading(true)
+		setError(false)
 		request("/authorization/users", { method: "GET" }, p => p.then(r => r.json()).catch(() => ({ error: true })))
 			.then(data => {
 				if (!data.error) setUsers(data)
+				else setError(true)
 				setLoading(false)
 			})
 	}
@@ -34,6 +37,8 @@ const AdminPanel = ({ withButton } = {}) => {
 				<CardContent>
 					{loading ? (
 						<p className="py-4 text-center text-sm text-muted">Loading…</p>
+					) : error ? (
+						<p className="py-4 text-center text-sm text-danger">Failed to load users. <button onClick={fetchUsers} className="underline hover:opacity-80">Retry</button></p>
 					) : (
 						<ul className="divide-y divide-border overflow-y-auto max-h-44">
 							{users.map(user => (
@@ -64,6 +69,8 @@ const AdminPanel = ({ withButton } = {}) => {
 				<CardContent>
 					{loading ? (
 						<p className="py-4 text-center text-sm text-muted">Loading…</p>
+					) : error ? (
+						<p className="py-4 text-center text-sm text-danger">Failed to load users. <button onClick={fetchUsers} className="underline hover:opacity-80">Retry</button></p>
 					) : (
 						<UserList users={users} fetchUsers={fetchUsers} />
 					)}

--- a/command/frontend/app/MobileMain.jsx
+++ b/command/frontend/app/MobileMain.jsx
@@ -13,42 +13,37 @@ const themeOptions = [
 	{ value: "system", icon: Monitor },
 ]
 
-const HOME_ROUTES = new Set(["route-1", "route-2", "route-3", "route-4", "route-5", "route-6", "route-7"])
-
 const MobileMain = ({ index }) => {
 	const { theme, applyTheme } = useTheme()
-	const isHome = !HOME_ROUTES.has(index)
 
 	return (
 		<div className="min-h-screen bg-bg pb-24 pt-3 px-3">
-			{isHome && (
-				<header className="mb-3 flex items-center justify-between gap-2">
-					<div className="flex items-center gap-2">
-						<img src="/res/logo.png" alt="Chimera" className="size-7 object-contain" />
-						<span className="text-base font-semibold tracking-tight">Chimera</span>
+			<header className="mb-3 flex items-center justify-between gap-2">
+				<div className="flex items-center gap-2">
+					<img src="/res/logo.png" alt="Chimera" className="size-7 object-contain" />
+					<span className="text-base font-semibold tracking-tight">Chimera</span>
+				</div>
+				<div className="flex items-center rounded-md border border-border text-muted">
+					<div className="flex">
+						{themeOptions.map(({ value, icon: Icon }) => (
+							<button
+								key={value}
+								aria-label={value}
+								title={value}
+								onClick={() => applyTheme(value)}
+								className={cn(
+									"flex items-center justify-center rounded-md px-2.5 py-1.5 transition-colors",
+									theme === value ? "bg-accent/15 text-accent" : "hover:text-primary"
+								)}
+							>
+								<Icon className="size-4" />
+							</button>
+						))}
 					</div>
-					<div className="flex items-center rounded-md border border-border text-muted">
-						<div className="flex">
-							{themeOptions.map(({ value, icon: Icon }) => (
-								<button
-									key={value}
-									aria-label={value}
-									title={value}
-									onClick={() => applyTheme(value)}
-									className={cn(
-										"flex items-center justify-center rounded-md px-2.5 py-1.5 transition-colors",
-										theme === value ? "bg-accent/15 text-accent" : "hover:text-primary"
-									)}
-								>
-									<Icon className="size-4" />
-								</button>
-							))}
-						</div>
-						<div className="w-px self-stretch bg-border" />
-						<SignOutButton className="flex items-center justify-center px-2.5 py-1.5 transition-colors hover:text-primary" iconOnly />
-					</div>
-				</header>
-			)}
+					<div className="w-px self-stretch bg-border" />
+					<SignOutButton className="flex items-center justify-center px-2.5 py-1.5 transition-colors hover:text-primary" iconOnly />
+				</div>
+			</header>
 			<MobileView index={index} />
 			<SideMenu mobile index={index} />
 		</div>

--- a/command/frontend/app/SessionList.jsx
+++ b/command/frontend/app/SessionList.jsx
@@ -3,8 +3,9 @@ import moment from "moment"
 import { Badge } from "../components/ui/badge"
 import { Button } from "../components/ui/button"
 
-const SessionList = ({ sessions, username, revokeSession }) => {
-	if (!sessions) return <p className="text-xs text-muted py-1">Loading…</p>
+const SessionList = ({ sessions, username, revokeSession, retry }) => {
+	if (sessions === undefined) return <p className="text-xs text-muted py-1">Loading…</p>
+	if (sessions.error) return <p className="text-xs text-danger py-1">Failed to load sessions. <button onClick={retry} className="underline hover:opacity-80">Retry</button></p>
 	if (sessions.length === 0) return <p className="text-xs text-muted py-1">No sessions</p>
 
 	return (

--- a/command/frontend/app/SetupForm.jsx
+++ b/command/frontend/app/SetupForm.jsx
@@ -95,9 +95,13 @@ const SetupForm = ({ trySetup, tokenRequired }) => {
 					{status === "failed" && (
 						<p className="text-danger text-sm">{message || "Setup failed. Check your credentials."}</p>
 					)}
+					{status === "done" && (
+						<p className="text-accent text-sm">Account created — redirecting to login…</p>
+					)}
 					<Button
 						className="bg-accent text-accent-foreground hover:opacity-90 w-full"
 						onClick={onSubmit}
+						disabled={status === "done"}
 					>
 						Create Account
 					</Button>

--- a/command/frontend/app/UserList.jsx
+++ b/command/frontend/app/UserList.jsx
@@ -14,23 +14,28 @@ const UserList = ({ users, fetchUsers }) => {
 	const [editTarget, setEditTarget] = useState(null)
 	const [deleteTarget, setDeleteTarget] = useState(null)
 
+	const loadSessions = (username) => {
+		setSessions(s => ({ ...s, [username]: undefined }))
+		request(`/authorization/users/${encodeURIComponent(username)}/sessions`, { method: "GET" }, p => p.then(r => r.json()).catch(() => ({ error: true })))
+			.then(data => {
+				setSessions(s => ({ ...s, [username]: data.error ? { error: true } : data }))
+			})
+	}
+
 	const toggleSessions = (username) => {
 		if (expandedSessions[username]) {
 			setExpandedSessions(s => ({ ...s, [username]: false }))
 			return
 		}
 		setExpandedSessions(s => ({ ...s, [username]: true }))
-		request(`/authorization/users/${encodeURIComponent(username)}/sessions`, { method: "GET" }, p => p.then(r => r.json()).catch(() => ({ error: true })))
-			.then(data => {
-				if (!data.error) setSessions(s => ({ ...s, [username]: data }))
-			})
+		loadSessions(username)
 	}
 
 	const revokeSession = (username, id) => {
 		request(`/authorization/sessions/${id}`, { method: "DELETE" }, p => p.then(r => r.json()).catch(() => ({ error: true })))
 			.then(res => {
 				if (res.error) {
-					toast("Failed to revoke session")
+					toast(res.errors || "Failed to revoke session")
 				} else {
 					toast("Session revoked")
 					setSessions(s => ({
@@ -46,7 +51,7 @@ const UserList = ({ users, fetchUsers }) => {
 			method: "DELETE"
 		}, p => p.then(r => r.json()).catch(() => ({ error: true }))).then(res => {
 			if (res.error) {
-				toast("Cannot delete user")
+				toast(res.errors || "Cannot delete user")
 			} else {
 				toast("User deleted")
 				setDeleteTarget(null)
@@ -96,7 +101,7 @@ const UserList = ({ users, fetchUsers }) => {
 					</div>
 					{expandedSessions[user.username] && (
 						<div className="mt-2 ml-1 border-l-2 border-border pl-3">
-							<SessionList sessions={sessions[user.username]} username={user.username} revokeSession={revokeSession} />
+							<SessionList sessions={sessions[user.username]} username={user.username} revokeSession={revokeSession} retry={() => loadSessions(user.username)} />
 						</div>
 					)}
 				</li>

--- a/command/frontend/hooks/useAuth.js
+++ b/command/frontend/hooks/useAuth.js
@@ -92,7 +92,7 @@ const useAuth = () => {
 			}, prom => prom.then(res => {
 				if (res.status === 401) return handleLoginAttempt(false, null, state.timestamp, setState)
 				if (!res.ok) return
-				res.json().then(body => { if (!body.error) setState(s => ({ ...s, role: body.role })) }).catch(() => {})
+				res.json().then(body => { if (!body.error) setState(s => ({ ...s, role: body.role, forcePasswordChange: !!body.forcePasswordChange })) }).catch(() => {})
 			}).catch(() => {}))
 		}
 		document.addEventListener("visibilitychange", refreshRole)
@@ -108,8 +108,8 @@ const useAuth = () => {
 
 	const trySetup = (username, password, token, callback) => {
 		attemptSetup(username, password, token).then(res => {
-			if (!res.error) setState(s => ({ ...s, setup: true }))
 			callback(!res.error, res.errors)
+			if (!res.error) setTimeout(() => setState(s => ({ ...s, setup: true })), 1500)
 		})
 	}
 

--- a/command/frontend/hooks/useLiveVideo.js
+++ b/command/frontend/hooks/useLiveVideo.js
@@ -1,16 +1,18 @@
-import { useEffect, useState } from "react"
+import { useEffect, useState, useRef } from "react"
 
 import moment from "moment"
 import { request, jsonProcessing } from "../js/request.js"
 
-const listVideos = (cameras, setState) => {
-	setState((old) => ({ ...old, loading: true, videoList: [] }))
+const listVideos = (cameras, setState, seqRef) => {
+	const seq = ++seqRef.current
+	setState((old) => ({ ...old, loading: true }))
 	request("/livestream/status", {
 		method: "GET",
 		headers: { "Content-Type": "application/json" },
 		mode: "cors"
 	}, (prom) => {
 		jsonProcessing(prom, (data) => {
+			if (seq !== seqRef.current) return
 			const nums = (Array.isArray(data) ? data : [])
 				.map((cam) => parseInt(cam.name.split("_")[3]))
 				.sort((a, b) => a - b)
@@ -41,13 +43,14 @@ const attemptRestart = (camera) => {
 }
 
 const useLiveVideo = (cameras) => {
+	const seqRef = useRef(0)
 	const [state, setState] = useState({
 		loading: false,
 		lastUpdated: moment().format("h:mm:ss a"),
 		videoList: []
 	})
 
-	const refresh = () => listVideos(cameras, setState)
+	const refresh = () => listVideos(cameras, setState, seqRef)
 
 	useEffect(() => {
 		refresh()

--- a/command/frontend/hooks/useProcesses.js
+++ b/command/frontend/hooks/useProcesses.js
@@ -85,6 +85,7 @@ const useProcesses = (settings = {}) => {
 		if (cameras[state.camera]?.id == null) return toast("No camera selected")
 		const url = type === "video" ? "/convert/createVideo" : "/convert/createZip"
 		const body = processBody(state, cameras, false)
+		setDialog({ open: false, processType: null, days: false })
 		if (state.download) {
 			const remove = toast("Generating", 0)
 			request(url, {
@@ -101,7 +102,6 @@ const useProcesses = (settings = {}) => {
 				body
 			}, (prom) => {
 				jsonProcessing(prom, () => {
-					setDialog({ open: false, processType: null, days: false })
 					setTimeout(() => listProcesses(setState), 1500)
 				})
 			})


### PR DESCRIPTION
Addresses #240 — Tier 3 UX / resilience defects from the PR #178 review. Closes all 8 sub-issues.

| # | File | Fix |
|---|------|-----|
| #241 | `SetupForm.jsx` / `useAuth.js` | Render a `"done"` success state; delay the `setup:true` flip ~1.5s so "Account created — redirecting…" is visible instead of a silent drop to `/login`. |
| #242 | `useAuth.js` | `refreshRole` now copies `forcePasswordChange` (not just `role`), so a backgrounded tab re-gates to the change-password screen after a forced reset. |
| #243 | `AdminPanel.jsx` | Added an `error` state; a failed `/users` GET now shows "Failed to load users. Retry" instead of an empty list. |
| #244 | `UserList.jsx` | Sessions fetch stores an error sentinel; delete/revoke toasts now surface backend `res.errors` (e.g. "cannot delete last admin"). |
| #245 | `SessionList.jsx` | Distinguishes errored (sentinel) from loading (`undefined`); renders an error + Retry instead of a permanent spinner. |
| #246 | `useLiveVideo.js` | Added the `seqRef` guard (mirroring `usePastImages`); stops blanking `videoList` on refresh and ignores superseded responses. |
| #247 | `useProcesses.js` | Close the create dialog unconditionally before branching, so the download path no longer leaves it open for a duplicate `/convert`. |
| #248 | `MobileMain.jsx` | Render the header (theme + sign-out) on all routes; removed the inverted/misnamed `HOME_ROUTES` set. |

Frontend `vite build` passes.

Closes #240, #241, #242, #243, #244, #245, #246, #247, #248
