### PR TITLE
Recover object detection when a camera scan hangs

### DIFF
--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -75,7 +75,7 @@ const config = {
 
 const status = {}
 const timers = {}
-const inFlight = new Set()
+const inFlight = new WeakSet()
 let pruneTimer = null
 let reconcileTimer = null
 let epoch = 0
@@ -204,18 +204,28 @@ const scan = async (id, era = epoch) => {
 	}
 }
 
-const timeout = (ms) => new Promise((_, reject) => {
-	setTimeout(() => reject(new Error("scan timeout")), ms).unref()
-})
+const capped = async (promise, ms) => {
+	let timer
+	const cap = new Promise((_, reject) => {
+		timer = setTimeout(() => reject(new Error("scan timeout")), ms)
+		timer.unref()
+	})
+	try {
+		return await Promise.race([promise, cap])
+	} finally {
+		clearTimeout(timer)
+	}
+}
 
 const startLoop = (id, era) => {
 	const st = status[id]
 	const loop = async () => {
-		// cap a scan so a hung query can't stall the loop, and skip re-launching while the prior scan is still outstanding so a permanent hang can't pile up concurrent scans
-		if (!inFlight.has(id)) {
-			inFlight.add(id)
-			const done = scan(id, era).finally(() => inFlight.delete(id))
-			await Promise.race([done, timeout(config.intervalMs * 6)]).catch(() => {})
+		if (!inFlight.has(st)) {
+			inFlight.add(st)
+			const done = scan(id, era).finally(() => inFlight.delete(st))
+			await capped(done, config.intervalMs * 6).catch((e) => {
+				if (status[id] === st) st.error = e.message
+			})
 		}
 		if (era !== epoch || status[id] !== st || !st.running) return
 		timers[id] = setTimeout(loop, config.intervalMs)

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -203,10 +203,15 @@ const scan = async (id, era = epoch) => {
 	}
 }
 
+const timeout = (ms) => new Promise((_, reject) => {
+	setTimeout(() => reject(new Error("scan timeout")), ms).unref()
+})
+
 const startLoop = (id, era) => {
 	const st = status[id]
 	const loop = async () => {
-		await scan(id, era).catch(() => {})
+		// cap a scan so a hung query (e.g. detection INSERT) can't stop the loop from re-arming
+		await Promise.race([scan(id, era), timeout(config.intervalMs * 6)]).catch(() => {})
 		if (era !== epoch || status[id] !== st || !st.running) return
 		timers[id] = setTimeout(loop, config.intervalMs)
 	}

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -75,6 +75,7 @@ const config = {
 
 const status = {}
 const timers = {}
+const inFlight = new Set()
 let pruneTimer = null
 let reconcileTimer = null
 let epoch = 0
@@ -210,8 +211,12 @@ const timeout = (ms) => new Promise((_, reject) => {
 const startLoop = (id, era) => {
 	const st = status[id]
 	const loop = async () => {
-		// cap a scan so a hung query (e.g. detection INSERT) can't stop the loop from re-arming
-		await Promise.race([scan(id, era), timeout(config.intervalMs * 6)]).catch(() => {})
+		// cap a scan so a hung query can't stall the loop, and skip re-launching while the prior scan is still outstanding so a permanent hang can't pile up concurrent scans
+		if (!inFlight.has(id)) {
+			inFlight.add(id)
+			const done = scan(id, era).finally(() => inFlight.delete(id))
+			await Promise.race([done, timeout(config.intervalMs * 6)]).catch(() => {})
+		}
 		if (era !== epoch || status[id] !== st || !st.running) return
 		timers[id] = setTimeout(loop, config.intervalMs)
 	}

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -239,6 +239,16 @@ describe("scan", () => {
 describe("startWorkers / stopWorkers", () => {
 	const tick = async () => { for (let i = 0; i < 25; i++) await Promise.resolve() }
 
+	const feedOf = (args) => String(args[args.indexOf("-i") + 1]).replace(/\\/g, "/")
+	const scansOf = (feed) => execFile.mock.calls.filter((c) => feedOf(c[1]).endsWith(`feed/${feed}/video.m3u8`)).length
+	const hangFeed = (feed) => {
+		let held = null
+		execFile.mockImplementation((file, args, opts, cb) => {
+			if (feedOf(args).endsWith(`feed/${feed}/video.m3u8`) && !held) held = cb
+			else cb(null)
+		})
+	}
+
 	beforeEach(() => {
 		jest.useFakeTimers()
 		execFile.mockClear()
@@ -378,6 +388,42 @@ describe("startWorkers / stopWorkers", () => {
 		expect(jest.getTimerCount()).toBe(4)
 		worker.stopWorkers()
 		expect(jest.getTimerCount()).toBe(0)
+	})
+
+	test("a hung scan is capped and not relaunched, and does not stall the other cameras", async () => {
+		hangFeed(2)
+		await worker.startWorkers()
+		await tick()
+		expect(scansOf(1)).toBe(1)
+		expect(scansOf(2)).toBe(1)
+
+		for (let i = 0; i < 6; i++) {
+			jest.advanceTimersByTime(worker.getConfig().intervalMs)
+			await tick()
+		}
+
+		expect(scansOf(1)).toBe(7)
+		expect(scansOf(2)).toBe(1)
+		expect(worker.getStatus()[2].error).toBe("scan timeout")
+		expect(worker.getStatus()[1].error).toBeNull()
+		expect(jest.getTimerCount()).toBe(4)
+	})
+
+	test("a permanently hung scan does not wedge its camera across a restart", async () => {
+		hangFeed(2)
+		await worker.startWorkers()
+		await tick()
+		for (let i = 0; i < 6; i++) {
+			jest.advanceTimersByTime(worker.getConfig().intervalMs)
+			await tick()
+		}
+		expect(scansOf(2)).toBe(1)
+
+		await worker.startWorkers()
+		await tick()
+
+		expect(scansOf(2)).toBe(2)
+		expect(worker.getStatus()[2].error).toBeNull()
 	})
 
 	test("a camera deleted from disk persists nothing on its next scan, even while the camera cache still lists it", async () => {


### PR DESCRIPTION
Closes #297.

If a camera's `scan()` ever hangs (most likely on the unbounded detection INSERT), the loop never re-arms, and `reconcile` skips the camera because it is still marked `running` — so object detection silently dies for that camera until a full restart, while `GET /object/status` still reports it healthy.

### Change
- `object/backend/lib/worker.js`: in `startLoop`, race `scan()` against a timeout (`config.intervalMs * 6`, using an `unref`'d timer) so the re-arm always runs even when a scan hangs.

### Proof
See #297 — driving the real `startWorkers → startLoop → scan → handleDetections` path with a never-settling INSERT left `detect` stuck at 1 across 10 reconcile cycles with `running` still true; the control (healthy INSERT) re-armed normally. With this change the loop re-arms after the timeout.

Base: `develop`. Follow-up to the #178 review.
