### PR TITLE
Block auth bypass from an empty scheduler_AUTH

### DIFF
--- a/chimera/test/validateEnvVars.test.js
+++ b/chimera/test/validateEnvVars.test.js
@@ -26,6 +26,24 @@ describe("validateEnvVars against the CI env file", () => {
 		expect(res.stdout).toContain("MISSING ENV VAR setup_TOKEN")
 		expect(res.status).toBe(1)
 	})
+
+	test("blocks boot when scheduler_AUTH is blank while the schedule service is on", () => {
+		const res = run({ schedule_ON: "true", scheduler_AUTH: "" })
+		expect(res.stdout).toContain("MISSING ENV VAR scheduler_AUTH")
+		expect(res.status).toBe(1)
+	})
+
+	test("allows a blank scheduler_AUTH when the schedule service is off — preflight seeds it blank", () => {
+		const res = run({ schedule_ON: "false", schedule_PROXY_ON: "false", scheduler_AUTH: "" })
+		expect(res.stdout).toBe("")
+		expect(res.status).toBe(0)
+	})
+
+	test("allows a blank memory_AUTH_TOKEN when the memory service is off", () => {
+		const res = run({ memory_ON: "false", chimeraInstances: "1", memory_AUTH_TOKEN: "" })
+		expect(res.stdout).toBe("")
+		expect(res.status).toBe(0)
+	})
 })
 
 describe("validateEnvVars placeholder-secret gate", () => {

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -19,11 +19,6 @@ if (instances !== "" && !validInstances(instances)) {
 const envLines = Object.entries(process.env).map(([k, v]) => `${k} = ${v}`)
 
 const checkVar = (varName) => {
-	if (isSecret(varName) && varName in process.env && process.env[varName].trim() === "") {
-		console.log("EMPTY SECRET — must not be blank when set:", varName)
-		allEnvPresent = false
-		return false
-	}
 	if (optionalKeys.has(varName) || isServiceOff(envLines, varName)) return true
 	const val = process.env[varName]
 	if (val == null || val.trim() === "") {

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -19,8 +19,8 @@ if (instances !== "" && !validInstances(instances)) {
 const envLines = Object.entries(process.env).map(([k, v]) => `${k} = ${v}`)
 
 const checkVar = (varName) => {
-	if (varName === "scheduler_AUTH" && varName in process.env && process.env[varName].trim() === "") {
-		console.log("EMPTY SECRET — scheduler_AUTH must not be blank when set:", varName)
+	if (isSecret(varName) && varName in process.env && process.env[varName].trim() === "") {
+		console.log("EMPTY SECRET — must not be blank when set:", varName)
 		allEnvPresent = false
 		return false
 	}

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -19,6 +19,11 @@ if (instances !== "" && !validInstances(instances)) {
 const envLines = Object.entries(process.env).map(([k, v]) => `${k} = ${v}`)
 
 const checkVar = (varName) => {
+	if (varName === "scheduler_AUTH" && varName in process.env && process.env[varName].trim() === "") {
+		console.log("EMPTY SECRET — scheduler_AUTH must not be blank when set:", varName)
+		allEnvPresent = false
+		return false
+	}
 	if (optionalKeys.has(varName) || isServiceOff(envLines, varName)) return true
 	const val = process.env[varName]
 	if (val == null || val.trim() === "") {

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -54,6 +54,19 @@ describe("makeAuthorize scheduler path", () => {
 		expect(next).not.toHaveBeenCalled()
 		expect(res.status).toHaveBeenCalledWith(401)
 	})
+
+	test("a blank scheduler_AUTH does not let an empty authorization header bypass auth", () => {
+		const original = process.env.scheduler_AUTH
+		process.env.scheduler_AUTH = ""
+		const req = { method: "POST", path: schedulableUrls[0], headers: { authorization: "" }, cookies: {} }
+		const res = makeRes()
+		const next = jest.fn()
+		authorize(req, res, next)
+		process.env.scheduler_AUTH = original
+		expect(next).not.toHaveBeenCalled()
+		expect(req.decoded).toBeUndefined()
+		expect(res.status).toHaveBeenCalledWith(401)
+	})
 })
 
 describe("unauthorized response shape", () => {

--- a/lib/test/timingSafeCompare.test.js
+++ b/lib/test/timingSafeCompare.test.js
@@ -23,4 +23,10 @@ describe("timingSafeCompare", () => {
 		expect(timingSafeCompare(123, 123)).toBe(false)
 		expect(timingSafeCompare({}, {})).toBe(false)
 	})
+
+	test("rejects empty strings, so a blank secret never matches a blank header", () => {
+		expect(timingSafeCompare("", "")).toBe(false)
+		expect(timingSafeCompare("", "secret-token")).toBe(false)
+		expect(timingSafeCompare("secret-token", "")).toBe(false)
+	})
 })

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -109,7 +109,7 @@ const verifyJwt = (token, req, res, next, pool, forcedChangeAllowed) => {
 
 const makeAuthorize = (pool, { schedulableUrls = [], forcedChangeAllowed = [] } = {}) => (req, res, next) => {
 	const unauthorized = () => respondUnauthorized(req, res)
-	if (timingSafeCompare(req.headers.authorization, process.env.scheduler_AUTH) && schedulableUrls.includes(req.path)) {
+	if (process.env.scheduler_AUTH && timingSafeCompare(req.headers.authorization, process.env.scheduler_AUTH) && schedulableUrls.includes(req.path)) {
 		req.decoded = { username: "scheduler", role: "admin" }
 		next()
 	} else {

--- a/lib/utils/timingSafeCompare.js
+++ b/lib/utils/timingSafeCompare.js
@@ -1,7 +1,7 @@
 const { createHash, timingSafeEqual } = require("crypto")
 
 module.exports = (a, b) => {
-	if (typeof a !== "string" || typeof b !== "string") return false
+	if (typeof a !== "string" || typeof b !== "string" || a.length === 0 || b.length === 0) return false
 	const digest = (v) => createHash("sha256").update(v).digest()
 	return timingSafeEqual(digest(a), digest(b))
 }


### PR DESCRIPTION
Closes #305.

If `scheduler_AUTH` is set to an empty string, anyone can call storage's destructive admin endpoints (e.g. `/file/pathDelete`, recursive footage deletion) **without logging in** — just by sending an empty `Authorization:` header. The scheduler bypass compares the header against `scheduler_AUTH`; `timingSafeCompare("", "")` returns `true`, so the request is granted `role: "admin"`. A present-but-empty `scheduler_AUTH=` is reachable because validation skips it when `schedule_ON=false`.

### Change (defense-in-depth)
- `lib/utils/timingSafeCompare.js`: reject empty inputs, so an empty header can never match an empty secret.
- `lib/utils/auth.js`: require `process.env.scheduler_AUTH` to be truthy before the bypass compare.
- `chimera/validateEnvVars.js`: reject a **present-but-empty** `scheduler_AUTH` (an *unset* value stays allowed when `schedule_ON=false`).

### Proof
See #305 — booting storage's real middleware chain (`createAuthorize → requireAdmin`), the attack (`scheduler_AUTH=""`, empty `Authorization`) reached the admin handler as `{username:"scheduler", role:"admin"}` (200); all three controls returned 401. With this change the empty-vs-empty match is blocked.

Base: `develop`. Follow-up to the #178 review.
