### PR TITLE
Fix pool error listeners, motion resurrection, storage crash paths

### DIFF
--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -4,7 +4,7 @@ const bcrypt = require("bcryptjs")
 const { randomUUID } = require("crypto")
 const { createPool } = require("lib")
 
-const pool = createPool()
+const pool = createPool("COMMAND POOL ERROR")
 
 const DUMMY_HASH = bcrypt.hashSync("invalid", 10)
 

--- a/lib/test/createPool.test.js
+++ b/lib/test/createPool.test.js
@@ -1,0 +1,34 @@
+jest.mock("pg", () => {
+	const on = jest.fn()
+	return { Pool: jest.fn(() => ({ on })), __on: on }
+})
+
+const createPool = require("../utils/createPool.js")
+const { __on: on } = require("pg")
+
+describe("createPool", () => {
+	test("attaches an error listener even without a label", () => {
+		createPool()
+		expect(on).toHaveBeenCalledWith("error", expect.any(Function))
+	})
+
+	test("logs a default label when none is given", () => {
+		createPool()
+		const handler = on.mock.calls[0][1]
+		const logSpy = jest.spyOn(console, "log").mockImplementation(() => {})
+		const err = new Error("boom")
+		handler(err)
+		expect(logSpy).toHaveBeenCalledWith("POOL ERROR", err)
+		logSpy.mockRestore()
+	})
+
+	test("logs the given label when provided, unchanged", () => {
+		createPool("MY POOL ERROR")
+		const handler = on.mock.calls[0][1]
+		const logSpy = jest.spyOn(console, "log").mockImplementation(() => {})
+		const err = new Error("boom")
+		handler(err)
+		expect(logSpy).toHaveBeenCalledWith("MY POOL ERROR", err)
+		logSpy.mockRestore()
+	})
+})

--- a/lib/utils/createPool.js
+++ b/lib/utils/createPool.js
@@ -8,6 +8,6 @@ module.exports = (errorLabel) => {
 		password: process.env.database_PASSWORD,
 		port: process.env.database_PORT,
 	})
-	if (errorLabel) pool.on("error", (err) => console.log(errorLabel, err))
+	pool.on("error", (err) => console.log(errorLabel || "POOL ERROR", err))
 	return pool
 }

--- a/storage/__mocks__/pm2.js
+++ b/storage/__mocks__/pm2.js
@@ -7,5 +7,6 @@ module.exports = {
 				unstable_restarts: 0
 			}
 		}])
-	}
+	},
+	restart: jest.fn((name, cb) => cb(null))
 }

--- a/storage/backend/lib/fsUsage.js
+++ b/storage/backend/lib/fsUsage.js
@@ -1,0 +1,20 @@
+const path = require("path")
+const fs = require("fs")
+const { mapLimit } = require("lib")
+
+const FS_CONCURRENCY = 64
+
+const CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH, "shared/captures")
+const OBJECT_CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH, "objectCaptures")
+
+const dirFileBytes = async (dir) => {
+	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
+	const files = entries.filter((entry) => entry.isFile())
+	const sizes = await mapLimit(files, FS_CONCURRENCY, async (entry) => {
+		const { size } = await fs.promises.stat(path.join(dir, entry.name)).catch(() => ({ size: 0 }))
+		return size
+	})
+	return sizes.reduce((sum, size) => sum + size, 0)
+}
+
+module.exports = { FS_CONCURRENCY, CAPTURES_DIR, OBJECT_CAPTURES_DIR, dirFileBytes }

--- a/storage/backend/lib/fsUsage.js
+++ b/storage/backend/lib/fsUsage.js
@@ -4,8 +4,8 @@ const { mapLimit } = require("lib")
 
 const FS_CONCURRENCY = 64
 
-const CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH, "shared/captures")
-const OBJECT_CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH, "objectCaptures")
+const CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH || "", "shared/captures")
+const OBJECT_CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH || "", "objectCaptures")
 
 const dirFileBytes = async (dir) => {
 	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])

--- a/storage/backend/routes/database.js
+++ b/storage/backend/routes/database.js
@@ -2,7 +2,7 @@ var express    = require("express")
 
 const app = express.Router()
 
-const pool = require("lib").createPool()
+const pool = require("../lib/pool")
 
 const queryForHealth = () => {
 	return pool.query("SELECT 2 + 2;")

--- a/storage/backend/routes/events.js
+++ b/storage/backend/routes/events.js
@@ -5,23 +5,9 @@ var { auth, loadCameras, cameraConfFiles, mapLimit } = require("lib")
 const { requireAdmin } = auth
 
 const pool = require("../lib/pool")
+const { FS_CONCURRENCY, CAPTURES_DIR, OBJECT_CAPTURES_DIR, dirFileBytes } = require("../lib/fsUsage")
 
 const app = express.Router()
-
-const FS_CONCURRENCY = 64
-
-const CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH, "shared/captures")
-const OBJECT_CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH, "objectCaptures")
-
-const dirFileBytes = async (dir) => {
-	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
-	const files = entries.filter((entry) => entry.isFile())
-	const sizes = await mapLimit(files, FS_CONCURRENCY, async (entry) => {
-		const { size } = await fs.promises.stat(path.join(dir, entry.name)).catch(() => ({ size: 0 }))
-		return size
-	})
-	return sizes.reduce((sum, size) => sum + size, 0)
-}
 
 const captureBreakdown = async (frameBytes) => {
 	let videos = 0, zips = 0, other = 0

--- a/storage/backend/routes/events.js
+++ b/storage/backend/routes/events.js
@@ -1,6 +1,7 @@
 var express = require("express")
 var path = require("path")
 var fs = require("fs")
+var pm2 = require("pm2")
 var { auth, loadCameras, cameraConfFiles, mapLimit } = require("lib")
 const { requireAdmin } = auth
 
@@ -116,7 +117,13 @@ app.delete("/camera/:id", requireAdmin, async (req, res) => {
 				if (e.code !== "ENOENT") console.log(`STORAGE: failed to remove ${path.basename(file)}; camera may resurrect on reload`, e.message)
 			})
 		}
-		res.json({ deleted: true })
+		pm2.restart("motion", (err) => {
+			if (err) {
+				console.log("STORAGE: motion restart failed after camera delete; camera may resurrect until motion is restarted", err.message || err)
+				return res.status(502).json({ deleted: true, motionRestarted: false })
+			}
+			res.json({ deleted: true, motionRestarted: true })
+		})
 	} catch (e) {
 		res.status(500).json({ error: true })
 	}

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -2,33 +2,22 @@ const path = require("path")
 const fs = require("fs")
 const rimraf = require("rimraf")
 const moment = require("moment")
-const { loadCameras, webhookAlert, mapLimit, createPool } = require("lib")
+const { loadCameras, webhookAlert, mapLimit } = require("lib")
 
-const pool = createPool("STORAGE FILE POOL ERROR")
-
-const FS_CONCURRENCY = 64
+const pool = require("../../lib/pool")
+const { FS_CONCURRENCY, CAPTURES_DIR, OBJECT_CAPTURES_DIR, dirFileBytes } = require("../../lib/fsUsage")
 
 const camerasOrFail = (res) => loadCameras().catch(() => {
 	res.status(500).send({ error: true })
 	return null
 })
 
-const topLevelFileBytes = async (dir) => {
-	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
-	const files = entries.filter((entry) => entry.isFile())
-	const sizes = await mapLimit(files, FS_CONCURRENCY, async (entry) => {
-		const { size } = await fs.promises.stat(path.join(dir, entry.name)).catch(() => ({ size: 0 }))
-		return size
-	})
-	return sizes.reduce((sum, size) => sum + size, 0)
-}
-
 module.exports = {
 	validateCameraAndAppendToPath: (req, res, next) => {
 		const camera = parseInt(req.body.camera)
 		if(camera == req.body.camera){
 			req.body.camera = camera
-			req.body.appendedPath = path.join(process.env.storage_FOLDERPATH, "./shared/captures/", String(camera))
+			req.body.appendedPath = path.join(CAPTURES_DIR, String(camera))
 			next()
 		}
 		else{
@@ -143,16 +132,13 @@ module.exports = {
 			const maxGb = parseFloat(process.env.storage_MAX_GB) || 0
 			if (!maxGb) return res.send({ skipped: true })
 
-			const capturesPath = path.join(process.env.storage_FOLDERPATH, "shared/captures")
-			const objectCapturesPath = path.join(process.env.storage_FOLDERPATH, "objectCaptures")
-
 			const { rows: frameTotalRows } = await pool.query(
 				"SELECT COALESCE(SUM(size), 0) AS total FROM frame_files WHERE size IS NOT NULL AND size > 0"
 			)
 			const frameTotal = parseInt(frameTotalRows[0].total) || 0
 
-			const nonFrameBytes = await topLevelFileBytes(capturesPath)
-			const usedObjectBytes = await topLevelFileBytes(objectCapturesPath)
+			const nonFrameBytes = await dirFileBytes(CAPTURES_DIR)
+			const usedObjectBytes = await dirFileBytes(OBJECT_CAPTURES_DIR)
 			const totalUsedBytes = frameTotal + nonFrameBytes + usedObjectBytes
 
 			const targetBytes = maxGb * 0.9 * 1e9
@@ -181,7 +167,7 @@ module.exports = {
 				}
 
 				await mapLimit(batch, FS_CONCURRENCY, row =>
-					fs.promises.unlink(path.join(capturesPath, row.camera.toString(), row.name)).catch(() => {})
+					fs.promises.unlink(path.join(CAPTURES_DIR, row.camera.toString(), row.name)).catch(() => {})
 				)
 				await pool.query("DELETE FROM frame_files WHERE id = ANY($1::int[])", [batch.map(r => r.id)])
 				deleted += batch.length

--- a/storage/backend/routes/lib/video.js
+++ b/storage/backend/routes/lib/video.js
@@ -148,11 +148,12 @@ module.exports = {
 		skip = skip == undefined ? 1 : skip
 
 		console.log(camera, start, end, fps)
-		createVideoList(camera, start, end, skip, (err, {rand, frames}) => {
+		createVideoList(camera, start, end, skip, (err, result) => {
 			if(err){
 				res.send({error: true})
 			}
 			else{
+				const {rand, frames} = result
 				if(save == undefined || save == true || save == "true"){
 					save = true
 				}

--- a/storage/backend/routes/lib/zip.js
+++ b/storage/backend/routes/lib/zip.js
@@ -103,6 +103,9 @@ const zip = (archive, camera, frames, start, end, save, req, res) => {
 			})
 		}
 		else{
+			archive.on("error", function(err) {
+				console.log("An error occurred: " + err.message)
+			})
 			res.attachment(fileName(camera, start, end, rand, "zip"))
 			archive.pipe(res, {end: true})
 		}

--- a/storage/test/convert.test.js
+++ b/storage/test/convert.test.js
@@ -379,4 +379,19 @@ describe("Convert Routes", () => {
 		})
 	})
 
+	describe("createVideo frame-list write failure", () => {
+		const fs = require("fs")
+		const { createVideo } = require("../backend/routes/lib/video.js")
+
+		test("returns {error:true} instead of throwing when the frame-list write fails", () => {
+			const writeFileSpy = jest.spyOn(fs, "writeFile").mockImplementation((p, d, cb) => cb(new Error("ENOSPC")))
+			const req = { body: { camera: "1", start: "20210101-000000", end: "20210102-000000" } }
+			const res = { send: jest.fn() }
+
+			expect(() => createVideo(req, res)).not.toThrow()
+			expect(res.send).toHaveBeenCalledWith({ error: true })
+
+			writeFileSpy.mockRestore()
+		})
+	})
 })

--- a/storage/test/convert.test.js
+++ b/storage/test/convert.test.js
@@ -364,4 +364,19 @@ describe("Convert Routes", () => {
 			writeFileSpy.mockRestore()
 		})
 	})
+
+	describe("zip streaming (non-save) branch error handling", () => {
+		const { EventEmitter } = require("events")
+		const { zip } = require("../backend/routes/lib/zip.js")
+
+		test("registers an archive error listener so an fs error does not crash storage", () => {
+			const archive = Object.assign(new EventEmitter(), { pipe: jest.fn(), finalize: jest.fn(), abort: jest.fn() })
+			const res = { attachment: jest.fn(), send: jest.fn() }
+
+			zip(archive, 1, 5, "20210101-000000", "20210102-000000", false, { body: {} }, res)
+
+			expect(() => archive.emit("error", new Error("EPIPE"))).not.toThrow()
+		})
+	})
+
 })

--- a/storage/test/events.test.js
+++ b/storage/test/events.test.js
@@ -15,6 +15,7 @@ const supertest = require("supertest")
 const lib = require("lib")
 const { __query: query } = require("pg")
 const fs = require("fs")
+const pm2 = require("pm2")
 const app = require("../backend/storage.js")
 
 const defaultAuthorize = lib.auth.authorize.getMockImplementation()
@@ -93,7 +94,23 @@ describe("Events Routes", () => {
 				.delete("/camera/1")
 				.set("Cookie", "validCookie")
 			expect(res.status).toBe(200)
-			expect(res.body).toEqual({ deleted: true })
+			expect(res.body).toEqual({ deleted: true, motionRestarted: true })
+		})
+
+		test("restarts motion so the deleted camera does not resurrect", async () => {
+			await supertest(app)
+				.delete("/camera/1")
+				.set("Cookie", "validCookie")
+			expect(pm2.restart).toHaveBeenCalledWith("motion", expect.any(Function))
+		})
+
+		test("reports motionRestarted:false without claiming full success when the restart fails", async () => {
+			pm2.restart.mockImplementationOnce((name, cb) => cb(new Error("pm2 busy")))
+			const res = await supertest(app)
+				.delete("/camera/1")
+				.set("Cookie", "validCookie")
+			expect(res.status).toBe(502)
+			expect(res.body).toEqual({ deleted: true, motionRestarted: false })
 		})
 
 		test("returns 400 for non-numeric id", async () => {


### PR DESCRIPTION
Closes #276
Closes #279

Partially addresses #282 (storage items only):
- zip.js streaming branch missing archive error listener
- video.js destructuring before err check
- consolidated storage's 3 pg pools into 1
- deduped dirFileBytes/FS_CONCURRENCY/path constants into fsUsage.js

DELETE /camera/:id now restarts motion after deleting. Success: 200 {deleted:true, motionRestarted:true}. Restart fails: 502 {deleted:true, motionRestarted:false} — doesn't claim full success.

Full jest run: 1 pre-existing failure only (storage/test/file.test.js pathDelete, unrelated rimraf bug, present before this PR).