### PR TITLE
Keep session on failed logout

### DIFF
--- a/command/e2e/auth.spec.js
+++ b/command/e2e/auth.spec.js
@@ -100,4 +100,16 @@ test.describe("authentication", () => {
 		await page.getByRole("dialog").getByRole("button", { name: "Log Out" }).click()
 		await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible()
 	})
+
+	test("failed logout keeps the session and shows an error", async ({ page }) => {
+		await mockApi(page, { "POST /authorization/logout": json({ error: true }, 500) })
+		await page.goto("/")
+		await page.getByPlaceholder("username").fill("admin")
+		await page.getByPlaceholder("password").fill("password123")
+		await page.getByRole("button", { name: "Sign In" }).click()
+		await page.getByRole("button", { name: "Log Out" }).click()
+		await page.getByRole("dialog").getByRole("button", { name: "Log Out" }).click()
+		await expect(page.getByText("Failed to log out")).toBeVisible()
+		await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
+	})
 })

--- a/command/frontend/app/SignOutButton.jsx
+++ b/command/frontend/app/SignOutButton.jsx
@@ -3,10 +3,20 @@ import { LogOut } from "lucide-react"
 import { useSignOut } from "./AuthContext.jsx"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from "../components/ui/dialog"
 import { Button } from "../components/ui/button"
+import toast from "../js/toast.js"
 
 const SignOutButton = ({ className, iconOnly }) => {
 	const signOut = useSignOut()
 	const [open, setOpen] = useState(false)
+
+	const handleSignOut = () => {
+		signOut((success, errors) => {
+			if (!success) {
+				setOpen(false)
+				toast(errors || "Failed to log out")
+			}
+		})
+	}
 
 	return (
 		<>
@@ -24,7 +34,7 @@ const SignOutButton = ({ className, iconOnly }) => {
 						<DialogClose asChild>
 							<Button variant="ghost" className="text-muted hover:text-primary">Cancel</Button>
 						</DialogClose>
-						<Button onClick={signOut} className="bg-danger text-danger-foreground hover:bg-danger/80">Log Out</Button>
+						<Button onClick={handleSignOut} className="bg-danger text-danger-foreground hover:bg-danger/80">Log Out</Button>
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>

--- a/command/frontend/hooks/useAuth.js
+++ b/command/frontend/hooks/useAuth.js
@@ -115,9 +115,10 @@ const useAuth = () => {
 		})
 	}
 
-	const signOut = () => {
-		attemptLogout().finally(() => {
-			setState(s => ({ ...s, loggedIn: false, role: null, forcePasswordChange: false, theme: null }))
+	const signOut = (callback) => {
+		attemptLogout().then(res => {
+			if (!res.error) setState(s => ({ ...s, loggedIn: false, role: null, forcePasswordChange: false, theme: null }))
+			callback(!res.error, res.errors)
 		})
 	}
 


### PR DESCRIPTION
Closes #325

`signOut` cleared client auth state in a `.finally()`, so the UI showed logged-out even when `POST /authorization/logout` failed — leaving the httpOnly cookie and `sessions.revoked=false` live. Now client state clears only on a successful response (`!res.error`); on failure `signOut` reports back via a callback and `SignOutButton` surfaces a "Failed to log out" toast while keeping the session. Added an e2e test covering the failure path.