### PR TITLE
Auth hardening: timing-safe compares, SECRETKEY length, eviction fairness

### DIFF
--- a/.github/ci.env
+++ b/.github/ci.env
@@ -1,10 +1,8 @@
 NODE_ENV = test
 chimeraInstances = 1
-cameras = '["indoor", "outdoor"]'
 alert_URL = http://example.com/hook
 admin_alert_URL = http://example.com/hook
-PRINTPASSWORD = false
-SECRETKEY = ci-test-secret
+SECRETKEY = ci-test-secret-please-ignore-1234567890
 command_PROXY_ON = true
 schedule_PROXY_ON = true
 storage_PROXY_ON = true

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -7,7 +7,7 @@ jest.mock("fs", () => {
 			if (p.includes("env.example")) return [
 				"SECRETKEY = Auth secret key",
 				"gateway_PORT = Port number",
-				"PRINTPASSWORD = (true | false)",
+				"command_ON = (true | false)",
 				"alert_TZ = IANA tz ***"
 			].join("\n")
 			if (p.includes("cam1.conf")) return "camera_id 1\ncamera_name indoor\nnetcam_url rtsp://1.1.1.1/cam\n"
@@ -43,7 +43,7 @@ describe("parseSchema", () => {
 
 describe("typeOf", () => {
 	test("bool for true|false placeholder", () => {
-		expect(typeOf("PRINTPASSWORD", "(true | false)")).toBe("bool")
+		expect(typeOf("command_ON", "(true | false)")).toBe("bool")
 	})
 
 	test("port for _PORT suffix", () => {
@@ -60,7 +60,7 @@ describe("typeOf", () => {
 })
 
 describe("varProblem", () => {
-	const boolVar = { key: "PRINTPASSWORD", placeholder: "(true | false)", optional: false }
+	const boolVar = { key: "command_ON", placeholder: "(true | false)", optional: false }
 	const portVar = { key: "gateway_PORT", placeholder: "Port number", optional: false }
 	const strVar = { key: "SECRETKEY", placeholder: "Auth secret key", optional: false }
 	const optVar = { key: "alert_TZ", placeholder: "IANA tz ***", optional: true }

--- a/chimera/test/validateEnvVars.test.js
+++ b/chimera/test/validateEnvVars.test.js
@@ -21,6 +21,17 @@ describe("validateEnvVars placeholder-secret gate", () => {
 		const res = run({ SECRETKEY: "a-real-secret-value" })
 		expect(res.stdout).not.toContain("PLACEHOLDER SECRET — change before deploying: SECRETKEY")
 	})
+
+	test("blocks boot when SECRETKEY is shorter than 32 characters", () => {
+		const res = run({ SECRETKEY: "too-short-a-secret" })
+		expect(res.stdout).toContain("SECRETKEY TOO SHORT — must be at least 32 characters: SECRETKEY")
+		expect(res.status).toBe(1)
+	})
+
+	test("accepts SECRETKEY at least 32 characters long", () => {
+		const res = run({ SECRETKEY: "a".repeat(32) })
+		expect(res.stdout).not.toContain("SECRETKEY TOO SHORT")
+	})
 })
 
 describe("validateEnvVars confirmURL gate", () => {

--- a/chimera/test/validateEnvVars.test.js
+++ b/chimera/test/validateEnvVars.test.js
@@ -12,13 +12,13 @@ const run = (overrides) => spawnSync(process.execPath, [SCRIPT], {
 
 describe("validateEnvVars placeholder-secret gate", () => {
 	test("blocks boot when SECRETKEY still holds the env.example placeholder", () => {
-		const res = run({ SECRETKEY: "Auth secret key for hashing" })
+		const res = run({ SECRETKEY: "Auth secret key for hashing, min 32 characters" })
 		expect(res.stdout).toContain("PLACEHOLDER SECRET — change before deploying: SECRETKEY")
 		expect(res.status).toBe(1)
 	})
 
 	test("does not flag SECRETKEY when set to a real value", () => {
-		const res = run({ SECRETKEY: "a-real-secret-value" })
+		const res = run({ SECRETKEY: "a-real-secret-value-thats-long-enough" })
 		expect(res.stdout).not.toContain("PLACEHOLDER SECRET — change before deploying: SECRETKEY")
 	})
 

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -23,6 +23,11 @@ const checkVar = (varName) => {
 		allEnvPresent = false
 		return false
 	}
+	if (varName === "SECRETKEY" && val.trim().length < 32) {
+		console.log("SECRETKEY TOO SHORT — must be at least 32 characters:", varName)
+		allEnvPresent = false
+		return false
+	}
 	if (typeOf(varName, placeholders.get(varName)) === "bool" && val.trim() !== "true" && val.trim() !== "false") {
 		console.log("MUST BE true OR false:", varName)
 		allEnvPresent = false

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -1,5 +1,5 @@
 var express = require("express")
-var { validateBody, auth, password } = require("lib")
+var { validateBody, auth, password, timingSafeCompare } = require("lib")
 const { requireAdmin } = auth
 const { passwordCheck, login, pool, withTransaction, HttpError } = require("./lib/auth.js")
 const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout"]
@@ -77,7 +77,7 @@ app.get("/status", async (req, res) => {
 
 app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	const { username, password, token } = req.body
-	if (process.env.setup_TOKEN && token !== process.env.setup_TOKEN) return res.status(403).json({ error: true })
+	if (process.env.setup_TOKEN && !timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true })
 	if (typeof username !== "string") return res.status(400).json({ error: true })
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(username)) return res.status(400).json({ error: true, errors: "Username must be 3-50 characters and contain only letters, numbers, dashes, dots, and underscores." })

--- a/command/backend/routes/cameras.js
+++ b/command/backend/routes/cameras.js
@@ -15,7 +15,7 @@ const stripCreds = (url) => {
 		}
 		return u.toString()
 	} catch {
-		return url
+		return "***"
 	}
 }
 
@@ -27,4 +27,5 @@ app.get("/", async (req, res) => {
 	}
 })
 
+app.stripCreds = stripCreds
 module.exports = app

--- a/command/test/cameras.test.js
+++ b/command/test/cameras.test.js
@@ -48,6 +48,7 @@ jest.mock("memory")
 const supertest = require("supertest")
 const jwt = require("jsonwebtoken")
 const app = require("../backend/command.js")
+const camerasRoute = require("../backend/routes/cameras.js")
 
 const { mockedPool } = require("pg")
 
@@ -86,6 +87,12 @@ describe("Cameras Route", () => {
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
 			expect(res.status).toBe(500)
 			expect(res.body).toEqual({ error: true })
+		})
+	})
+
+	describe("stripCreds", () => {
+		test("returns a placeholder instead of the raw url when parsing fails", () => {
+			expect(camerasRoute.stripCreds("not a valid url")).toBe("***")
 		})
 	})
 })

--- a/env.example
+++ b/env.example
@@ -12,7 +12,6 @@ alert_URL = Primary alert webhook url
 admin_alert_URL = Admin alert webhook url
 alert_TZ = IANA tz for human-readable times in webhook alerts, e.g. America/New_York. Defaults to UTC. Display only; does not affect stored data. ***
 
-PRINTPASSWORD = (true | false)
 SECRETKEY = Auth secret key for hashing
 
 ##################################################################

--- a/env.example
+++ b/env.example
@@ -12,7 +12,7 @@ alert_URL = Primary alert webhook url
 admin_alert_URL = Admin alert webhook url
 alert_TZ = IANA tz for human-readable times in webhook alerts, e.g. America/New_York. Defaults to UTC. Display only; does not affect stored data. ***
 
-SECRETKEY = Auth secret key for hashing
+SECRETKEY = Auth secret key for hashing, min 32 characters
 
 ##################################################################
 # Gateway

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ module.exports = {
 	webhookAlert: require("./utils/webhookAlert.js"),
 	alertTime: require("./utils/alertTime.js"),
 	auth: require("./utils/auth.js"),
+	timingSafeCompare: require("./utils/timingSafeCompare.js"),
 	tracker: require("./utils/tracker.js"),
 	handleServerStart: require("./utils/handleServerStart.js"),
 	handleSecureServerStart: require("./utils/handleSecureServerStart.js"),

--- a/lib/test/timingSafeCompare.test.js
+++ b/lib/test/timingSafeCompare.test.js
@@ -1,0 +1,26 @@
+const timingSafeCompare = require("../utils/timingSafeCompare.js")
+
+describe("timingSafeCompare", () => {
+	test("accepts matching strings", () => {
+		expect(timingSafeCompare("secret-token", "secret-token")).toBe(true)
+	})
+
+	test("rejects mismatched strings of the same length", () => {
+		expect(timingSafeCompare("secret-token", "secret-tokeN")).toBe(false)
+	})
+
+	test("rejects strings of different lengths", () => {
+		expect(timingSafeCompare("short", "a-much-longer-value")).toBe(false)
+	})
+
+	test("rejects when either value is undefined", () => {
+		expect(timingSafeCompare(undefined, "secret-token")).toBe(false)
+		expect(timingSafeCompare("secret-token", undefined)).toBe(false)
+		expect(timingSafeCompare(undefined, undefined)).toBe(false)
+	})
+
+	test("rejects non-string values", () => {
+		expect(timingSafeCompare(123, 123)).toBe(false)
+		expect(timingSafeCompare({}, {})).toBe(false)
+	})
+})

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -1,5 +1,6 @@
 const secretKey = process.env.SECRETKEY
 const jwt = require("jsonwebtoken")
+const timingSafeCompare = require("./timingSafeCompare.js")
 
 const sessionCache = new Map()
 const SESSION_CACHE_MS = 5000
@@ -108,7 +109,7 @@ const verifyJwt = (token, req, res, next, pool, forcedChangeAllowed) => {
 
 const makeAuthorize = (pool, { schedulableUrls = [], forcedChangeAllowed = [] } = {}) => (req, res, next) => {
 	const unauthorized = () => respondUnauthorized(req, res)
-	if (req.headers.authorization != undefined && req.headers.authorization == process.env.scheduler_AUTH && schedulableUrls.includes(req.path)) {
+	if (timingSafeCompare(req.headers.authorization, process.env.scheduler_AUTH) && schedulableUrls.includes(req.path)) {
 		req.decoded = { username: "scheduler", role: "admin" }
 		next()
 	} else {

--- a/lib/utils/timingSafeCompare.js
+++ b/lib/utils/timingSafeCompare.js
@@ -1,0 +1,7 @@
+const { createHash, timingSafeEqual } = require("crypto")
+
+module.exports = (a, b) => {
+	if (typeof a !== "string" || typeof b !== "string") return false
+	const digest = (v) => createHash("sha256").update(v).digest()
+	return timingSafeEqual(digest(a), digest(b))
+}

--- a/memory/lib/loginAttempts.js
+++ b/memory/lib/loginAttempts.js
@@ -5,12 +5,10 @@ module.exports = () => {
 		if(hits.size > 5000) for(const [k, v] of hits) if(now > v.reset) hits.delete(k)
 		if(hits.size > MAX_KEYS){
 			const target = MAX_KEYS - (MAX_KEYS >> 3)
-			for(const [k, v] of hits){
+			for(const k of hits.keys()){
 				if(hits.size <= target) break
-				if(now <= v.reset && v.count >= v.max) continue
 				hits.delete(k)
 			}
-			if(hits.size > MAX_KEYS) for(const k of hits.keys()){ if(hits.size <= MAX_KEYS) break; hits.delete(k) }
 		}
 	}
 	return {

--- a/memory/socket.js
+++ b/memory/socket.js
@@ -1,6 +1,6 @@
 const { Server } = require("socket.io")
 
-const { isPrimeInstance } = require("lib")
+const { isPrimeInstance, timingSafeCompare } = require("lib")
 
 module.exports = () => {
 	if(process.env.memory_ON == "true" && isPrimeInstance){
@@ -12,7 +12,7 @@ module.exports = () => {
 				credentials: true
 			},
 			allowRequest: (req, callback) => {
-				const authorized = req.headers.authorization == process.env.memory_AUTH_TOKEN
+				const authorized = timingSafeCompare(req.headers.authorization, process.env.memory_AUTH_TOKEN)
 				callback(authorized ? "OK" : "UNAUTHORIZED", authorized)
 			}
 		})

--- a/memory/test/loginAttempts.test.js
+++ b/memory/test/loginAttempts.test.js
@@ -1,0 +1,43 @@
+const makeLoginAttempts = require("../lib/loginAttempts.js")
+
+describe("loginAttempts", () => {
+	test("blocks once max attempts are reserved within the window", () => {
+		const { loginReserve } = makeLoginAttempts()
+		const results = []
+		for (let i = 0; i < 4; i++) loginReserve("k", 3, 60000, (blocked) => results.push(blocked))
+		expect(results).toEqual([false, false, false, true])
+	})
+
+	test("loginRelease frees a slot back up", () => {
+		const { loginReserve, loginRelease } = makeLoginAttempts()
+		loginReserve("k", 1, 60000, () => {})
+		loginRelease("k")
+		let blocked
+		loginReserve("k", 1, 60000, (b) => { blocked = b })
+		expect(blocked).toBe(false)
+	})
+
+	test("a new window resets the count", () => {
+		const { loginReserve } = makeLoginAttempts()
+		const realNow = Date.now
+		Date.now = () => 0
+		loginReserve("k", 1, 1000, () => {})
+		Date.now = () => 2000
+		let blocked
+		loginReserve("k", 1, 1000, (b) => { blocked = b })
+		Date.now = realNow
+		expect(blocked).toBe(false)
+	})
+
+	test("eviction past MAX_KEYS is age-based, not preferential to non-saturated victim counters", () => {
+		const { loginReserve } = makeLoginAttempts()
+		loginReserve("saturated-old", 1, 60000, () => {})
+		loginReserve("victim", 10, 60000, () => {})
+		for (let i = 0; i < 20000; i++) loginReserve(`flood-${i}`, 100, 60000, () => {})
+		let victimBlocked
+		loginReserve("victim", 10, 60000, (b) => { victimBlocked = b })
+		let saturatedBlocked
+		loginReserve("saturated-old", 1, 60000, (b) => { saturatedBlocked = b })
+		expect(victimBlocked).toBe(saturatedBlocked)
+	})
+})


### PR DESCRIPTION
Closes #281

Partially addresses #282 — removes dead `PRINTPASSWORD` env var and a leftover `cameras=` line from `.github/ci.env`.

## Changes

1. **Timing-unsafe comparisons** — new `lib/utils/timingSafeCompare.js` (SHA256 digest + `crypto.timingSafeEqual`), exported from `lib/index.js`, used for `scheduler_AUTH` (`lib/utils/auth.js`), `memory_AUTH_TOKEN` (`memory/socket.js`), and `setup_TOKEN` (`command/backend/routes/authorization.js`).

2. **SECRETKEY strength** — `chimera/validateEnvVars.js` rejects SECRETKEY < 32 chars alongside the existing placeholder check. CI fixture secret bumped to match.

3. **Login rate-limit eviction** — `memory/lib/loginAttempts.js` prune is now pure oldest-first. The old logic evicted only from the non-saturated pool, so a distinct-key flood spent its whole eviction budget on partial (victim) counters while blocked entries were immune. Trade-off: blocked entries are no longer protected from eviction under sustained flood — fairer than the original asymmetry.

4. **`stripCreds` fallback** — returns `"***"` instead of the raw URL on parse failure.

## Not done

`GET /convert/listProcess` `requireAdmin` (from #281) — `RecordingsList.jsx` and `ProcessList.jsx` call it for all signed-in users, and `/recordings` is not in `adminRoutes` in `routeIndexMapping.js`. Gating it would break the non-admin recordings view. Needs a product decision.

## Test plan

CI green: `test` (full `jest` across all projects), `build`, `e2e`.

New tests: `lib/test/timingSafeCompare.test.js`, `chimera/test/validateEnvVars.test.js` (SECRETKEY length), `memory/test/loginAttempts.test.js` (eviction fairness), `command/test/cameras.test.js` (stripCreds placeholder).
