### PR TITLE
Run the container as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --chown=node:node --from=builder /app ./
 
-# node is the non-root user shipped in the base image; the gateway binds 80/443,
-# so the setcap above lets it hold those privileged ports without root.
-# Volume mount points must exist and be node-owned so the named volumes
-# (storage captures, acme-webroot) inherit non-root ownership and stay writable.
 RUN chmod +x entrypoint.sh \
     && mkdir -p /mnt/storage /app/.well-known \
-    && chown node:node /mnt/storage /app/.well-known
+    && chown node:node /app /mnt/storage /app/.well-known
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,22 @@ WORKDIR /app
 ENV TZ=UTC
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates motion ffmpeg postgresql-client \
+        ca-certificates motion ffmpeg postgresql-client libcap2-bin \
     && npm install -g pm2 \
+    && setcap cap_net_bind_service=+ep "$(readlink -f "$(command -v node)")" \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app ./
+COPY --chown=node:node --from=builder /app ./
 
-RUN chmod +x entrypoint.sh
+# node is the non-root user shipped in the base image; the gateway binds 80/443,
+# so the setcap above lets it hold those privileged ports without root.
+# Volume mount points must exist and be node-owned so the named volumes
+# (storage captures, acme-webroot) inherit non-root ownership and stay writable.
+RUN chmod +x entrypoint.sh \
+    && mkdir -p /mnt/storage /app/.well-known \
+    && chown node:node /mnt/storage /app/.well-known
+
+USER node
 
 EXPOSE 80 443
 


### PR DESCRIPTION
Closes #304.

The Dockerfile has no `USER` directive, so Node, PM2, `motion`, and `ffmpeg` all run as root (UID 0). `motion`/`ffmpeg` parse untrusted data (RTSP streams, traffic behind the internet-facing gateway), so a parser bug yields **root inside the container**. Running as non-root contains the blast radius.

### Change
- `Dockerfile` (runtime stage, `node:22-slim`): drop to the base image's built-in non-root `node` user.
  - `COPY --chown=node:node` the app tree; create and `chown` the volume mount points (`/mnt/storage`, `/app/.well-known`) so the named volumes inherit non-root ownership.
  - Grant the `node` binary `cap_net_bind_service` (via `libcap2-bin` + `setcap`) so the gateway can still bind the privileged ports 80/443 without root. All root-requiring steps stay before `USER node`.

### Notes for reviewers
- I could not run a Docker build in this environment — please verify the image builds and starts. The change was constructed so every root-requiring step precedes the `USER` switch.
- Existing deployments with already-populated volumes may need a one-time `chown` of the mounted data to `node`.

### Proof
See #304 — the Dockerfile has no `USER` directive anywhere.

Base: `develop`. Follow-up to the #178 review.
