### PR TITLE
Harden object model retry, config clamps, cleanup

### DIFF
--- a/heartbeat.config.js
+++ b/heartbeat.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	checkUrl: {
 		command: `${baseUrl}/command/health`,
 		livestream: `${baseUrl}/livestream/health`,
+		object: `${baseUrl}/object/health`,
 		schedule: `${baseUrl}/schedule/health`,
 		storage: `${baseUrl}/storage/health`
 	},

--- a/object/backend/lib/detector.js
+++ b/object/backend/lib/detector.js
@@ -15,14 +15,32 @@ const COCO = [
 	"toaster", "sink", "refrigerator", "book", "clock", "vase", "scissors", "teddy bear", "hair drier", "toothbrush"
 ]
 
+const BACKOFF_MS = 5000
+const MAX_BACKOFF_MS = 30 * 60 * 1000
+
 let sessionPromise = null
+let lastError = null
+let lastFailureAt = 0
+let backoffMs = 0
 
 const load = () => {
-	if (!sessionPromise) {
-		sessionPromise = ensureModel()
-			.then((modelPath) => ort.InferenceSession.create(modelPath))
-			.catch((e) => { sessionPromise = null; throw e })
-	}
+	if (sessionPromise) return sessionPromise
+	if (lastError && Date.now() - lastFailureAt < backoffMs) return Promise.reject(lastError)
+	sessionPromise = ensureModel()
+		.then((modelPath) => ort.InferenceSession.create(modelPath))
+		.then((session) => {
+			lastError = null
+			backoffMs = 0
+			return session
+		})
+		.catch((e) => {
+			sessionPromise = null
+			lastError = e
+			lastFailureAt = Date.now()
+			backoffMs = Math.min(backoffMs ? backoffMs * 2 : BACKOFF_MS, MAX_BACKOFF_MS)
+			console.log(`🔍 Model load failed, backing off ${backoffMs}ms:`, e.message)
+			throw e
+		})
 	return sessionPromise
 }
 

--- a/object/backend/lib/webhook.js
+++ b/object/backend/lib/webhook.js
@@ -1,10 +1,12 @@
+const WEBHOOK_TIMEOUT_MS = 5000
+
 module.exports = async (url, content, jpeg) => {
 	if (!url) return
 	try {
 		const form = new FormData()
 		if (content) form.append("content", content)
 		if (jpeg && jpeg.length) form.append("file", new Blob([jpeg], { type: "image/jpeg" }), "detection.jpg")
-		await fetch(url, { method: "POST", body: form })
+		await fetch(url, { method: "POST", body: form, signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS) })
 	} catch (e) {
 		console.log("object webhook failed", e.message)
 	}

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -9,14 +9,29 @@ const sendWebhook = require("./webhook.js")
 const INPUT = detector.INPUT
 const TEMP_DIR = path.join(process.cwd(), "objectTemp")
 const CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH || process.cwd(), "objectCaptures")
-const MAX_CAPTURES = Number.isFinite(parseInt(process.env.object_MAX_CAPTURES)) ? parseInt(process.env.object_MAX_CAPTURES) : 500
+const MAX_CAPTURES = Number.isFinite(parseInt(process.env.object_MAX_CAPTURES)) ? Math.max(0, parseInt(process.env.object_MAX_CAPTURES)) : 500
 const PRUNE_INTERVAL_MS = parseInt(process.env.object_PRUNE_INTERVAL_MS) > 0 ? parseInt(process.env.object_PRUNE_INTERVAL_MS) : 300000
 const PRUNE_CONCURRENCY = 32
 const CAMERA_TTL_MS = 30000
+const TEMP_STALE_MS = 60000
 fs.mkdirSync(TEMP_DIR, { recursive: true })
 fs.mkdirSync(CAPTURES_DIR, { recursive: true })
 
 const confTier = (conf) => conf == null ? 0 : conf < 0.6 ? 1 : conf < 0.7 ? 2 : conf < 0.8 ? 3 : conf < 0.9 ? 4 : 5
+
+const sweepTemp = async () => {
+	const names = await fs.promises.readdir(TEMP_DIR).catch(() => [])
+	const cutoff = Date.now() - TEMP_STALE_MS
+	await mapLimit(names, PRUNE_CONCURRENCY, async (f) => {
+		const p = path.join(TEMP_DIR, f)
+		try {
+			const stat = await fs.promises.stat(p)
+			if (stat.mtimeMs < cutoff) await fs.promises.unlink(p)
+		} catch (e) {}
+	})
+}
+
+sweepTemp().catch(() => {})
 
 const pruneCaptures = async () => {
 	const names = await fs.promises.readdir(CAPTURES_DIR)
@@ -46,8 +61,13 @@ const pruneCaptures = async () => {
 	}
 }
 
+const parseConfidence = (val) => {
+	const c = parseFloat(val)
+	return Number.isFinite(c) && c >= 0 && c <= 1 ? c : 0.5
+}
+
 const config = {
-	confidence: Number.isFinite(parseFloat(process.env.object_CONFIDENCE)) ? parseFloat(process.env.object_CONFIDENCE) : 0.5,
+	confidence: parseConfidence(process.env.object_CONFIDENCE),
 	intervalMs: parseInt(process.env.object_INTERVAL_MS) || 5000,
 	classes: ["person", "car", "bird", "dog", "cat", "truck", "bus", "motorcycle", "umbrella", "bicycle"],
 }
@@ -141,7 +161,11 @@ const scan = async (id) => {
 	try {
 		const list = await cameras()
 		const cam = list.find(c => c.id === id)
-		if (!cam) return []
+		if (!cam) {
+			const err = new Error("unknown camera")
+			err.code = "UNKNOWN_CAMERA"
+			throw err
+		}
 		const st = status[id] || (status[id] = {})
 		const { jpeg, raw } = await extractFrame(cam.id)
 		const all = await detector.detect(toTensor(raw), config.confidence)
@@ -192,7 +216,10 @@ const startWorkers = async () => {
 	const era = epoch
 	await reconcile(era)
 	if (era !== epoch) return
-	pruneTimer = setInterval(() => pruneCaptures().catch(() => {}), PRUNE_INTERVAL_MS)
+	pruneTimer = setInterval(() => {
+		pruneCaptures().catch(() => {})
+		sweepTemp().catch(() => {})
+	}, PRUNE_INTERVAL_MS)
 	reconcileTimer = setInterval(() => reconcile(era), CAMERA_TTL_MS)
 	console.log(`🔍 Object detection workers started for ${Object.values(status).filter((s) => s.running).length} camera(s)`)
 }
@@ -218,6 +245,7 @@ module.exports = {
 	startWorkers,
 	stopWorkers,
 	pruneCaptures,
+	sweepTemp,
 	scan,
 	toTensor,
 	cameras,

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -34,6 +34,7 @@ const sweepTemp = async () => {
 sweepTemp().catch(() => {})
 
 const pruneCaptures = async () => {
+	if (MAX_CAPTURES <= 0) return
 	const names = await fs.promises.readdir(CAPTURES_DIR)
 	if (names.length <= MAX_CAPTURES) return
 	const stats = await mapLimit(names, PRUNE_CONCURRENCY, async (f) => {

--- a/object/backend/routes/object.js
+++ b/object/backend/routes/object.js
@@ -30,7 +30,8 @@ app.post("/scan", requireAdmin, (req, res) => {
 	const camera = parseInt(req.body && req.body.camera)
 	if (!camera) return res.status(400).send({ error: "camera required" })
 	ifPrime(res, () =>
-		worker.scan(camera).then(detections => res.send({ camera, detections })).catch(e => res.status(502).send({ error: e.message })))
+		worker.scan(camera).then(detections => res.send({ camera, detections }))
+			.catch(e => res.status(e.code === "UNKNOWN_CAMERA" ? 404 : 502).send({ error: e.message })))
 })
 
 app.get("/detections", async (req, res) => {
@@ -43,8 +44,14 @@ app.get("/detections", async (req, res) => {
 		if (!(id > 0)) return res.status(400).send({ error: "unknown camera" })
 		params.push(id); where.push(`camera = $${params.length}`)
 	}
-	if (start) { params.push(start); where.push(`timestamp >= $${params.length}`) }
-	if (end) { params.push(end); where.push(`timestamp <= $${params.length}`) }
+	if (start) {
+		if (isNaN(Date.parse(start))) return res.status(400).send({ error: "invalid start" })
+		params.push(start); where.push(`timestamp >= $${params.length}`)
+	}
+	if (end) {
+		if (isNaN(Date.parse(end))) return res.status(400).send({ error: "invalid end" })
+		params.push(end); where.push(`timestamp <= $${params.length}`)
+	}
 	params.push(limit)
 	const clause = where.length ? `WHERE ${where.join(" AND ")} ` : ""
 	try {

--- a/object/test/detector-backoff.test.js
+++ b/object/test/detector-backoff.test.js
@@ -1,0 +1,62 @@
+jest.mock("onnxruntime-node", () => ({ InferenceSession: { create: jest.fn() } }))
+jest.mock("../backend/lib/model.js", () => ({ ensureModel: jest.fn() }))
+
+describe("detector.load backoff", () => {
+	let ort, ensureModel, load, now
+
+	beforeEach(() => {
+		jest.resetModules()
+		ort = require("onnxruntime-node")
+		ensureModel = require("../backend/lib/model.js").ensureModel
+		load = require("../backend/lib/detector.js").load
+		now = 1000000
+		jest.spyOn(Date, "now").mockImplementation(() => now)
+	})
+
+	afterEach(() => {
+		Date.now.mockRestore()
+	})
+
+	test("caches the failure and refuses to retry until the backoff window elapses", async () => {
+		ensureModel.mockRejectedValue(new Error("model download failed: 500"))
+		await expect(load()).rejects.toThrow("model download failed: 500")
+		expect(ensureModel).toHaveBeenCalledTimes(1)
+
+		now += 4999
+		await expect(load()).rejects.toThrow("model download failed: 500")
+		expect(ensureModel).toHaveBeenCalledTimes(1)
+	})
+
+	test("retries after the backoff elapses, doubling the window on repeat failure", async () => {
+		ensureModel.mockRejectedValue(new Error("boom"))
+		await expect(load()).rejects.toThrow("boom")
+		expect(ensureModel).toHaveBeenCalledTimes(1)
+
+		now += 5000
+		await expect(load()).rejects.toThrow("boom")
+		expect(ensureModel).toHaveBeenCalledTimes(2)
+
+		now += 9999
+		await expect(load()).rejects.toThrow("boom")
+		expect(ensureModel).toHaveBeenCalledTimes(2)
+
+		now += 1
+		await expect(load()).rejects.toThrow("boom")
+		expect(ensureModel).toHaveBeenCalledTimes(3)
+	})
+
+	test("resolves and caches the session after a successful attempt following a prior failure", async () => {
+		const session = { inputNames: ["in"], outputNames: ["out"] }
+		ensureModel.mockRejectedValueOnce(new Error("boom"))
+		await expect(load()).rejects.toThrow("boom")
+
+		now += 5000
+		ensureModel.mockResolvedValueOnce("/model/path")
+		ort.InferenceSession.create.mockResolvedValueOnce(session)
+		await expect(load()).resolves.toBe(session)
+		expect(ensureModel).toHaveBeenCalledTimes(2)
+
+		await expect(load()).resolves.toBe(session)
+		expect(ensureModel).toHaveBeenCalledTimes(2)
+	})
+})

--- a/object/test/object.test.js
+++ b/object/test/object.test.js
@@ -81,6 +81,27 @@ describe("Object Routes", () => {
 			.expect(400, done)
 	})
 
+	test("Detections reject an unparseable start date", (done) => {
+		supertest(app)
+			.get("/object/detections?start=banana")
+			.set("Cookie", authorized)
+			.expect(400, done)
+	})
+
+	test("Detections reject an unparseable end date", (done) => {
+		supertest(app)
+			.get("/object/detections?end=banana")
+			.set("Cookie", authorized)
+			.expect(400, done)
+	})
+
+	test("Detections accept a valid ISO start/end range", (done) => {
+		supertest(app)
+			.get("/object/detections?start=2024-01-01&end=2024-02-01")
+			.set("Cookie", authorized)
+			.expect(200, done)
+	})
+
 	test("Config update requires auth", (done) => {
 		supertest(app).post("/object/config").send({ confidence: 0.7 }).expect(401, done)
 	})
@@ -120,6 +141,18 @@ describe("Object Routes", () => {
 			.send({ camera: 1 })
 			.expect(502)
 			.expect((res) => expect(res.body.error).toBe("frame grab failed"))
+			.end(done)
+	})
+
+	test("Scan returns 404 for an unknown camera instead of a false-positive empty result", (done) => {
+		const err = Object.assign(new Error("unknown camera"), { code: "UNKNOWN_CAMERA" })
+		require("../backend/lib/worker.js").scan.mockRejectedValueOnce(err)
+		supertest(app)
+			.post("/object/scan")
+			.set("Cookie", authorized)
+			.send({ camera: 999 })
+			.expect(404)
+			.expect((res) => expect(res.body.error).toBe("unknown camera"))
 			.end(done)
 	})
 })

--- a/object/test/sweep-temp.test.js
+++ b/object/test/sweep-temp.test.js
@@ -1,0 +1,55 @@
+jest.mock("lib", () => ({ isPrimeInstance: true, objectState: { register: jest.fn() }, loadCameras: jest.fn(() => Promise.resolve([])), mapLimit: require("../../lib/utils/mapLimit.js") }))
+jest.mock("child_process", () => ({ execFile: jest.fn() }))
+jest.mock("fs", () => ({ mkdirSync: jest.fn(), readFileSync: jest.fn(), unlinkSync: jest.fn(), writeFileSync: jest.fn(), readdirSync: jest.fn(), statSync: jest.fn(), promises: { readdir: jest.fn(), stat: jest.fn(), unlink: jest.fn() } }))
+jest.mock("../backend/lib/pool.js", () => ({ query: jest.fn() }))
+jest.mock("../backend/lib/webhook.js", () => jest.fn())
+jest.mock("../backend/lib/detector.js", () => ({ INPUT: 4, detect: jest.fn() }))
+
+const path = require("path")
+const fs = require("fs")
+const worker = require("../backend/lib/worker.js")
+
+const NOW = 1700000000000
+
+beforeEach(() => {
+	jest.clearAllMocks()
+	jest.spyOn(Date, "now").mockReturnValue(NOW)
+})
+
+afterEach(() => {
+	Date.now.mockRestore()
+})
+
+describe("sweepTemp", () => {
+	test("removes orphaned temp files older than the stale threshold, keeps fresh ones", async () => {
+		fs.promises.readdir.mockResolvedValue(["1-100-0.jpg", "1-100-0.raw", "2-200-1.jpg"])
+		fs.promises.stat.mockImplementation((p) => {
+			const name = path.basename(p)
+			const mtimeMs = name.startsWith("1-100-0") ? NOW - 70000 : NOW - 1000
+			return Promise.resolve({ mtimeMs })
+		})
+
+		await worker.sweepTemp()
+
+		const unlinked = fs.promises.unlink.mock.calls.map((c) => path.basename(c[0])).sort()
+		expect(unlinked).toEqual(["1-100-0.jpg", "1-100-0.raw"])
+	})
+
+	test("does nothing when the temp directory is empty", async () => {
+		fs.promises.readdir.mockResolvedValue([])
+		await worker.sweepTemp()
+		expect(fs.promises.unlink).not.toHaveBeenCalled()
+	})
+
+	test("swallows a stat failure for a file that vanished mid-sweep", async () => {
+		fs.promises.readdir.mockResolvedValue(["gone.jpg"])
+		fs.promises.stat.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+		await expect(worker.sweepTemp()).resolves.toBeUndefined()
+		expect(fs.promises.unlink).not.toHaveBeenCalled()
+	})
+
+	test("swallows a readdir failure instead of throwing", async () => {
+		fs.promises.readdir.mockRejectedValue(new Error("EACCES"))
+		await expect(worker.sweepTemp()).resolves.toBeUndefined()
+	})
+})

--- a/object/test/webhook.test.js
+++ b/object/test/webhook.test.js
@@ -1,0 +1,27 @@
+global.fetch = jest.fn().mockResolvedValue({})
+
+const sendWebhook = require("../backend/lib/webhook.js")
+
+describe("sendWebhook", () => {
+	beforeEach(() => {
+		fetch.mockClear()
+	})
+
+	test("does nothing when no url is given", async () => {
+		await sendWebhook(undefined, "hi", Buffer.from("x"))
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	test("posts with a bounded abort signal so an unresponsive alert_URL can't hang the scan loop", async () => {
+		await sendWebhook("http://hook.test", "hi", Buffer.from("x"))
+		expect(fetch).toHaveBeenCalledWith("http://hook.test", expect.objectContaining({
+			method: "POST",
+			signal: expect.any(AbortSignal),
+		}))
+	})
+
+	test("swallows fetch errors instead of throwing", async () => {
+		fetch.mockRejectedValueOnce(new Error("network down"))
+		await expect(sendWebhook("http://hook.test", "hi")).resolves.toBeUndefined()
+	})
+})

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -520,10 +520,25 @@ describe("env-derived numeric config", () => {
 		expect(require("../backend/lib/worker.js").MAX_CAPTURES).toBe(500)
 	})
 
-	test("object_MAX_CAPTURES=-1 clamps to 0 instead of deleting every capture", () => {
+	test("object_MAX_CAPTURES=-1 clamps to 0 instead of going negative", () => {
 		process.env.object_MAX_CAPTURES = "-1"
 		jest.resetModules()
 		expect(require("../backend/lib/worker.js").MAX_CAPTURES).toBe(0)
+	})
+
+	test("pruneCaptures with MAX_CAPTURES=0 skips pruning instead of wiping every capture", async () => {
+		process.env.object_MAX_CAPTURES = "0"
+		jest.resetModules()
+		const freshFs = require("fs")
+		const freshPool = require("../backend/lib/pool.js")
+		const freshWorker = require("../backend/lib/worker.js")
+		freshFs.promises.readdir.mockResolvedValue(["a.jpg", "b.jpg"])
+
+		await freshWorker.pruneCaptures()
+
+		expect(freshFs.promises.readdir).not.toHaveBeenCalledWith(freshWorker.CAPTURES_DIR)
+		expect(freshFs.promises.unlink).not.toHaveBeenCalled()
+		expect(freshPool.query).not.toHaveBeenCalled()
 	})
 
 	test("object_CONFIDENCE > 1 falls back to the default instead of disabling detection", () => {

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -153,8 +153,11 @@ describe("scan", () => {
 		expect(worker.getStatus()[4].error).toBe("ffmpeg boom")
 	})
 
-	test("scanning an unknown camera id leaves no status entry behind", async () => {
-		expect(await worker.scan(999)).toEqual([])
+	test("scanning an unknown camera id throws distinguishably and leaves no status entry behind", async () => {
+		const err = await worker.scan(999).catch((e) => e)
+		expect(err).toBeInstanceOf(Error)
+		expect(err.message).toBe("unknown camera")
+		expect(err.code).toBe("UNKNOWN_CAMERA")
 		expect(worker.getStatus()[999]).toBeUndefined()
 	})
 
@@ -515,5 +518,23 @@ describe("env-derived numeric config", () => {
 		delete process.env.object_MAX_CAPTURES
 		jest.resetModules()
 		expect(require("../backend/lib/worker.js").MAX_CAPTURES).toBe(500)
+	})
+
+	test("object_MAX_CAPTURES=-1 clamps to 0 instead of deleting every capture", () => {
+		process.env.object_MAX_CAPTURES = "-1"
+		jest.resetModules()
+		expect(require("../backend/lib/worker.js").MAX_CAPTURES).toBe(0)
+	})
+
+	test("object_CONFIDENCE > 1 falls back to the default instead of disabling detection", () => {
+		process.env.object_CONFIDENCE = "2"
+		jest.resetModules()
+		expect(require("../backend/lib/worker.js").getConfig().confidence).toBe(0.5)
+	})
+
+	test("object_CONFIDENCE < 0 falls back to the default", () => {
+		process.env.object_CONFIDENCE = "-1"
+		jest.resetModules()
+		expect(require("../backend/lib/worker.js").getConfig().confidence).toBe(0.5)
 	})
 })

--- a/pm2.config.js
+++ b/pm2.config.js
@@ -10,7 +10,7 @@ if ((Number(process.env.chimeraInstances) > 1 || process.env.chimeraInstances ==
 
 const scaled = process.env.chimeraInstances == 1 ? undefined : process.env.chimeraInstances
 const baseEnv = { NODE_ENV: process.env.NODE_ENV, memory_ON: process.env.memory_ON }
-const ignore_watch = ["shared", "feed", "objectTemp", "objectCaptures", "*.log", "log", ".env", ".well-known", "*.config.js", "*.json", "node_modules"]
+const ignore_watch = ["shared", "feed", "objectTemp", "objectCaptures", "object/backend/model", "*.log", "log", ".env", ".well-known", "*.config.js", "*.json", "node_modules"]
 
 const svc = (name, { instances = scaled } = {}) => ({
 	script: `${name}/start.js`,


### PR DESCRIPTION
Closes #280.

Partially addresses #282 (object-owned items 1-8: MAX_CAPTURES/CONFIDENCE clamps, webhook timeout, temp sweep, detections date validation, scan 404, heartbeat + pm2 config). Doc items left for another agent.