### PR TITLE
Reject NaN detections in the confidence filter

### DIFF
--- a/object/backend/lib/detector.js
+++ b/object/backend/lib/detector.js
@@ -78,14 +78,14 @@ const parse = (output, confidence) => {
 			for (let gx = 0; gx < grid; gx++, i++) {
 				const o = i * numChannels
 				const obj = data[o + 4]
-				if (obj < confidence) continue
+				if (!(obj >= confidence)) continue
 				let best = 0, bestScore = 0
 				for (let c = 0; c < numClasses; c++) {
 					const score = data[o + 5 + c]
 					if (score > bestScore) { bestScore = score; best = c }
 				}
 				const score = obj * bestScore
-				if (score < confidence) continue
+				if (!(score >= confidence)) continue
 				const cx = (data[o] + gx) * stride
 				const cy = (data[o + 1] + gy) * stride
 				const w = Math.exp(data[o + 2]) * stride


### PR DESCRIPTION
Closes #299.

The detector drops low-confidence boxes with `if (obj < confidence) continue`. When a value is `NaN`, `NaN < confidence` is `false`, so NaN boxes are **not** dropped — they survive both confidence filters and get written to the DB as garbage detections (and fire webhooks reading `person (NaN%)`).

### Change
- `object/backend/lib/detector.js`: invert both guards to `if (!(obj >= confidence)) continue` / `if (!(score >= confidence)) continue` so NaN is rejected.

### Proof
See #299 — `NaN < 0.3` is `false` (survives), `!(NaN >= 0.3)` is `true` (rejected).

Base: `develop`. Follow-up to the #178 review.
