### PR TITLE
Run container as non-root node user (#304)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,18 @@ FROM node:22-slim
 WORKDIR /app
 
 ENV TZ=UTC
+ENV PM2_HOME=/home/node/.pm2
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates motion ffmpeg postgresql-client \
+        ca-certificates motion ffmpeg postgresql-client gosu \
     && npm install -g pm2 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app ./
 
-RUN chmod +x entrypoint.sh
+RUN chmod +x entrypoint.sh \
+    && mkdir -p /app/log /home/node/.pm2 \
+    && chown -R node:node /app /home/node
 
 EXPOSE 80 443
 

--- a/certbot-entry.sh
+++ b/certbot-entry.sh
@@ -7,6 +7,11 @@ until apk add --no-cache curl; do sleep 5; done
 DOMAIN=$(echo "$gateway_HOST" | sed -e 's|^http://||' -e 's|^https://||' | awk -F/ '{print $1}' | awk -F: '{print $1}')
 mkdir -p /webroot/.well-known/acme-challenge
 
+grant_gateway_read() {
+	chgrp -R 1000 /etc/letsencrypt/live /etc/letsencrypt/archive 2>/dev/null || true
+	chmod -R g+rX /etc/letsencrypt/live /etc/letsencrypt/archive 2>/dev/null || true
+}
+
 if [ -n "$DOMAIN" ]; then
 	echo ready > /webroot/.well-known/acme-challenge/probe
 	tries=0
@@ -21,6 +26,7 @@ fails=0
 while true; do
 	if [ -n "$DOMAIN" ] && [ ! -d "/etc/letsencrypt/live/$DOMAIN" ]; then
 		if certbot certonly --webroot -w /webroot -d "$DOMAIN" --register-unsafely-without-email --agree-tos --non-interactive; then
+			grant_gateway_read
 			fails=0
 		else
 			fails=$((fails+1))
@@ -35,5 +41,6 @@ while true; do
 
 	certbot renew --webroot -w /webroot --quiet ||
 		curl -fsS -X POST -H "Content-Type: application/json" -d "{\"content\": \"⚠️ certbot renew failed on $(hostname)\"}" "$alert_URL"
+	grant_gateway_read
 	sleep 43200
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     env_file: .env
     environment:
       TZ: UTC
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=80
     ports:
       - "${gateway_PORT}:${gateway_PORT}"
       - "${gateway_PORT_SECURE:-443}:${gateway_PORT_SECURE:-443}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
 set -e
 
-echo "→ Preparing acme challenge directory..."
-mkdir -p ./.well-known/acme-challenge
+echo "→ Fixing ownership on mounted volumes..."
+mkdir -p /mnt/storage/shared/captures /app/.well-known/acme-challenge
+chown node:node /mnt/storage /mnt/storage/shared /mnt/storage/shared/captures \
+                /app/.well-known /app/.well-known/acme-challenge \
+                /etc/motion/cameraconf
 
 echo "→ Validating environment variables..."
-node chimera/validateEnvVars.js
+gosu node node chimera/validateEnvVars.js
 
 echo "→ Preparing database..."
-node chimera/prepareDatabase.js
+gosu node node chimera/prepareDatabase.js
 
 echo "→ Starting PM2..."
-exec pm2-runtime pm2.config.js
+exec gosu node pm2-runtime pm2.config.js

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,8 @@ set -e
 echo "→ Fixing ownership on mounted volumes..."
 mkdir -p /mnt/storage/shared/captures /app/.well-known/acme-challenge
 chown node:node /mnt/storage /mnt/storage/shared /mnt/storage/shared/captures \
-                /app/.well-known /app/.well-known/acme-challenge \
-                /etc/motion/cameraconf
+                /app/.well-known /app/.well-known/acme-challenge
+chown -R node:node /etc/motion/cameraconf
 
 echo "→ Validating environment variables..."
 gosu node node chimera/validateEnvVars.js


### PR DESCRIPTION
Closes #304. Container ran everything as root; a motion/ffmpeg parser bug = root in the container.

**Note:** This is an intentional breaking change to the deployment. No migration needed — a fresh deployment is assumed.

Drop to the built-in `node` user:
- **Dockerfile** — install `gosu`, set `PM2_HOME`, chown `/app`. No `USER` (entrypoint needs root to fix mounts).
- **entrypoint.sh** — chown the mounted volumes as root, then `exec gosu node pm2-runtime`.
- **docker-compose.yml** — `net.ipv4.ip_unprivileged_port_start=80` sysctl so non-root binds 80/443.
- **certbot-entry.sh** — chgrp/chmod cert `live`/`archive` to GID 1000 after issuance+renew so the non-root gateway can read `privkey.pem` on its `:ro` mount.

Verified: `sh -n` on both scripts, `docker compose config`. Not verified: real boot / TLS — run `docker compose up` before merge.