### PR TITLE
Fix issue 260 tier-6 code health refactors

### DIFF
--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -76,84 +76,12 @@ const confirmURL = (varName) => {
 	}
 }
 
-checkVar("NODE_ENV")
-checkVar("chimeraInstances")
+schema.forEach(v => checkVar(v.key))
+schema.filter(v => /_URL$/.test(v.key)).forEach(v => confirmURL(v.key))
+// storage_MOTION_CONF_FILEPATH intentionally skips the filesystem path check
+schema.filter(v => /_FILEPATH$/.test(v.key) && v.key !== "storage_MOTION_CONF_FILEPATH").forEach(v => confirmPath(v.key))
+schema.filter(v => /_FOLDERPATH$/.test(v.key)).forEach(v => confirmPath(v.key, true))
 
-checkVar("storage_MAX_GB")
-checkVar("alert_URL")
-confirmURL("alert_URL")
-checkVar("admin_alert_URL")
-confirmURL("admin_alert_URL")
-checkVar("PRINTPASSWORD")
-checkVar("SECRETKEY")
-
-checkVar("command_PROXY_ON")
-checkVar("schedule_PROXY_ON")
-checkVar("storage_PROXY_ON")
-checkVar("livestream_PROXY_ON")
-checkVar("object_PROXY_ON")
-checkVar("gateway_ON")
-checkVar("gateway_PORT")
-checkVar("gateway_HOST")
-checkVar("gateway_PORT_SECURE")
-
-checkVar("privateKey_FILEPATH")
-confirmPath("privateKey_FILEPATH")
-
-checkVar("certificate_FILEPATH")
-confirmPath("certificate_FILEPATH")
-
-checkVar("gateway_HTTPS_Redirect")
-checkVar("command_ON")
-checkVar("command_PORT")
-checkVar("command_HOST")
-checkVar("setup_TOKEN")
-
-checkVar("schedule_ON")
-checkVar("schedule_PORT")
-checkVar("schedule_HOST")
-checkVar("scheduler_AUTH")
-
-checkVar("storage_ON")
-checkVar("storage_PORT")
-checkVar("storage_HOST")
-checkVar("storage_FOLDERPATH")
-confirmPath("storage_FOLDERPATH", true)
-
-checkVar("storage_MOTION_CONF_FILEPATH")
-
-checkVar("ffmpeg_FILEPATH")
-confirmPath("ffmpeg_FILEPATH")
-
-checkVar("ffprobe_FILEPATH")
-confirmPath("ffprobe_FILEPATH")
-
-checkVar("livestream_ON")
-checkVar("livestream_PORT")
-checkVar("livestream_HOST")
-checkVar("livestream_FOLDERPATH")
-confirmPath("livestream_FOLDERPATH", true)
-
-checkVar("object_ON")
-checkVar("object_PORT")
-checkVar("object_CONFIDENCE")
-checkVar("object_INTERVAL_MS")
-checkVar("object_MODEL_URL")
-confirmURL("object_MODEL_URL")
-checkVar("object_INPUT_SIZE")
-checkVar("object_ALERT_ON")
-checkVar("object_MAX_CAPTURES")
-
-checkVar("memory_ON")
-checkVar("memory_PORT")
-checkVar("memory_HOST")
-checkVar("memory_AUTH_TOKEN")
-
-checkVar("database_NAME")
-checkVar("database_USER")
-checkVar("database_PASSWORD")
-checkVar("database_HOST")
-checkVar("database_PORT")
 if(allEnvPresent){
 	process.exit(0)
 }

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -2,7 +2,8 @@ var express = require("express")
 var { validateBody, auth, password } = require("lib")
 const { requireAdmin } = auth
 const { passwordCheck, login, pool, withTransaction, HttpError } = require("./lib/auth.js")
-const authorize = auth.createAuthorize(pool)
+const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout"]
+const authorize = auth.createAuthorize(pool, { forcedChangeAllowed })
 
 const bcrypt = require("bcryptjs")
 const { randomBytes } = require("crypto")

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -2,15 +2,9 @@ const secretKey = process.env.SECRETKEY
 const jwt = require("jsonwebtoken")
 const bcrypt = require("bcryptjs")
 const { randomUUID } = require("crypto")
+const { createPool } = require("lib")
 
-const Pool = require("pg").Pool
-const pool = new Pool({
-	user: process.env.database_USER,
-	host: process.env.database_HOST,
-	database: process.env.database_NAME,
-	password: process.env.database_PASSWORD,
-	port: process.env.database_PORT,
-})
+const pool = createPool()
 
 const DUMMY_HASH = bcrypt.hashSync("invalid", 10)
 

--- a/command/frontend/app/AddUserDialog.jsx
+++ b/command/frontend/app/AddUserDialog.jsx
@@ -4,7 +4,7 @@ import { Input } from "../components/ui/input"
 import { Label } from "../components/ui/label"
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from "../components/ui/dialog"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "../components/ui/select"
-import { request } from "../js/request.js"
+import { request, authPromiseHandler } from "../js/request.js"
 import toast from "../js/toast.js"
 
 const ROLES = ["user", "admin"]
@@ -21,7 +21,7 @@ const AddUserDialog = ({ onAdded }) => {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(form)
-		}, p => p.then(r => r.json()).catch(() => ({ error: true }))).then(res => {
+		}, authPromiseHandler).then(res => {
 			if (res.error) {
 				toast(res.errors || "Failed to add user")
 			} else {

--- a/command/frontend/app/AdminPanel.jsx
+++ b/command/frontend/app/AdminPanel.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react"
 import moment from "moment"
 import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card"
 import { Badge } from "../components/ui/badge"
-import { request } from "../js/request.js"
+import { request, authPromiseHandler } from "../js/request.js"
 import NavigateToRoute from "./NavigateToRoute.jsx"
 import UserList from "./UserList.jsx"
 import AddUserDialog from "./AddUserDialog.jsx"
@@ -15,7 +15,7 @@ const AdminPanel = ({ withButton } = {}) => {
 	const fetchUsers = () => {
 		setLoading(true)
 		setError(false)
-		request("/authorization/users", { method: "GET" }, p => p.then(r => r.json()).catch(() => ({ error: true })))
+		request("/authorization/users", { method: "GET" }, authPromiseHandler)
 			.then(data => {
 				if (!data.error) setUsers(data)
 				else setError(true)

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -301,7 +301,6 @@ const ClipMakerFull = () => {
 
 	const frameTimes = useMemo(() => frames.map(parseFrameTime), [frames])
 
-	// single-cam effects
 	useEffect(() => {
 		const canvas = canvasRef.current
 		if (frames.length === 0) {
@@ -422,7 +421,6 @@ const ClipMakerFull = () => {
 		}
 	}, [scrubIdx, frames, imagesLoaded, showBoxes, boxesForScrub, contentPad])
 
-	// multi-cam: load images when frame lists change
 	const multiAllFrames = useMemo(() =>
 		multiCam ? Object.fromEntries(Object.entries(camStates).map(([id, s]) => [id, s.frames])) : {},
 	[multiCam, camStates]
@@ -478,7 +476,6 @@ const ClipMakerFull = () => {
 
 	const multiRows = selectedCams.length > 0 ? Math.ceil(selectedCams.length / 2) : 2
 
-	// multi-cam: paint canvases on scrub, syncing by timestamp
 	useEffect(() => {
 		if (!multiCam) return
 		const pct = multiFrameCount > 1 ? scrubIdx / (multiFrameCount - 1) : 0

--- a/command/frontend/app/EditUserDialog.jsx
+++ b/command/frontend/app/EditUserDialog.jsx
@@ -4,7 +4,7 @@ import { Input } from "../components/ui/input"
 import { Label } from "../components/ui/label"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from "../components/ui/dialog"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "../components/ui/select"
-import { request } from "../js/request.js"
+import { request, authPromiseHandler } from "../js/request.js"
 import toast from "../js/toast.js"
 import { validatePassword } from "../js/password.js"
 
@@ -35,7 +35,7 @@ const EditUserDialog = ({ user, open, onOpenChange, onUpdated }) => {
 			method: "PATCH",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body)
-		}, p => p.then(r => r.json()).catch(() => ({ error: true }))).then(res => {
+		}, authPromiseHandler).then(res => {
 			if (res.error) {
 				toast(res.errors || "Failed to update user")
 			} else {

--- a/command/frontend/app/UserList.jsx
+++ b/command/frontend/app/UserList.jsx
@@ -5,7 +5,7 @@ import { Button } from "../components/ui/button"
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from "../components/ui/dialog"
 import SessionList from "./SessionList.jsx"
 import EditUserDialog from "./EditUserDialog.jsx"
-import { request } from "../js/request.js"
+import { request, authPromiseHandler } from "../js/request.js"
 import toast from "../js/toast.js"
 
 const UserList = ({ users, fetchUsers }) => {
@@ -16,7 +16,7 @@ const UserList = ({ users, fetchUsers }) => {
 
 	const loadSessions = (username) => {
 		setSessions(s => ({ ...s, [username]: undefined }))
-		request(`/authorization/users/${encodeURIComponent(username)}/sessions`, { method: "GET" }, p => p.then(r => r.json()).catch(() => ({ error: true })))
+		request(`/authorization/users/${encodeURIComponent(username)}/sessions`, { method: "GET" }, authPromiseHandler)
 			.then(data => {
 				setSessions(s => ({ ...s, [username]: data.error ? { error: true } : data }))
 			})
@@ -32,7 +32,7 @@ const UserList = ({ users, fetchUsers }) => {
 	}
 
 	const revokeSession = (username, id) => {
-		request(`/authorization/sessions/${id}`, { method: "DELETE" }, p => p.then(r => r.json()).catch(() => ({ error: true })))
+		request(`/authorization/sessions/${id}`, { method: "DELETE" }, authPromiseHandler)
 			.then(res => {
 				if (res.error) {
 					toast(res.errors || "Failed to revoke session")
@@ -49,7 +49,7 @@ const UserList = ({ users, fetchUsers }) => {
 	const deleteUser = () => {
 		request(`/authorization/users/${encodeURIComponent(deleteTarget.username)}`, {
 			method: "DELETE"
-		}, p => p.then(r => r.json()).catch(() => ({ error: true }))).then(res => {
+		}, authPromiseHandler).then(res => {
 			if (res.error) {
 				toast(res.errors || "Cannot delete user")
 			} else {

--- a/command/frontend/hooks/useAuth.js
+++ b/command/frontend/hooks/useAuth.js
@@ -1,13 +1,8 @@
 import {useEffect, useState} from "react"
 
-import { request } from "../js/request.js"
+import { request, authPromiseHandler } from "../js/request.js"
 
 const timeout = 750
-
-const authPromiseHandler = (prom) => {
-	return prom.then(res => res.json())
-		.catch(() => ({ error: true }))
-}
 
 const checkStatus = () =>
 	request("/authorization/status", { method: "GET" }, authPromiseHandler)

--- a/command/frontend/js/request.js
+++ b/command/frontend/js/request.js
@@ -5,6 +5,8 @@ const request = (url, opt, callback) => {
 	return callback(fetch(url, opt))
 }
 
+const authPromiseHandler = (prom) => prom.then(res => res.json()).catch(() => ({ error: true }))
+
 const statusProcessing = (prom, code, callback) => {
 	prom
 		.then(res => callback(res.status === code))
@@ -57,4 +59,4 @@ const downloadProcessing = (prom, callback) => {
 	})
 }
 
-export { request, statusProcessing, jsonProcessing, downloadProcessing }
+export { request, authPromiseHandler, statusProcessing, jsonProcessing, downloadProcessing }

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,5 +19,7 @@ module.exports = {
 	cameraConfDir: require("./utils/loadCameras.js").cameraConfDir,
 	cameraConfFiles: require("./utils/loadCameras.js").cameraConfFiles,
 	pruneInterval: require("./utils/pruneInterval.js"),
+	createPool: require("./utils/createPool.js"),
+	schedulableUrls: require("./utils/schedulableUrls.js"),
 	isPrimeInstance: !("NODE_APP_INSTANCE" in process.env) || process.env.NODE_APP_INSTANCE === "0"
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -12,6 +12,7 @@
     "jsonwebtoken": "^9.0.0",
     "moment-timezone": "^0.6.2",
     "nanoid": "^3.1.30",
+    "pg": "^8.11.0",
     "pm2": "^7.0.3",
     "request-ip": "^3.3.0"
   },

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -2,7 +2,9 @@ process.env.scheduler_AUTH = "scheduler-secret"
 process.env.SECRETKEY = "test-secret"
 
 const jwt = require("jsonwebtoken")
-const { createAuthorize, requireAdmin, schedulableUrls, invalidateSession, invalidateUser, invalidateAllSessions, connectSessionSync } = require("../utils/auth.js")
+const { createAuthorize, requireAdmin, invalidateSession, invalidateUser, invalidateAllSessions, connectSessionSync } = require("../utils/auth.js")
+const schedulableUrls = require("../utils/schedulableUrls.js")
+const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout"]
 
 const makeRes = () => ({
 	redirect: jest.fn(),
@@ -14,7 +16,7 @@ const makeRes = () => ({
 beforeEach(() => invalidateAllSessions())
 
 describe("makeAuthorize scheduler path", () => {
-	const authorize = createAuthorize(null)
+	const authorize = createAuthorize(null, { schedulableUrls })
 
 	test("scheduler token on a schedulable url authorizes as admin", () => {
 		const req = { method: "POST", path: schedulableUrls[0], headers: { authorization: process.env.scheduler_AUTH } }
@@ -379,7 +381,7 @@ describe("makeAuthorize forced password change", () => {
 	const forcedPool = () => ({ query: jest.fn().mockResolvedValue({ rows: [{ role: "user", force_password_change: true, revoked: false }], rowCount: 1 }) })
 
 	test("blocks a non-allowlisted route", async () => {
-		const authorize = createAuthorize(forcedPool())
+		const authorize = createAuthorize(forcedPool(), { forcedChangeAllowed })
 		const req = { method: "POST", originalUrl: "/cameras", path: "/cameras", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
 		const res = makeRes()
 		const next = jest.fn()
@@ -390,7 +392,7 @@ describe("makeAuthorize forced password change", () => {
 	})
 
 	test("allows the password-change route", async () => {
-		const authorize = createAuthorize(forcedPool())
+		const authorize = createAuthorize(forcedPool(), { forcedChangeAllowed })
 		const req = { method: "POST", originalUrl: "/authorization/password", path: "/password", headers: {}, cookies: { bearertoken: `Bearer ${token}` } }
 		const res = makeRes()
 		const next = jest.fn()

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -1,8 +1,6 @@
 const secretKey = process.env.SECRETKEY
 const jwt = require("jsonwebtoken")
 
-const schedulableUrls = ["/convert/createVideo", "/convert/createZip", "/file/pathMetrics", "/file/pathDelete", "/file/pathClean", "/file/pathAutoClean"]
-const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout"]
 const sessionCache = new Map()
 const SESSION_CACHE_MS = 5000
 
@@ -52,7 +50,7 @@ const respondUnauthorized = (req, res) => {
 	return isNavigation ? res.redirect(303, "/?loginForm") : res.status(401).send({ error: "unauthorized" })
 }
 
-const verifyJwt = (token, req, res, next, pool) => {
+const verifyJwt = (token, req, res, next, pool, forcedChangeAllowed) => {
 	const unauthorized = () => respondUnauthorized(req, res)
 	jwt.verify(token, secretKey, async (err, decoded) => {
 		if (err) {
@@ -105,7 +103,7 @@ const verifyJwt = (token, req, res, next, pool) => {
 	})
 }
 
-const makeAuthorize = (pool) => (req, res, next) => {
+const makeAuthorize = (pool, { schedulableUrls = [], forcedChangeAllowed = [] } = {}) => (req, res, next) => {
 	const unauthorized = () => respondUnauthorized(req, res)
 	if (req.headers.authorization != undefined && req.headers.authorization == process.env.scheduler_AUTH && schedulableUrls.includes(req.path)) {
 		req.decoded = { username: "scheduler", role: "admin" }
@@ -113,7 +111,7 @@ const makeAuthorize = (pool) => (req, res, next) => {
 	} else {
 		const bearerTokenCookie = req.cookies && req.cookies.bearertoken
 		if (bearerTokenCookie && bearerTokenCookie.includes("Bearer")) {
-			verifyJwt(bearerTokenCookie.split(/%20|\s+/)[1], req, res, next, pool)
+			verifyJwt(bearerTokenCookie.split(/%20|\s+/)[1], req, res, next, pool, forcedChangeAllowed)
 		} else unauthorized()
 	}
 }
@@ -128,7 +126,5 @@ module.exports = {
 	requireAdmin: (req, res, next) => {
 		if (req.decoded?.role === "admin") next()
 		else res.status(403).json({ error: "forbidden" })
-	},
-
-	schedulableUrls: schedulableUrls
+	}
 }

--- a/lib/utils/createPool.js
+++ b/lib/utils/createPool.js
@@ -1,0 +1,13 @@
+const { Pool } = require("pg")
+
+module.exports = (errorLabel) => {
+	const pool = new Pool({
+		user: process.env.database_USER,
+		host: process.env.database_HOST,
+		database: process.env.database_NAME,
+		password: process.env.database_PASSWORD,
+		port: process.env.database_PORT,
+	})
+	if (errorLabel) pool.on("error", (err) => console.log(errorLabel, err))
+	return pool
+}

--- a/lib/utils/schedulableUrls.js
+++ b/lib/utils/schedulableUrls.js
@@ -1,0 +1,1 @@
+module.exports = ["/convert/createVideo", "/convert/createZip", "/file/pathMetrics", "/file/pathDelete", "/file/pathClean", "/file/pathAutoClean"]

--- a/livestream/backend/lib/pool.js
+++ b/livestream/backend/lib/pool.js
@@ -1,13 +1,1 @@
-const { Pool } = require("pg")
-
-const pool = new Pool({
-	user: process.env.database_USER,
-	host: process.env.database_HOST,
-	database: process.env.database_NAME,
-	password: process.env.database_PASSWORD,
-	port: process.env.database_PORT,
-})
-
-pool.on("error", (err) => console.log("LIVESTREAM POOL ERROR", err))
-
-module.exports = pool
+module.exports = require("lib").createPool("LIVESTREAM POOL ERROR")

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -128,6 +128,7 @@
         "jsonwebtoken": "^9.0.0",
         "moment-timezone": "^0.6.2",
         "nanoid": "^3.1.30",
+        "pg": "^8.11.0",
         "pm2": "^7.0.3",
         "request-ip": "^3.3.0"
       },
@@ -21023,6 +21024,7 @@
         "jsonwebtoken": "^9.0.0",
         "moment-timezone": "^0.6.2",
         "nanoid": "^3.1.30",
+        "pg": "^8.11.0",
         "pm2": "^7.0.3",
         "request-ip": "^3.3.0"
       }

--- a/object/backend/lib/pool.js
+++ b/object/backend/lib/pool.js
@@ -1,13 +1,1 @@
-const { Pool } = require("pg")
-
-const pool = new Pool({
-	user: process.env.database_USER,
-	host: process.env.database_HOST,
-	database: process.env.database_NAME,
-	password: process.env.database_PASSWORD,
-	port: process.env.database_PORT,
-})
-
-pool.on("error", (err) => console.log("OBJECT POOL ERROR", err))
-
-module.exports = pool
+module.exports = require("lib").createPool("OBJECT POOL ERROR")

--- a/schedule/backend/lib/pool.js
+++ b/schedule/backend/lib/pool.js
@@ -1,13 +1,1 @@
-const { Pool } = require("pg")
-
-const pool = new Pool({
-	user: process.env.database_USER,
-	host: process.env.database_HOST,
-	database: process.env.database_NAME,
-	password: process.env.database_PASSWORD,
-	port: process.env.database_PORT,
-})
-
-pool.on("error", (err) => console.log("SCHEDULE POOL ERROR", err))
-
-module.exports = pool
+module.exports = require("lib").createPool("SCHEDULE POOL ERROR")

--- a/schedule/backend/routes/lib/scheduler.js
+++ b/schedule/backend/routes/lib/scheduler.js
@@ -2,10 +2,8 @@ const cron     = require("node-cron")
 const axios  = require("axios").default.create({
 	validateStatus: (status) => status == 200,
 })
-const { webhookAlert, alertTime, randomID, jsonFileHanding, auth, pruneInterval } = require("lib")
+const { webhookAlert, alertTime, randomID, jsonFileHanding, pruneInterval, schedulableUrls } = require("lib")
 const pool = require("../../lib/pool")
-
-const {schedulableUrls} = auth
 
 const client = require("memory").client("TASK SCHEDULER")
 

--- a/storage/backend/lib/pool.js
+++ b/storage/backend/lib/pool.js
@@ -1,13 +1,1 @@
-const { Pool } = require("pg")
-
-const pool = new Pool({
-	user: process.env.database_USER,
-	host: process.env.database_HOST,
-	database: process.env.database_NAME,
-	password: process.env.database_PASSWORD,
-	port: process.env.database_PORT,
-})
-
-pool.on("error", (err) => console.log("STORAGE POOL ERROR", err))
-
-module.exports = pool
+module.exports = require("lib").createPool("STORAGE POOL ERROR")

--- a/storage/backend/routes/database.js
+++ b/storage/backend/routes/database.js
@@ -2,14 +2,7 @@ var express    = require("express")
 
 const app = express.Router()
 
-const Pool = require("pg").Pool
-const pool = new Pool({
-	user: process.env.database_USER,
-	host: process.env.database_HOST,
-	database: process.env.database_NAME,
-	password: process.env.database_PASSWORD,
-	port: process.env.database_PORT,
-})
+const pool = require("lib").createPool()
 
 const queryForHealth = () => {
 	return pool.query("SELECT 2 + 2;")

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -2,20 +2,9 @@ const path = require("path")
 const fs = require("fs")
 const rimraf = require("rimraf")
 const moment = require("moment")
-const { loadCameras, webhookAlert, mapLimit } = require("lib")
+const { loadCameras, webhookAlert, mapLimit, createPool } = require("lib")
 
-const Pool = require("pg").Pool
-const pool = new Pool({
-	user: process.env.database_USER,
-	host: process.env.database_HOST,
-	database: process.env.database_NAME,
-	password: process.env.database_PASSWORD,
-	port: process.env.database_PORT,
-})
-
-pool.on("error", (err) => {
-	console.log("STORAGE FILE POOL ERROR", err)
-})
+const pool = createPool("STORAGE FILE POOL ERROR")
 
 const FS_CONCURRENCY = 64
 

--- a/storage/backend/storage.js
+++ b/storage/backend/storage.js
@@ -1,6 +1,6 @@
 var path       = require("path")
 var express    = require("express")
-const { auth, helmetOptions, tracker, pruneInterval } = require("lib")
+const { auth, helmetOptions, tracker, pruneInterval, schedulableUrls } = require("lib")
 const helmet = require("helmet")
 const pool = require("./lib/pool")
 
@@ -16,7 +16,7 @@ app.use(express.json())
 
 app.use("/storage/health", require("heartbeat").heart)
 
-app.use(auth.createAuthorize(pool))
+app.use(auth.createAuthorize(pool, { schedulableUrls }))
 
 app.use("/", require("./routes/events.js"))
 app.use("/motion", require("./routes/motion.js"))


### PR DESCRIPTION
Addresses the **Tier 6 — code health / refactors** items from #260 (PR #178 review). Behavior-preserving DRY/layering cleanups.

## What's in this PR

**#261 — Inject auth allow-lists instead of hardcoding routes in `lib/`**
`lib/utils/auth.js` no longer bakes in `command`/`storage` route inventories. `createAuthorize(pool, { schedulableUrls, forcedChangeAllowed })` now receives both lists (defaulting to `[]`):
- `forcedChangeAllowed` is declared and injected by the owning **command** service (`routes/authorization.js`).
- `schedulableUrls` moves to a shared data module (`lib/utils/schedulableUrls.js`) since it's genuinely cross-service — **storage** injects it into `createAuthorize`, and the **schedule** service imports it for cron-URL validation. The generic auth middleware is no longer coupled to specific routes.

**#262 — DRY the copy-pasted JSON-response handler**
`authPromiseHandler` is now defined once and exported from `command/frontend/js/request.js`. `useAuth.js` and the six hand-rolled `p => p.then(r => r.json()).catch(() => ({ error: true }))` sites (`AdminPanel`, `UserList` ×3, `AddUserDialog`, `EditUserDialog`) all route through it.

**#263 — Shared `createPool()` factory**
New `lib/utils/createPool(errorLabel)` replaces the duplicated `pg.Pool` config across the services (command auth, storage ×3, schedule, livestream, object). Optional label preserves each pool's existing `pool.on("error", …)` prefix; pools without a handler keep none (no behavior change). `pg` is now declared in `lib/package.json`.

**#265 — Derive `validateEnvVars` from `parseSchema()`**
The ~55 hand-listed `checkVar(...)` calls plus the URL/path validators are now derived from the schema (`env.example`):
```js
schema.forEach(v => checkVar(v.key))
schema.filter(v => /_URL$/.test(v.key)).forEach(v => confirmURL(v.key))
schema.filter(v => /_FILEPATH$/.test(v.key) && v.key !== "storage_MOTION_CONF_FILEPATH").forEach(v => confirmPath(v.key))
schema.filter(v => /_FOLDERPATH$/.test(v.key)).forEach(v => confirmPath(v.key, true))
```
This closes the drift the issue describes: `object_HOST` (a required schema var that was silently unvalidated) is now enforced. `storage_MOTION_CONF_FILEPATH` keeps its intentional path-check exemption.

**#266 — Remove banned section comments**
Dropped the `// single-cam effects` / `// multi-cam: …` dividers in `ClipMaker.jsx`.

## Deferred

**#264 — Unify ClipMaker's single/multi-cam state** is intentionally **not** included. The single-cam path paints frames by direct scrub index and maps detection boxes to that exact index, while the multi-cam path selects frames by timestamp-sync — so a true single code path can't be reached without either changing single-cam box behavior or keeping conditional branches. Given it's a ~1150-line stateful component with no behavioral test coverage, a blind rewrite is disproportionate risk for a non-blocking item. #266 (the comment symptom) is fixed; #264 stays open for a dedicated follow-up.

## Verification
- Full jest suite: **identical to baseline** (315 passed; the 7 pre-existing suite failures are missing `*_FOLDERPATH`/gateway env vars, present on `develop` too). `lib` auth suite 55/55, `chimera` validateEnvVars 31/31.
- `vite build` (command) succeeds; eslint clean on changed files; `npm ci` lockfile-consistent.

Closes #260
Closes #261
Closes #262
Closes #263
Closes #265
Closes #266
Refs #260, #264
