### PR TITLE
Fix object worker capture-write and in-flight scan races

### DIFF
--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -1,7 +1,7 @@
 const fs = require("fs")
 const path = require("path")
 const { execFile } = require("child_process")
-const { isPrimeInstance, loadCameras, mapLimit } = require("lib")
+const { isPrimeInstance, loadCameras, mapLimit, webhookAlert } = require("lib")
 const pool = require("./pool.js")
 const detector = require("./detector.js")
 const sendWebhook = require("./webhook.js")
@@ -14,8 +14,8 @@ const PRUNE_INTERVAL_MS = parseInt(process.env.object_PRUNE_INTERVAL_MS) > 0 ? p
 const PRUNE_CONCURRENCY = 32
 const CAMERA_TTL_MS = 30000
 const TEMP_STALE_MS = 60000
-fs.mkdirSync(TEMP_DIR, { recursive: true })
-fs.mkdirSync(CAPTURES_DIR, { recursive: true })
+try { fs.mkdirSync(TEMP_DIR, { recursive: true }) } catch (e) { console.error("❌ Failed to create object temp directory:", e.message) }
+try { fs.mkdirSync(CAPTURES_DIR, { recursive: true }) } catch (e) { console.error("❌ Failed to create object captures directory:", e.message) }
 
 const confTier = (conf) => conf == null ? 0 : conf < 0.6 ? 1 : conf < 0.7 ? 2 : conf < 0.8 ? 3 : conf < 0.9 ? 4 : 5
 
@@ -137,10 +137,22 @@ const toTensor = (raw) => {
 
 const roundTo = (val, sig) => Math.round(val * 10 ** sig) / 10 ** sig
 
+let captureWriteFailing = false
+
 const handleDetections = async (camera, detections, jpeg) => {
 	const image = `${camera}-${Date.now()}.jpg`
-	try { fs.writeFileSync(path.join(CAPTURES_DIR, image), jpeg) } catch (e) {}
-	const persistable = detections.filter((d) => Array.isArray(d.box))
+	const stored = await fs.promises.writeFile(path.join(CAPTURES_DIR, image), jpeg)
+		.then(() => true)
+		.catch((e) => {
+			console.log("OBJECT CAPTURE WRITE ERROR", e.message)
+			if (!captureWriteFailing) {
+				captureWriteFailing = true
+				webhookAlert(`⚠️ Object capture write to ${CAPTURES_DIR} failed (${e.message}) — detections are still being alerted but no longer recorded. Check disk space.`, "admin")
+			}
+			return false
+		})
+	if (stored) captureWriteFailing = false
+	const persistable = stored ? detections.filter((d) => Array.isArray(d.box)) : []
 	if (persistable.length) {
 		const values = []
 		const rows = persistable.map((d, i) => {
@@ -158,7 +170,7 @@ const handleDetections = async (camera, detections, jpeg) => {
 	await sendWebhook(process.env.alert_URL, `🔍 Camera ${camera}: detected ${summary}`, jpeg)
 }
 
-const scan = async (id) => {
+const scan = async (id, era = epoch) => {
 	try {
 		const list = await cameras()
 		const cam = list.find(c => c.id === id)
@@ -167,10 +179,13 @@ const scan = async (id) => {
 			err.code = "UNKNOWN_CAMERA"
 			throw err
 		}
-		const st = status[id] || (status[id] = {})
 		const { jpeg, raw } = await extractFrame(cam.id)
 		const all = await detector.detect(toTensor(raw), config.confidence)
 		const detections = all.filter((d) => config.classes.includes(d.class))
+
+		if (era !== epoch || (_cameras && !_cameras.some(c => c.id === id))) return detections
+
+		const st = status[id] || (status[id] = {})
 		st.lastRun = new Date().toISOString()
 		st.error = null
 		if (detections.length) {
@@ -179,7 +194,7 @@ const scan = async (id) => {
 		}
 		return detections
 	} catch (e) {
-		if (status[id]) status[id].error = e.message
+		if (e.code !== "UNKNOWN_CAMERA" && status[id]) status[id].error = e.message
 		throw e
 	}
 }
@@ -187,7 +202,7 @@ const scan = async (id) => {
 const startLoop = (id, era) => {
 	const st = status[id]
 	const loop = async () => {
-		await scan(id).catch(() => {})
+		await scan(id, era).catch(() => {})
 		if (era !== epoch || status[id] !== st || !st.running) return
 		timers[id] = setTimeout(loop, config.intervalMs)
 	}
@@ -229,6 +244,7 @@ const stopWorkers = () => {
 	epoch++
 	_cameras = null
 	_camerasAt = 0
+	captureWriteFailing = false
 	clearInterval(pruneTimer)
 	pruneTimer = null
 	clearInterval(reconcileTimer)

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -14,7 +14,7 @@ const PRUNE_INTERVAL_MS = parseInt(process.env.object_PRUNE_INTERVAL_MS) > 0 ? p
 const PRUNE_CONCURRENCY = 32
 const CAMERA_TTL_MS = 30000
 const TEMP_STALE_MS = 60000
-try { fs.mkdirSync(TEMP_DIR, { recursive: true }) } catch (e) { console.error("❌ Failed to create object temp directory:", e.message) }
+fs.mkdirSync(TEMP_DIR, { recursive: true })
 try { fs.mkdirSync(CAPTURES_DIR, { recursive: true }) } catch (e) { console.error("❌ Failed to create object captures directory:", e.message) }
 
 const confTier = (conf) => conf == null ? 0 : conf < 0.6 ? 1 : conf < 0.7 ? 2 : conf < 0.8 ? 3 : conf < 0.9 ? 4 : 5
@@ -89,6 +89,8 @@ const cameras = async (reload = false) => {
 	return _cameras
 }
 
+const gone = (id, era) => era !== epoch || !_cameras || !_cameras.some((c) => c.id === id)
+
 const feedPath = (feed) => path.join(process.env.livestream_FOLDERPATH || "", "feed", String(feed), "video.m3u8")
 
 let scanSeq = 0
@@ -139,7 +141,7 @@ const roundTo = (val, sig) => Math.round(val * 10 ** sig) / 10 ** sig
 
 let captureWriteFailing = false
 
-const handleDetections = async (camera, detections, jpeg) => {
+const handleDetections = async (camera, detections, jpeg, era) => {
 	const image = `${camera}-${Date.now()}.jpg`
 	const stored = await fs.promises.writeFile(path.join(CAPTURES_DIR, image), jpeg)
 		.then(() => true)
@@ -152,6 +154,7 @@ const handleDetections = async (camera, detections, jpeg) => {
 			return false
 		})
 	if (stored) captureWriteFailing = false
+	if (gone(camera, era)) return
 	const persistable = stored ? detections.filter((d) => Array.isArray(d.box)) : []
 	if (persistable.length) {
 		const values = []
@@ -183,18 +186,19 @@ const scan = async (id, era = epoch) => {
 		const all = await detector.detect(toTensor(raw), config.confidence)
 		const detections = all.filter((d) => config.classes.includes(d.class))
 
-		if (era !== epoch || (_cameras && !_cameras.some(c => c.id === id))) return detections
+		if (detections.length && era === epoch) await cameras(true).catch(() => {})
+		if (gone(id, era)) return detections
 
 		const st = status[id] || (status[id] = {})
 		st.lastRun = new Date().toISOString()
 		st.error = null
 		if (detections.length) {
 			st.lastDetection = { time: st.lastRun, detections }
-			await handleDetections(id, detections, jpeg)
+			await handleDetections(id, detections, jpeg, era)
 		}
 		return detections
 	} catch (e) {
-		if (e.code !== "UNKNOWN_CAMERA" && status[id]) status[id].error = e.message
+		if (status[id]) status[id].error = e.message
 		throw e
 	}
 }

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -1,6 +1,6 @@
-jest.mock("lib", () => ({ isPrimeInstance: true, objectState: { register: jest.fn() }, loadCameras: jest.fn(() => Promise.resolve([])), mapLimit: require("../../lib/utils/mapLimit.js") }))
+jest.mock("lib", () => ({ isPrimeInstance: true, objectState: { register: jest.fn() }, loadCameras: jest.fn(() => Promise.resolve([])), mapLimit: require("../../lib/utils/mapLimit.js"), webhookAlert: jest.fn() }))
 jest.mock("child_process", () => ({ execFile: jest.fn() }))
-jest.mock("fs", () => ({ mkdirSync: jest.fn(), readFileSync: jest.fn(), unlinkSync: jest.fn(), writeFileSync: jest.fn(), readdirSync: jest.fn(() => []), statSync: jest.fn(() => ({ mtimeMs: 0 })), promises: { readdir: jest.fn(() => Promise.resolve([])), stat: jest.fn(() => Promise.resolve({ mtimeMs: 0 })), unlink: jest.fn(() => Promise.resolve()) } }))
+jest.mock("fs", () => ({ mkdirSync: jest.fn(), readFileSync: jest.fn(), unlinkSync: jest.fn(), writeFileSync: jest.fn(), readdirSync: jest.fn(() => []), statSync: jest.fn(() => ({ mtimeMs: 0 })), promises: { readdir: jest.fn(() => Promise.resolve([])), stat: jest.fn(() => Promise.resolve({ mtimeMs: 0 })), unlink: jest.fn(() => Promise.resolve()), writeFile: jest.fn(() => Promise.resolve()) } }))
 jest.mock("../backend/lib/pool.js", () => ({ query: jest.fn() }))
 jest.mock("../backend/lib/webhook.js", () => jest.fn())
 jest.mock("../backend/lib/detector.js", () => ({ INPUT: 4, detect: jest.fn() }))
@@ -11,7 +11,7 @@ const fs = require("fs")
 const pool = require("../backend/lib/pool.js")
 const sendWebhook = require("../backend/lib/webhook.js")
 const detector = require("../backend/lib/detector.js")
-const { loadCameras } = require("lib")
+const { loadCameras, webhookAlert } = require("lib")
 const worker = require("../backend/lib/worker.js")
 
 const SIZE = detector.INPUT * detector.INPUT
@@ -33,6 +33,7 @@ beforeEach(() => {
 	delete process.env.object_ALERT_ON
 	execFile.mockImplementation((file, args, opts, cb) => cb(null))
 	fs.readFileSync.mockImplementation((p) => String(p).endsWith(".raw") ? makeRaw() : Buffer.from("jpeg"))
+	fs.promises.writeFile.mockResolvedValue()
 	pool.query.mockResolvedValue({})
 	sendWebhook.mockResolvedValue()
 })
@@ -137,6 +138,32 @@ describe("scan", () => {
 		expect(worker.getStatus()[3].error).toBeNull()
 	})
 
+	test("still alerts when the capture write fails, but persists nothing and raises an admin alert", async () => {
+		fs.promises.writeFile.mockRejectedValueOnce(new Error("ENOSPC"))
+		detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
+		await worker.scan(4)
+		expect(pool.query).not.toHaveBeenCalled()
+		expect(sendWebhook).toHaveBeenCalledWith(
+			"http://hook.test",
+			expect.stringContaining("person (90%)"),
+			expect.any(Buffer)
+		)
+		expect(webhookAlert).toHaveBeenCalledWith(expect.stringContaining("ENOSPC"), "admin")
+	})
+
+	test("only raises one admin alert until a capture write succeeds again", async () => {
+		fs.promises.writeFile.mockRejectedValue(new Error("ENOSPC"))
+		detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
+		await worker.scan(4)
+		await worker.scan(4)
+		expect(webhookAlert).toHaveBeenCalledTimes(1)
+		fs.promises.writeFile.mockResolvedValue()
+		await worker.scan(4)
+		fs.promises.writeFile.mockRejectedValue(new Error("ENOSPC"))
+		await worker.scan(4)
+		expect(webhookAlert).toHaveBeenCalledTimes(2)
+	})
+
 	test("object_ALERT_ON=false suppresses the webhook but still inserts", async () => {
 		process.env.object_ALERT_ON = "false"
 		detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
@@ -146,11 +173,30 @@ describe("scan", () => {
 		delete process.env.object_ALERT_ON
 	})
 
-	test("records ffmpeg failure in status and rejects", async () => {
+	test("records ffmpeg failure in a tracked camera's status and rejects", async () => {
+		detector.detect.mockResolvedValue([])
+		await worker.scan(4)
+		detector.detect.mockClear()
 		execFile.mockImplementation((file, args, opts, cb) => cb(new Error("ffmpeg boom")))
 		await expect(worker.scan(4)).rejects.toThrow("ffmpeg boom")
 		expect(detector.detect).not.toHaveBeenCalled()
 		expect(worker.getStatus()[4].error).toBe("ffmpeg boom")
+	})
+
+	test("a scan still in flight when the workers stop persists nothing", async () => {
+		let release
+		execFile.mockImplementation((file, args, opts, cb) => { release = cb })
+		detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
+
+		const scanning = worker.scan(1)
+		for (let i = 0; i < 10; i++) await Promise.resolve()
+		worker.stopWorkers()
+		release(null)
+		await scanning
+
+		expect(fs.promises.writeFile).not.toHaveBeenCalled()
+		expect(pool.query).not.toHaveBeenCalled()
+		expect(sendWebhook).not.toHaveBeenCalled()
 	})
 
 	test("scanning an unknown camera id throws distinguishably and leaves no status entry behind", async () => {
@@ -315,6 +361,30 @@ describe("startWorkers / stopWorkers", () => {
 		expect(jest.getTimerCount()).toBe(4)
 		worker.stopWorkers()
 		expect(jest.getTimerCount()).toBe(0)
+	})
+
+	test("a scan in flight when its camera is removed leaves no status entry behind", async () => {
+		let hung = null
+		execFile.mockImplementation((file, args, opts, cb) => {
+			const feed = String(args[args.indexOf("-i") + 1]).replace(/\\/g, "/")
+			if (feed.endsWith("feed/2/video.m3u8") && !hung) hung = cb
+			else cb(null)
+		})
+		await worker.startWorkers()
+		await tick()
+		expect(hung).toEqual(expect.any(Function))
+
+		loadCameras.mockResolvedValue([{ id: 1, name: "a" }])
+		jest.advanceTimersByTime(30000)
+		await tick()
+		expect(worker.getStatus()[2]).toBeUndefined()
+
+		hung(new Error("feed gone"))
+		await tick()
+
+		expect(worker.getStatus()[2]).toBeUndefined()
+		expect(Object.keys(worker.getStatus())).toEqual(["1"])
+		expect(jest.getTimerCount()).toBe(3)
 	})
 
 	test("a camera added while running gets a worker without a restart", async () => {

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -199,6 +199,23 @@ describe("scan", () => {
 		expect(sendWebhook).not.toHaveBeenCalled()
 	})
 
+	test("a scan whose camera is stopped during the capture write inserts nothing and sends no webhook", async () => {
+		let release
+		fs.promises.writeFile.mockImplementation(() => new Promise((r) => { release = r }))
+		detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
+
+		const scanning = worker.scan(1)
+		for (let i = 0; i < 10; i++) await Promise.resolve()
+		expect(release).toEqual(expect.any(Function))
+		worker.stopWorkers()
+		release()
+		await scanning
+
+		expect(fs.promises.writeFile).toHaveBeenCalledTimes(1)
+		expect(pool.query).not.toHaveBeenCalled()
+		expect(sendWebhook).not.toHaveBeenCalled()
+	})
+
 	test("scanning an unknown camera id throws distinguishably and leaves no status entry behind", async () => {
 		const err = await worker.scan(999).catch((e) => e)
 		expect(err).toBeInstanceOf(Error)
@@ -220,7 +237,7 @@ describe("scan", () => {
 })
 
 describe("startWorkers / stopWorkers", () => {
-	const tick = async () => { for (let i = 0; i < 10; i++) await Promise.resolve() }
+	const tick = async () => { for (let i = 0; i < 25; i++) await Promise.resolve() }
 
 	beforeEach(() => {
 		jest.useFakeTimers()
@@ -363,28 +380,25 @@ describe("startWorkers / stopWorkers", () => {
 		expect(jest.getTimerCount()).toBe(0)
 	})
 
-	test("a scan in flight when its camera is removed leaves no status entry behind", async () => {
-		let hung = null
-		execFile.mockImplementation((file, args, opts, cb) => {
-			const feed = String(args[args.indexOf("-i") + 1]).replace(/\\/g, "/")
-			if (feed.endsWith("feed/2/video.m3u8") && !hung) hung = cb
-			else cb(null)
-		})
+	test("a camera deleted from disk persists nothing on its next scan, even while the camera cache still lists it", async () => {
+		detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
 		await worker.startWorkers()
 		await tick()
-		expect(hung).toEqual(expect.any(Function))
+
+		fs.promises.writeFile.mockClear()
+		pool.query.mockClear()
+		sendWebhook.mockClear()
 
 		loadCameras.mockResolvedValue([{ id: 1, name: "a" }])
-		jest.advanceTimersByTime(30000)
-		await tick()
-		expect(worker.getStatus()[2]).toBeUndefined()
-
-		hung(new Error("feed gone"))
+		jest.advanceTimersByTime(worker.getConfig().intervalMs)
 		await tick()
 
-		expect(worker.getStatus()[2]).toBeUndefined()
-		expect(Object.keys(worker.getStatus())).toEqual(["1"])
-		expect(jest.getTimerCount()).toBe(3)
+		const written = fs.promises.writeFile.mock.calls.map((c) => path.basename(String(c[0])))
+		expect(written).toEqual([expect.stringMatching(/^1-\d+\.jpg$/)])
+		expect(pool.query).toHaveBeenCalledTimes(1)
+		expect(pool.query.mock.calls[0][1][0]).toBe(1)
+		expect(sendWebhook).toHaveBeenCalledTimes(1)
+		expect(sendWebhook.mock.calls[0][1]).toContain("Camera 1")
 	})
 
 	test("a camera added while running gets a worker without a restart", async () => {


### PR DESCRIPTION
Three correctness bugs in the object detection worker, plus a fix for a bug that PR #291's version of this change introduces.

### 1. A failed capture write still writes DB rows pointing at a file that does not exist

`handleDetections` wrote the capture with `try { fs.writeFileSync(...) } catch (e) {}` and then inserted `objects_detected` rows referencing `image` **regardless of whether the write succeeded**. On a full or read-only disk the order is: write throws → swallowed → rows inserted → the ObjectDetections UI renders broken thumbnails for detections whose JPEG was never written, and nothing anywhere says why.

Now: `fs.promises.writeFile` (also unblocks the event loop — this ran on the hot path of every detection), rows are only persisted when the write actually succeeded, and the first failure raises a **one-shot** admin `webhookAlert` that re-arms on the next successful write, so a full disk pages you once rather than on every frame. Detections are still alerted on regardless — losing the recording should not lose the notification.

### 2. A scan in flight past `stopWorkers()` / camera deletion still writes

`scan()` had no post-await guard. A scan whose ffmpeg + detect round-trip lands after `stopWorkers()`, or after its camera was deleted and reconciled away, still wrote a capture to disk, inserted rows and fired an alert webhook for a camera that no longer exists. `scan(id, era = epoch)` now carries the era through from `startLoop`, and after the awaits:

```js
if (era !== epoch || (_cameras && !_cameras.some(c => c.id === id))) return detections
```

Same bug class as the motion resurrection fix in 9a86cff.

### 3. `mkdirSync` at module load throws at require time

A permissions failure on `objectTemp` / `objectCaptures` took down the whole process at require time. Wrapped in try/catch with a logged reason.

### 4. Fixes the status-resurrection bug that PR #291 introduces

Worth calling out explicitly. #291 rewrites the catch as:

```js
if (e.code !== "UNKNOWN_CAMERA") (status[id] || (status[id] = {})).error = e.message
```

`develop`'s version (`if (status[id]) status[id].error = ...`) never *created* an entry; #291's does. That reintroduces exactly the resurrection the rest of the change is trying to prevent:

1. camera is deleted → `reconcile()` deletes `status[id]` and clears its timer
2. the still-in-flight scan for that camera then fails (its feed is gone)
3. the catch **recreates** `status[id]` — a zombie entry with no timer, for a camera that does not exist
4. `GET /object/status` reports the phantom camera until the next reconcile sweeps it

This PR ships the guarded version instead:

```js
if (e.code !== "UNKNOWN_CAMERA" && status[id]) status[id].error = e.message
```

Errors are recorded only for cameras that are actually tracked, which is the only case that can arise from the scan loop (`reconcile` always creates the entry first).

### Tests

`object/test/worker.test.js`, all green:

- capture write fails → still webhooks, persists nothing, raises the admin alert
- only one admin alert until a write succeeds again
- a scan in flight when the workers stop persists nothing
- **new regression test**: a scan in flight when its camera is removed leaves no `status` entry behind — this test fails against #291's catch block and passes here
- the existing "unknown camera id ... leaves no status entry behind" test still passes
- "records ffmpeg failure in a tracked camera's status" now seeds the tracked entry explicitly instead of relying on `scan` creating one as a side effect

`npx jest object`: 9 suites, 92 tests passing. `npx eslint object/backend/lib/worker.js` adds no new errors (one fewer, in fact — the empty catch block is gone).

Deliberately **not** included from #291: the `detector.js` anchor-mismatch guard (unreachable — `anchors = 21·S²/1024` and `sizeFromAnchors` inverts it exactly; for the shipped `INPUT=416`, `i` tops out at exactly 3549), the `server.js` SIGINT handler (net-zero — `failureCallback` already stops workers on SIGINT), and the `object/package.json` dep changes (separate dep-hygiene PR).


---

## Update — second review round

Mutation testing against this branch found the flagship guard **did not fix the race it is named after**, and had no test behind it. Fixed in `27ce8fa`.

**Retracting claim 4 above.** The "#291 introduces a status-resurrection bug" framing was the PR's stated justification for its own existence, and it is hollow. Against `develop`, that line is a revert plus an untested extra condition — dropping the `e.code !== "UNKNOWN_CAMERA"` clause left all tests passing. The clause is now removed and `develop`'s `if (status[id])` restored (that guard is what prevents resurrection, and it stays).

**The camera-deletion guard was checking a stale cache.** `_cameras` is the same 30s-TTL cache `scan` already used, so after a camera's conf is deleted the worker kept writing captures and inserting rows for up to 30 seconds. Removing the entire `(_cameras && !_cameras.some(...))` clause left **all 92 tests passing** — the headline feature was untested.

The real race is the *pre-reconcile* window: cameras are motion `.conf` files deleted by a **different pm2 process**, with no IPC, so the worker's only authoritative signal is `loadCameras()`. The fix revalidates against a fresh conf load immediately before persisting, and only on scans that actually produced detections:

```js
if (detections.length && era === epoch) await cameras(true).catch(() => {})
if (gone(id, era)) return detections
```

No DB query added; the fs read runs only on the path that creates orphans, and is negligible next to the ffmpeg extract and inference that already ran.

Also fixed:
- **A new hole this PR opened.** Switching to `await fs.promises.writeFile` added a yield point that did not exist on `develop` (`writeFileSync`). A scan stopped *during* the write still inserted rows and fired a webhook. `handleDetections` now re-checks after the write, before the INSERT and the alert.
- **`TEMP_DIR` throws at boot again.** Swallowing that error converted a loud boot failure into silent permanent breakage — every ffmpeg extract would fail forever, recorded only as a per-camera status error. `CAPTURES_DIR` keeps its catch, since it has a real backstop (the one-shot write alert).

Every guard now has a test that fails when it is removed. Suite: 483 passing.
