### PR TITLE
Protect in-flight captures from the prune race

### DIFF
--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -19,6 +19,8 @@ try { fs.mkdirSync(CAPTURES_DIR, { recursive: true }) } catch (e) { console.erro
 
 const confTier = (conf) => conf == null ? 0 : conf < 0.6 ? 1 : conf < 0.7 ? 2 : conf < 0.8 ? 3 : conf < 0.9 ? 4 : 5
 
+const inFlightCaptures = new Set()
+
 const sweepTemp = async () => {
 	const names = await fs.promises.readdir(TEMP_DIR).catch(() => [])
 	const cutoff = Date.now() - TEMP_STALE_MS
@@ -40,7 +42,7 @@ const pruneCaptures = async () => {
 	const stats = await mapLimit(names, PRUNE_CONCURRENCY, async (f) => {
 		try { return { f, t: (await fs.promises.stat(path.join(CAPTURES_DIR, f))).mtimeMs } } catch (e) { return null }
 	})
-	const files = stats.filter(Boolean)
+	const files = stats.filter((s) => s && !inFlightCaptures.has(s.f))
 	if (files.length <= MAX_CAPTURES) return
 
 	const { rows } = await pool.query(
@@ -143,30 +145,35 @@ let captureWriteFailing = false
 
 const handleDetections = async (camera, detections, jpeg, era) => {
 	const image = `${camera}-${Date.now()}.jpg`
-	const stored = await fs.promises.writeFile(path.join(CAPTURES_DIR, image), jpeg)
-		.then(() => true)
-		.catch((e) => {
-			console.log("OBJECT CAPTURE WRITE ERROR", e.message)
-			if (!captureWriteFailing) {
-				captureWriteFailing = true
-				webhookAlert(`⚠️ Object capture write to ${CAPTURES_DIR} failed (${e.message}) — detections are still being alerted but no longer recorded. Check disk space.`, "admin")
-			}
-			return false
-		})
-	if (stored) captureWriteFailing = false
-	if (gone(camera, era)) return
-	const persistable = stored ? detections.filter((d) => Array.isArray(d.box)) : []
-	if (persistable.length) {
-		const values = []
-		const rows = persistable.map((d, i) => {
-			const p = i * 5
-			values.push(camera, d.class, roundTo(d.score, 6), JSON.stringify(d.box.map((n) => roundTo(n, 1))), image)
-			return `($${p + 1}, $${p + 2}, $${p + 3}, $${p + 4}, $${p + 5})`
-		})
-		await pool.query(
-			`INSERT INTO objects_detected(camera, type, confidence, box, image) VALUES ${rows.join(", ")}`,
-			values
-		).catch((e) => console.log("OBJECT INSERT ERROR", e.message))
+	inFlightCaptures.add(image)
+	try {
+		const stored = await fs.promises.writeFile(path.join(CAPTURES_DIR, image), jpeg)
+			.then(() => true)
+			.catch((e) => {
+				console.log("OBJECT CAPTURE WRITE ERROR", e.message)
+				if (!captureWriteFailing) {
+					captureWriteFailing = true
+					webhookAlert(`⚠️ Object capture write to ${CAPTURES_DIR} failed (${e.message}) — detections are still being alerted but no longer recorded. Check disk space.`, "admin")
+				}
+				return false
+			})
+		if (stored) captureWriteFailing = false
+		if (gone(camera, era)) return
+		const persistable = stored ? detections.filter((d) => Array.isArray(d.box)) : []
+		if (persistable.length) {
+			const values = []
+			const rows = persistable.map((d, i) => {
+				const p = i * 5
+				values.push(camera, d.class, roundTo(d.score, 6), JSON.stringify(d.box.map((n) => roundTo(n, 1))), image)
+				return `($${p + 1}, $${p + 2}, $${p + 3}, $${p + 4}, $${p + 5})`
+			})
+			await pool.query(
+				`INSERT INTO objects_detected(camera, type, confidence, box, image) VALUES ${rows.join(", ")}`,
+				values
+			).catch((e) => console.log("OBJECT INSERT ERROR", e.message))
+		}
+	} finally {
+		inFlightCaptures.delete(image)
 	}
 	if (process.env.object_ALERT_ON === "false") return
 	const summary = detections.map((d) => `${d.class} (${Math.round(d.score * 100)}%)`).join(", ")

--- a/object/test/prune-inflight.test.js
+++ b/object/test/prune-inflight.test.js
@@ -1,0 +1,81 @@
+process.env.object_MAX_CAPTURES = "1"
+
+jest.mock("lib", () => ({ isPrimeInstance: true, objectState: { register: jest.fn() }, loadCameras: jest.fn(() => [{ id: 1, name: "a" }]), mapLimit: require("../../lib/utils/mapLimit.js"), webhookAlert: jest.fn() }))
+jest.mock("child_process", () => ({ execFile: jest.fn() }))
+jest.mock("fs", () => ({ mkdirSync: jest.fn(), readFileSync: jest.fn(), unlinkSync: jest.fn(), writeFileSync: jest.fn(), readdirSync: jest.fn(), statSync: jest.fn(), promises: { readdir: jest.fn(), stat: jest.fn(), unlink: jest.fn(), writeFile: jest.fn() } }))
+jest.mock("../backend/lib/pool.js", () => ({ query: jest.fn() }))
+jest.mock("../backend/lib/webhook.js", () => jest.fn())
+jest.mock("../backend/lib/detector.js", () => ({ INPUT: 4, detect: jest.fn() }))
+
+const path = require("path")
+const { execFile } = require("child_process")
+const fs = require("fs")
+const pool = require("../backend/lib/pool.js")
+const detector = require("../backend/lib/detector.js")
+const worker = require("../backend/lib/worker.js")
+
+const SIZE = detector.INPUT * detector.INPUT
+
+const MTIME = { "old-high.jpg": 10, "old-low.jpg": 20 }
+
+const settle = async () => { for (let i = 0; i < 20; i++) await Promise.resolve() }
+
+let releaseInsert
+
+beforeEach(() => {
+	jest.clearAllMocks()
+	process.env.object_ALERT_ON = "false"
+	releaseInsert = null
+	execFile.mockImplementation((file, args, opts, cb) => cb(null))
+	fs.readFileSync.mockReturnValue(Buffer.alloc(SIZE * 3))
+	fs.promises.writeFile.mockResolvedValue()
+	fs.promises.unlink.mockResolvedValue()
+	fs.promises.stat.mockImplementation((p) => Promise.resolve({ mtimeMs: MTIME[path.basename(p)] ?? Date.now() }))
+	detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
+	pool.query.mockImplementation((sql) => {
+		if (String(sql).startsWith("SELECT")) return Promise.resolve({ rows: [{ image: "old-high.jpg", confidence: "0.95" }, { image: "old-low.jpg", confidence: "0.55" }] })
+		if (String(sql).startsWith("INSERT")) return new Promise((r) => { releaseInsert = () => r({}) })
+		return Promise.resolve({})
+	})
+})
+
+afterAll(() => { delete process.env.object_ALERT_ON })
+
+const unlinked = () => fs.promises.unlink.mock.calls.map((c) => path.basename(String(c[0])))
+const deleted = () => pool.query.mock.calls.filter((c) => String(c[0]).startsWith("DELETE")).map((c) => c[1][0])
+
+describe("pruneCaptures with a capture in flight", () => {
+	test("keeps the just-written capture whose insert has not settled, and still evicts down to MAX_CAPTURES", async () => {
+		const scanning = worker.scan(1)
+		await settle()
+		const fresh = path.basename(String(fs.promises.writeFile.mock.calls[0][0]))
+		expect(releaseInsert).toEqual(expect.any(Function))
+
+		fs.promises.readdir.mockResolvedValue(["old-high.jpg", "old-low.jpg", fresh])
+		await worker.pruneCaptures()
+
+		expect(unlinked()).toEqual(["old-low.jpg"])
+		expect(deleted()).toEqual([["old-low.jpg"]])
+
+		releaseInsert()
+		await scanning
+	})
+
+	test("releases the capture for pruning once the insert settles", async () => {
+		const scanning = worker.scan(1)
+		await settle()
+		const fresh = path.basename(String(fs.promises.writeFile.mock.calls[0][0]))
+		releaseInsert()
+		await scanning
+
+		fs.promises.unlink.mockClear()
+		pool.query.mockClear()
+		pool.query.mockImplementation((sql) => String(sql).startsWith("SELECT")
+			? Promise.resolve({ rows: [{ image: "old-high.jpg", confidence: "0.95" }] })
+			: Promise.resolve({}))
+		fs.promises.readdir.mockResolvedValue(["old-high.jpg", fresh])
+		await worker.pruneCaptures()
+
+		expect(unlinked()).toEqual([fresh])
+	})
+})


### PR DESCRIPTION
Closes #298.

`pruneCaptures` ranks a capture with no `objects_detected` row as lowest tier (deleted first) — which is exactly the state of a capture just written to disk whose INSERT has not committed yet. So prune can delete the newest capture and orphan the row the pending INSERT is about to create, leaving a DB row whose image 404s.

### Change
- `object/backend/lib/worker.js`: track in-flight capture basenames in a module-level `Set` (added immediately before `writeFile`, removed in a `finally` after the INSERT settles) and exclude them from prune candidates.

### Proof
See #298 — with `MAX_CAPTURES=2`, prune deleted the fresh in-flight file and issued a `DELETE` for its row while keeping the two older committed captures. With the guard the in-flight file is skipped.

Base: `develop`. Follow-up to the #178 review.
