### PR TITLE
Allow non-admin livestream restart, add restart-all UI

### DIFF
--- a/command/frontend/app/LiveVideo.jsx
+++ b/command/frontend/app/LiveVideo.jsx
@@ -81,9 +81,9 @@ const LiveVideo = (props) => {
 		return (
 			<div className="flex flex-col gap-3">
 				<div className="flex justify-end">
-					<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} title="Restart all camera streams">
-						<RefreshCw className="size-3.5" />
-						Restart streams
+					<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} disabled={state.restarting} title="Restart all camera streams">
+						<RefreshCw className={cn("size-3.5", state.restarting && "animate-spin")} />
+						{state.restarting ? "Restarting…" : "Restart streams"}
 					</Button>
 				</div>
 				{state.videoList.map((video) => (
@@ -97,9 +97,9 @@ const LiveVideo = (props) => {
 		return (
 			<div className="flex flex-col gap-2">
 				<div className="flex justify-end">
-					<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} title="Restart all camera streams">
-						<RefreshCw className="size-3.5" />
-						Restart streams
+					<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} disabled={state.restarting} title="Restart all camera streams">
+						<RefreshCw className={cn("size-3.5", state.restarting && "animate-spin")} />
+						{state.restarting ? "Restarting…" : "Restart streams"}
 					</Button>
 				</div>
 				{videos.map((row, ri) => (

--- a/command/frontend/app/LiveVideo.jsx
+++ b/command/frontend/app/LiveVideo.jsx
@@ -81,8 +81,9 @@ const LiveVideo = (props) => {
 		return (
 			<div className="flex flex-col gap-3">
 				<div className="flex justify-end">
-					<Button variant="ghost" size="icon" className="size-7" onClick={refresh}>
+					<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} title="Restart all camera streams">
 						<RefreshCw className="size-3.5" />
+						Restart streams
 					</Button>
 				</div>
 				{state.videoList.map((video) => (
@@ -96,8 +97,9 @@ const LiveVideo = (props) => {
 		return (
 			<div className="flex flex-col gap-2">
 				<div className="flex justify-end">
-					<Button variant="ghost" size="icon" className="size-7" onClick={refresh}>
+					<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} title="Restart all camera streams">
 						<RefreshCw className="size-3.5" />
+						Restart streams
 					</Button>
 				</div>
 				{videos.map((row, ri) => (

--- a/command/frontend/hooks/useLiveVideo.js
+++ b/command/frontend/hooks/useLiveVideo.js
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from "react"
 
 import moment from "moment"
 import { request, jsonProcessing } from "../js/request.js"
+import toast from "../js/toast.js"
 
 const listVideos = (cameras, setState, seqRef) => {
 	const seq = ++seqRef.current
@@ -33,14 +34,13 @@ const listVideos = (cameras, setState, seqRef) => {
 	})
 }
 
-const attemptRestart = (camera) => {
+const attemptRestart = (camera) =>
 	request("/livestream/restart", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ camera }),
 		mode: "cors"
-	})
-}
+	}, (prom) => prom)
 
 const useLiveVideo = (cameras) => {
 	const seqRef = useRef(0)
@@ -52,11 +52,17 @@ const useLiveVideo = (cameras) => {
 
 	const refresh = () => listVideos(cameras, setState, seqRef)
 
+	const restartAll = () => {
+		if (!cameras.length) return
+		toast("Restarting livestreams…")
+		Promise.allSettled(cameras.map((cam) => attemptRestart(cam.id))).then(refresh)
+	}
+
 	useEffect(() => {
 		refresh()
 	}, [cameras])
 
-	return [state, refresh, attemptRestart]
+	return [state, refresh, restartAll]
 }
 
 export default useLiveVideo

--- a/command/frontend/hooks/useLiveVideo.js
+++ b/command/frontend/hooks/useLiveVideo.js
@@ -46,6 +46,7 @@ const useLiveVideo = (cameras) => {
 	const seqRef = useRef(0)
 	const [state, setState] = useState({
 		loading: false,
+		restarting: false,
 		lastUpdated: moment().format("h:mm:ss a"),
 		videoList: []
 	})
@@ -53,9 +54,13 @@ const useLiveVideo = (cameras) => {
 	const refresh = () => listVideos(cameras, setState, seqRef)
 
 	const restartAll = () => {
-		if (!cameras.length) return
+		if (!cameras.length || state.restarting) return
+		setState((old) => ({ ...old, restarting: true }))
 		toast("Restarting livestreams…")
-		Promise.allSettled(cameras.map((cam) => attemptRestart(cam.id))).then(refresh)
+		Promise.allSettled(cameras.map((cam) => attemptRestart(cam.id))).then(() => {
+			setState((old) => ({ ...old, restarting: false }))
+			refresh()
+		})
 	}
 
 	useEffect(() => {

--- a/livestream/README.md
+++ b/livestream/README.md
@@ -5,7 +5,7 @@ Serves and monitors per-camera HLS streams. RTSP→HLS transcoding runs in separ
 ---
 # API
 
-Session-guarded (`authorize`) except `/livestream/health`; restart also requires admin (`requireAdmin`):
+Session-guarded (`authorize`) except `/livestream/health`:
 
 - pm2 status for all cameras or one
 - restart a camera's ffmpeg process

--- a/livestream/backend/routes/livestream.js
+++ b/livestream/backend/routes/livestream.js
@@ -1,7 +1,6 @@
 var express    = require("express")
 const path = require("path")
-const { subprocess, auth } = require("lib")
-const { requireAdmin } = auth
+const { subprocess } = require("lib")
 
 const app = express.Router()
 
@@ -22,7 +21,7 @@ app.get("/status", (req, res, next) => {
 	next()
 }, subprocess.processListMiddleware)
 
-app.post("/restart", requireAdmin, (req, res, next) => {
+app.post("/restart", (req, res, next) => {
 	const {camera} = req.body
 	if(camera){
 		req.processName = `live_stream_cam_${camera}`

--- a/livestream/test/livestream.test.js
+++ b/livestream/test/livestream.test.js
@@ -44,13 +44,20 @@ describe("Livestream Routes", () => {
 		})
 	})
 
-	describe("POST /restart admin gating", () => {
-		test("non-admin user is forbidden", (done) => {
+	describe("POST /restart", () => {
+		test("unauthenticated user is unauthorized", (done) => {
+			supertest(app)
+				.post("/livestream/restart")
+				.send({ camera: 1 })
+				.expect(401, done)
+		})
+
+		test("non-admin user passes the gate (400 without a camera)", (done) => {
 			supertest(app)
 				.post("/livestream/restart")
 				.set("Cookie", "userCookie")
-				.send({ camera: 1 })
-				.expect(403, done)
+				.send({})
+				.expect(400, done)
 		})
 
 		test("admin passes the gate (400 without a camera)", (done) => {


### PR DESCRIPTION
## What
- Drop `requireAdmin` from `POST /livestream/restart`; endpoint stays session-guarded via app-level `authorize`, so any authenticated user can restart streams.
- Add a "Restart streams" button (list + grid views) wired to a new `restartAll` that restarts every camera via `Promise.allSettled` then refreshes status.
- Fix `attemptRestart` to pass the `request` callback so it returns the fetch promise.
- Update tests (unauthenticated→401, non-admin→400, admin→400) and README auth note.
