### PR TITLE
Fix README and env.example inaccuracies (object, memory, storage, livestream, schedule, lib, chimera)

### DIFF
--- a/chimera/README.md
+++ b/chimera/README.md
@@ -5,7 +5,7 @@ One-shot scripts that run before any service starts: validate config, prepare th
 ---
 # Boot chain
 
-[entrypoint.sh](entrypoint.sh), the container entrypoint — runs in order, aborts on first failure (`set -e`):
+[entrypoint.sh](../entrypoint.sh), the container entrypoint — runs in order, aborts on first failure (`set -e`):
 
 1. `mkdir -p ./.well-known/acme-challenge` — ACME dir the [gateway](../gateway) serves for TLS.
 2. `validateEnvVars.js` — fail-fast env validation.
@@ -28,7 +28,7 @@ Checks every required env var — all checks run (no short-circuit), so one run 
 
 Connects with `database_*` and runs each `CREATE TABLE`/`INDEX` once — idempotent (existing table → `42P07`, treated as success; indexes use `IF NOT EXISTS`). Any other error exits `1`.
 
-Tables (owner): `frame_files`, `frame_deletes` (storage) · `auth`, `sessions` (command) · `objects_detected` (object) · `task_runs` (schedule). Plus timestamp indexes on `frame_files`, `objects_detected`, `task_runs`.
+Tables (owner): `frame_files`, `frame_deletes` (storage) · `auth`, `sessions` (command) · `objects_detected` (object) · `task_runs` (schedule). Plus four indexes: timestamp indexes on `frame_files`, `objects_detected`, `task_runs`, and one on `sessions(username)`.
 
 ---
 # preflight.js — `npm run preflight`

--- a/env.example
+++ b/env.example
@@ -89,10 +89,12 @@ object_HOST = https://object.server.example or http://127.0.0.1:8081
 
 object_CONFIDENCE = Detection confidence threshold 0-1 (default 0.5) ***
 object_INTERVAL_MS = Milliseconds between scans per camera (default 5000) ***
-object_MODEL_URL = Override URL to download the YOLOX ONNX model ***
+object_MODEL_URL = Override URL to download the YOLOX ONNX model; requires object_MODEL_SHA256 ***
+object_MODEL_SHA256 = SHA256 of the model at object_MODEL_URL, required when object_MODEL_URL is set ***
 object_INPUT_SIZE = Model input square size, match the model (default 416) ***
 object_ALERT_ON = Fire webhook/Discord alerts on detection (true | false, default true) ***
 object_MAX_CAPTURES = Max capture images to retain on disk (default 500) ***
+object_PRUNE_INTERVAL_MS = Milliseconds between capture-pruning sweeps (default 300000) ***
 
 ##################################################################
 # Memory

--- a/lib/README.md
+++ b/lib/README.md
@@ -2,7 +2,7 @@
 
 Shared helpers every service imports (`require("lib")`, a `file:../lib` dep); loads `.env`. Not a server.
 
-`index.js` exports all of these (CommonJS); `module.js` re-exports only `formatBytes` (ESM).
+Exports below are from `index.js` (CommonJS) unless noted; `module.js` re-exports only `formatBytes` (ESM).
 
 ---
 # Exports
@@ -15,16 +15,18 @@ Shared helpers every service imports (`require("lib")`, a `file:../lib` dep); lo
 - `helmetOptions` — CSP for `helmet`.
 
 **Server & runtime**
-- `handleServerStart` / `handleSecureServerStart` — start HTTP / HTTPS listeners (TLS paths from `certPaths`).
-- `certPaths` — resolves TLS key/cert from `gateway_HOST` under `/etc/letsencrypt/live/`.
+- `handleServerStart` / `handleSecureServerStart` — start HTTP / HTTPS listeners (TLS paths from `certPaths`, an internal helper not exported from `index.js`).
 - `watchCertRenewal` — cert/key mtime poll periodically; `pm2.restart("gateway")` in the early AM UTC window after the certbot sidecar renews.
 - `pruneInterval` — run a SQL prune on a 12h timer.
+- `createPool` — `pg.Pool` factory with a labeled `error` logger.
 - `isPrimeInstance` — true on the single/prime pm2 instance.
 - `subprocess` — pm2 helpers (`checkProcess`, `restart`, …).
+- `schedulableUrls` — routes `scheduler_AUTH` may call without a session.
 
 **Cameras & alerts**
-- `loadCameras` — motion + camera confs → `{id, name, rtsp_url, full_url}` (re-read on every call; rejects on I/O failure so callers can tell "unreadable" from "no cameras"; `loadCamerasSync` is the sync variant and still returns `[]`).
+- `loadCameras` — motion + camera confs → `{id, name, rtsp_url, full_url}` (re-read on every call; rejects on I/O failure so callers can tell "unreadable" from "no cameras"; `loadCamerasSync` (sync, still returns `[]`) lives in `utils/loadCameras.js` but isn't exported from `index.js`).
 - `cameraConfFiles` — conf paths declaring a given `camera_id` (rejects on I/O failure, same contract as `loadCameras`).
+- `cameraConfDir` — resolves the `camera_dir` referenced by `storage_MOTION_CONF_FILEPATH`.
 - `webhookAlert` — POST to the alert webhook (`alert_URL` / `admin_alert_URL`).
 - `alertTime` — `moment-timezone` helper in `alert_TZ`.
 
@@ -33,6 +35,7 @@ Shared helpers every service imports (`require("lib")`, a `file:../lib` dep); lo
 - `randomID` — `nanoid` generator.
 - `password` — shared password-policy JSON.
 - `jsonFileHanding` — JSON read/write/validate (key spelled `jsonFileHanding`).
+- `mapLimit` — run an async fn over items with bounded concurrency.
 
 ---
 # Consumers & config

--- a/livestream/README.md
+++ b/livestream/README.md
@@ -5,7 +5,7 @@ Serves and monitors per-camera HLS streams. RTSP→HLS transcoding runs in separ
 ---
 # API
 
-Session-guarded (`authorize`) except `/livestream/health`:
+Session-guarded (`authorize`) except `/livestream/health`; restart also requires admin (`requireAdmin`):
 
 - pm2 status for all cameras or one
 - restart a camera's ffmpeg process
@@ -14,12 +14,12 @@ Session-guarded (`authorize`) except `/livestream/health`:
 ---
 # Runtime
 
-- pm2 spawns one ffmpeg per camera (`live_stream_cam_<id>`) when `livestream_ON=true`: RTSP-over-TCP → rolling HLS in `livestream_FOLDERPATH/feed/<id>/`. Needs `ffmpeg` on `PATH`.
-- Cameras load from [cameraconf/*.conf](../cameraconf) via [lib](../lib) `loadCameras`.
+- pm2 spawns one ffmpeg per camera (`live_stream_cam_<id>`) when `livestream_ON=true`: RTSP-over-TCP → rolling HLS in `livestream_FOLDERPATH/feed/<id>/`. Runs `ffmpeg_FILEPATH`, falling back to `ffmpeg` on `PATH`.
+- Cameras load from [cameraconf/*.conf](../cameraconf) via [lib](../lib) `loadCameras`, resolved through `storage_MOTION_CONF_FILEPATH`.
 - Launched by pm2 (`livestream/start.js`) when `livestream_ON=true`; [gateway](../gateway) proxies when `livestream_PROXY_ON=true`.
 - No tables; sessions validated against [command](../command)'s `auth`/`sessions` via [lib](../lib).
 
 ---
 # Config
 
-`livestream_ON`, `livestream_PORT`, `livestream_HOST`, `livestream_FOLDERPATH`, `livestream_PROXY_ON`; see [../env.example](../env.example).
+`livestream_ON`, `livestream_PORT`, `livestream_HOST`, `livestream_FOLDERPATH`, `livestream_PROXY_ON`, `ffmpeg_FILEPATH`, `storage_MOTION_CONF_FILEPATH`; see [../env.example](../env.example).

--- a/memory/README.md
+++ b/memory/README.md
@@ -7,7 +7,7 @@
 
 - Runs only on the prime pm2 instance, only when `memory_ON=true` (`pm2.config.js` forces this in cluster mode). Launched by pm2 (`memory/start.js`, single instance).
 - Internal only, no gateway route. Clients (`require("memory").client("<LABEL>")`) must send `Authorization: memory_AUTH_TOKEN`.
-- Labels (logging only): `AUTH` (command), `OBJECT` (object), `TASK SCHEDULER` + `MEMORY-HEALTH` (schedule), `PROCESS` / `VIDEO PROCESS` / `ZIP PROCESS` (storage).
+- Labels (logging only): `AUTH` (command, livestream, object, schedule, storage), `TASK SCHEDULER` + `MEMORY-HEALTH` (schedule), `PROCESS` / `VIDEO PROCESS` / `ZIP PROCESS` (storage).
 
 ---
 # Modules
@@ -17,7 +17,7 @@ Factories in [lib/](lib), wired to socket events by [socket.js](socket.js):
 - **loginAttempts** — shared login rate limiter (tumbling window); command falls back to a local copy when `memory_ON` is off.
 - **scheduledTasks** — `node-cron` registry; on fire, emits the task id to every instance ([schedule](../schedule)).
 - **converterProcesses** — cancel handles for in-flight mp4/zip jobs ([storage](../storage)).
-- **cronTask** — one `node-cron` job that emits a caller-supplied id.
+- **sessionSync** — broadcasts `sessionInvalidate`, `sessionInvalidateUser`, `sessionInvalidateAll` so every `AUTH` client's session cache stays in sync.
 
 Built-in events: `log`, `callback` (schedule's `MEMORY-HEALTH` check), `disconnect`.
 

--- a/object/README.md
+++ b/object/README.md
@@ -16,9 +16,9 @@ Session-guarded (`authorize`) except `/object/health`; config updates and on-dem
 # Runtime
 
 - Launched by pm2 (`object/start.js`, single instance) when `object_ON=true`; [gateway](../gateway) proxies when `object_PROXY_ON=true`.
-- The prime instance scans each camera every `object_INTERVAL_MS`, writes to `objects_detected`, and prunes captures to `object_MAX_CAPTURES`.
-- With `memory_ON=true`, config/status/scan route through the [memory](../memory) socket (as the `OBJECT` client).
-- YOLOX-Tiny ONNX (~20MB) fetched to `backend/model/yolox_tiny.onnx` on first boot; override with `object_MODEL_URL`.
+- The prime instance scans each camera every `object_INTERVAL_MS`, writes to `objects_detected`, and prunes captures to `object_MAX_CAPTURES` every `object_PRUNE_INTERVAL_MS`.
+- config/status/scan are local, `isPrimeInstance`-gated handlers; the only memory socket client is `AUTH` (session sync), used when `memory_ON=true`.
+- YOLOX-Tiny ONNX (~20MB) fetched to `backend/model/yolox_tiny.onnx` on first boot; override with `object_MODEL_URL` (requires `object_MODEL_SHA256`).
 - Auth and camera loading from [lib](../lib).
 
 ---

--- a/schedule/README.md
+++ b/schedule/README.md
@@ -5,7 +5,7 @@ Cron tasks for the other services: each tick fires an authenticated HTTP call to
 ---
 # API
 
-Session-guarded (`authorize`) except `/schedule/health`; start/stop/destroy also require admin (`requireAdmin`):
+Session-guarded (`authorize`) except `/schedule/health`; every task route also requires admin (`requireAdmin`) — only the memory-socket health-check doesn't:
 
 - schedule, list, stop, destroy cron tasks
 - read run history from `task_runs` (per task or all, newest first)

--- a/storage/README.md
+++ b/storage/README.md
@@ -2,16 +2,7 @@
 
 Saves motion-detected camera frames, serves them, builds downloadable videos/zips, and handles deletion, metrics, and stats.
 
-Runs on the same machine as [motion](https://github.com/Motion-Project/motion), which saves RTSP frames and logs each to `frame_files`. Motion can't capture file size in `sql_query`, so `on_picture_save` shells out:
-
-```
-picture_type jpeg
-picture_filename %t/%Y%m%d-%H%M%S-%q
-
-on_picture_save SZ=$(wc -c %f | head -n1 | awk '{print $1;}'); PGPASSWORD="$database_PASSWORD" psql -h postgres -U "$database_USER" -d "$database_NAME" -c "INSERT INTO frame_files(timestamp, camera, name, size) VALUES(now(), %t, '%Y%m%d-%H%M%S-%q.jpg', $SZ);"
-```
-
-`postgresql-client` ships in the image; `database_*` from `.env`. Full config: [motion.conf.example](../motion.conf.example). Needs [ffmpeg](https://ffmpeg.org) for video generation.
+Runs on the same machine as [motion](https://github.com/Motion-Project/motion), which saves RTSP frames and logs each to `frame_files`. Motion can't capture file size in `sql_query`, so `on_picture_save` shells out to `psql` after each save. `postgresql-client` ships in the image; `database_*` from `.env`. Full config: [motion.conf.example](../motion.conf.example). Needs [ffmpeg](https://ffmpeg.org) for video generation.
 
 ---
 # API
@@ -28,7 +19,7 @@ Session-guarded (`authorize`) except `/storage/health`; video/zip creation, dele
 # Runtime
 
 - pm2 runs storage (`storage/start.js`) + the bundled `motion` when `storage_ON=true`; [gateway](../gateway) proxies when `storage_PROXY_ON=true`.
-- `frame_deletes` logs quota deletions; the prime instance prunes rows older than 30 days.
+- `frame_deletes` logs manual deletions (`pathDelete` / `pathClean`), not quota auto-clean; the prime instance prunes rows older than 30 days.
 - [schedule](../schedule) POSTs `/file/pathAutoClean` when `storage_MAX_GB` is set.
 
 ---


### PR DESCRIPTION
Closes #283

All 13 items from the issue verified against code and fixed. None were already-correct or found wrong.