### PR TITLE
ClipMaker: unify single/multi-cam into one array model (#264)

### DIFF
--- a/command/e2e/clip.spec.js
+++ b/command/e2e/clip.spec.js
@@ -38,3 +38,48 @@ test.describe("clip maker multi-cam generate", () => {
 		await expect(page).toHaveURL(/\/recordings$/)
 	})
 })
+
+const PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==", "base64")
+const png = () => ({ status: 200, contentType: "image/png", body: PNG })
+const F0 = "/frames/20240101-120000.jpg"
+const F1 = "/frames/20240101-120010.jpg"
+
+// listFramesVideo returns time-stamped frame URLs; detections at 12:00:05 map onto F0 within tolerance
+const boxMocks = {
+	"POST /convert/listFramesVideo": json({ list: [F0, F1] }),
+	[`GET ${F0}`]: png(),
+	[`GET ${F1}`]: png(),
+	"GET /object/captures/cap.jpg": png(),
+	"GET /object/detections": json([
+		{ image: "cap.jpg", camera: 0, timestamp: "2024-01-01T12:00:05.000Z", box: [50, 50, 100, 100], type: "person", confidence: 0.9 }
+	])
+}
+
+test.describe("clip maker detection boxes", () => {
+	test("single-cam renders a detection overlay when boxes are toggled on", async ({ page }) => {
+		await mockApi(page, boxMocks)
+		await page.goto("/")
+		await login(page)
+		await page.getByRole("button", { name: "Clip Maker" }).click()
+		await page.getByRole("combobox").click()
+		await page.getByRole("option", { name: "indoor", exact: true }).click()
+		await page.getByRole("button", { name: /Load Images/ }).click()
+		await page.getByText("Boxes").click()
+		await expect(page.locator("svg rect").first()).toBeVisible()
+	})
+
+	test("multi-cam renders a box overlay in every camera cell", async ({ page }) => {
+		await mockApi(page, boxMocks)
+		await page.goto("/")
+		await login(page)
+		await page.getByRole("button", { name: "Clip Maker" }).click()
+		await page.getByRole("button", { name: "Switch to multi-camera" }).click()
+		await page.getByRole("button", { name: "indoor", exact: true }).click()
+		await page.getByRole("button", { name: "outdoor", exact: true }).click()
+		await page.getByRole("button", { name: /Load Images/ }).click()
+		await page.getByText("Boxes").click()
+		await expect(async () => {
+			expect(await page.locator("svg rect").count()).toBeGreaterThanOrEqual(2)
+		}).toPass()
+	})
+})

--- a/command/e2e/clip.spec.js
+++ b/command/e2e/clip.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require("@playwright/test")
+const { json, mockApi, login } = require("./api")
+
+const FRAMES = json({ list: ["/frames/x/20240101-000000.jpg", "/frames/x/20240101-000100.jpg"] })
+
+const openMultiCamReadyToGenerate = async (page, overrides = {}) => {
+	await mockApi(page, { "POST /convert/listFramesVideo": FRAMES, ...overrides })
+	await page.goto("/")
+	await login(page)
+	await expect(page.getByRole("button", { name: "Live" })).toBeVisible()
+	await page.getByRole("button", { name: "Clip Maker" }).click()
+	await expect(page).toHaveURL(/\/clip$/)
+	await page.getByRole("button", { name: "Switch to multi-camera" }).click()
+	await page.getByRole("button", { name: "indoor", exact: true }).click()
+	await page.getByRole("button", { name: "outdoor", exact: true }).click()
+	await page.getByRole("button", { name: /Load Images/ }).click()
+	const generate = page.getByRole("button", { name: "Generate" })
+	await expect(generate).toBeEnabled()
+	await generate.click()
+	return page.getByRole("button", { name: /Video/ })
+}
+
+test.describe("clip maker multi-cam generate", () => {
+	test("stays on the page and reports failure when every camera fails", async ({ page }) => {
+		const videoBtn = await openMultiCamReadyToGenerate(page, {
+			"POST /convert/createVideo": json({ error: true })
+		})
+		await videoBtn.click()
+		await expect(page.getByText("Generation failed")).toBeVisible()
+		await expect(page).toHaveURL(/\/clip$/)
+	})
+
+	test("navigates to recordings once the server confirms", async ({ page }) => {
+		const videoBtn = await openMultiCamReadyToGenerate(page, {
+			"POST /convert/createVideo": json({ url: "/recordings/clip.mp4" })
+		})
+		await videoBtn.click()
+		await expect(page).toHaveURL(/\/recordings$/)
+	})
+})

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useMemo, useRef, useEffect } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { useRole } from "./AuthContext"
-import { ImageOff, Square, Minus, Plus, ZoomIn, Check, X, Rewind, LayoutGrid, RectangleHorizontal, ArrowUpDown, Save, SkipBack, ScanEye } from "lucide-react"
+import { ImageOff, Square, Minus, Plus, ZoomIn, Check, X, Rewind, LayoutGrid, RectangleHorizontal, Save, SkipBack, ScanEye } from "lucide-react"
 import { useMediaQuery } from "react-responsive"
 import useCameras from "../hooks/useCameras"
-import { Card } from "../components/ui/card"
 import { Button } from "../components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "../components/ui/dialog"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "../components/ui/select"
@@ -15,6 +14,10 @@ import { Switch } from "../components/ui/switch"
 import { request, jsonProcessing } from "../js/request"
 import { detectGrayPad } from "../js/letterbox.js"
 import DetectionOverlay from "../components/DetectionOverlay.jsx"
+import ResizeHandle from "../components/ResizeHandle.jsx"
+import CameraGridMini from "../components/CameraGridMini.jsx"
+import usePreviewHeight from "../hooks/usePreviewHeight"
+import { padSlots } from "../js/grid.js"
 import toast from "../js/toast"
 import moment from "moment"
 
@@ -199,40 +202,19 @@ const ClipMakerMini = () => {
 		})
 	}, [cameras])
 
-	const camSlots = cameras.slice(0, 4)
-	const slots = [0, 1, 2, 3].map(i => camSlots[i] ?? null)
+	const slots = padSlots(cameras.slice(0, 4))
 
 	return (
-		<Card className="h-full overflow-hidden cursor-pointer select-none transition-shadow" onClick={() => navigate("/clip")}>
-			<div className="relative flex-1 grid grid-cols-2 grid-rows-2 gap-px bg-border min-h-0 h-full">
-				{slots.map((cam, i) => (
-					<div
-						key={i}
-						onClick={cam ? (e) => { e.stopPropagation(); navigate(`/clip?camera=${cam.id}`) } : undefined}
-						className={`relative overflow-hidden ${cam ? "bg-black" : "bg-muted/20"}`}
-					>
-						{cam && snapshots[cam.id] && (
-							<img src={snapshots[cam.id]} className="w-full h-full object-cover" alt={cam.name} />
-						)}
-						{cam && !snapshots[cam.id] && (
-							<div className="absolute inset-0 flex items-center justify-center">
-								<ImageOff className="size-5 opacity-30 text-muted" />
-							</div>
-						)}
-						{cam && (
-							<div className="absolute bottom-1.5 inset-x-0 flex justify-center pointer-events-none">
-								<span className="bg-accent/85 text-accent-foreground text-xs font-medium px-3 py-0.5 rounded-full">
-									{cam.name}
-								</span>
-							</div>
-						)}
-					</div>
-				))}
-				<div className="absolute inset-0 m-auto z-10 rounded-full shadow-lg size-14 flex items-center justify-center bg-accent text-accent-foreground" onClick={(e) => { e.stopPropagation(); navigate("/clip") }}>
-					<Rewind className="size-6" />
-				</div>
-			</div>
-		</Card>
+		<CameraGridMini
+			slots={slots}
+			onActivate={() => navigate("/clip")}
+			onCellClick={cam => navigate(`/clip?camera=${cam.id}`)}
+			cellLabel={cam => cam.name}
+			centerIcon={<Rewind className="size-6" />}
+			renderCell={cam => snapshots[cam.id]
+				? <img src={snapshots[cam.id]} className="w-full h-full object-cover" alt={cam.name} />
+				: <div className="absolute inset-0 flex items-center justify-center"><ImageOff className="size-5 opacity-30 text-muted" /></div>}
+		/>
 	)
 }
 
@@ -264,7 +246,6 @@ const ClipMakerFull = () => {
 	const [detections, setDetections] = useState([])
 	const [showBoxes, setShowBoxes] = useState(false)
 	const [contentPad, setContentPad] = useState({}) // { [camera]: {top,bot,left,right} } letterbox pad in 416-space
-	const [previewHeight, setPreviewHeight] = useState(240)
 	const [previewDims, setPreviewDims] = useState(null) // {w,h} natural size of the current single-cam frame
 
 	const canvasRef = useRef(null)
@@ -447,6 +428,7 @@ const ClipMakerFull = () => {
 	}, [multiCam, camStates])
 
 	const multiRows = selectedCams.length > 0 ? Math.ceil(selectedCams.length / 2) : 2
+	const [previewHeight, , startResizeDrag] = usePreviewHeight(240, { rows: multiCam ? multiRows : 1 })
 
 	useEffect(() => {
 		if (!multiCam) return
@@ -743,22 +725,6 @@ const ClipMakerFull = () => {
 		})
 	}
 
-	const startResizeDrag = (e) => {
-		e.preventDefault()
-		const el = e.currentTarget
-		el.setPointerCapture(e.pointerId)
-		const startY = e.clientY
-		const startH = previewHeight
-		const maxH = Math.min(window.innerWidth * 9/16, window.innerHeight * 2/3) / (multiCam ? multiRows : 1)
-		const move = (ev) => setPreviewHeight(clamp(startH + ev.clientY - startY, 80, maxH))
-		const up = () => {
-			el.removeEventListener("pointermove", move)
-			el.removeEventListener("pointerup", up)
-		}
-		el.addEventListener("pointermove", move)
-		el.addEventListener("pointerup", up)
-	}
-
 	const stopLoading = () => {
 		if (multiCam) {
 			setCamStates(s => Object.fromEntries(Object.entries(s).map(([id, state]) =>
@@ -822,15 +788,7 @@ const ClipMakerFull = () => {
 							)
 						})}
 					</div>
-					<div className="relative w-full h-4 flex items-center cursor-ns-resize touch-none select-none group" onPointerDown={startResizeDrag}>
-						<div className="absolute inset-x-0 h-0.5 bg-border group-hover:bg-muted/40 transition-colors" />
-						<div className="absolute left-3 z-10 bg-bg pl-0.5 pr-1">
-							<div className="w-8 h-0.5 rounded-full bg-muted/30 group-hover:bg-muted/50 transition-colors" />
-						</div>
-						<div className="absolute right-2 z-10 bg-bg">
-							<ArrowUpDown className="size-3 text-muted/60 group-hover:text-muted transition-colors" />
-						</div>
-					</div>
+					<ResizeHandle onPointerDown={startResizeDrag} />
 				</>
 			) : (
 				<>
@@ -858,15 +816,7 @@ const ClipMakerFull = () => {
 							<ImageOff className="h-10 w-10 opacity-40 text-muted [grid-area:1/1]" />
 						)}
 					</div>
-					<div className="relative w-full h-4 flex items-center cursor-ns-resize touch-none select-none group" onPointerDown={startResizeDrag}>
-						<div className="absolute inset-x-0 h-0.5 bg-border group-hover:bg-muted/40 transition-colors" />
-						<div className="absolute left-3 z-10 bg-bg pl-0.5 pr-1">
-							<div className="w-8 h-0.5 rounded-full bg-muted/30 group-hover:bg-muted/50 transition-colors" />
-						</div>
-						<div className="absolute right-2 z-10 bg-bg">
-							<ArrowUpDown className="size-3 text-muted/60 group-hover:text-muted transition-colors" />
-						</div>
-					</div>
+					<ResizeHandle onPointerDown={startResizeDrag} />
 				</>
 			)}
 

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -726,6 +726,8 @@ const ClipMakerFull = () => {
 		if (selectedCams.some(idx => cameras[idx]?.id == null)) return toast("No camera selected")
 		setSubmitting(true)
 		const endpoint = type === "video" ? "/convert/createVideo" : "/convert/createZip"
+		const total = selectedCams.length
+		let done = 0, failed = 0
 		selectedCams.forEach(idx => {
 			const camId = cameras[idx].id
 			setMultiGenerating(g => ({ ...g, [camId]: type }))
@@ -735,13 +737,21 @@ const ClipMakerFull = () => {
 				body: createBody(camId, type)
 			}, prom => jsonProcessing(prom, data => {
 				setMultiGenerating(g => ({ ...g, [camId]: null }))
+				done++
 				if (!data || data.error || !data.url) {
+					failed++
 					toast(`Failed: ${cameras.find(c => c.id === camId)?.name ?? camId}`)
+				}
+				if (done < total) return
+				if (failed === total) {
+					setSubmitting(false)
+					toast("Generation failed")
+				} else {
+					toast(`${type === "video" ? "Videos" : "Archives"} queued`)
+					navTimer.current = setTimeout(() => navigate("/recordings"), 1500)
 				}
 			}))
 		})
-		toast(`${type === "video" ? "Videos" : "Archives"} queued`)
-		navTimer.current = setTimeout(() => navigate("/recordings"), 1500)
 	}
 
 	const setDatePart = (setter, part, val) => {
@@ -971,7 +981,7 @@ const ClipMakerFull = () => {
 											</Button>
 										)
 									})}
-									<Button size="sm" variant="ghost" className="h-7 px-2" onClick={toggleMultiCam}>
+									<Button size="sm" variant="ghost" className="h-7 px-2" aria-label="Switch to single camera" onClick={toggleMultiCam}>
 										<RectangleHorizontal className="size-3" />
 									</Button>
 								</div>
@@ -987,7 +997,7 @@ const ClipMakerFull = () => {
 									</SelectContent>
 								</Select>
 								{isDesktop && (
-									<Button size="icon" variant="ghost" className="shrink-0 size-9" onClick={toggleMultiCam}>
+									<Button size="icon" variant="ghost" className="shrink-0 size-9" aria-label="Switch to multi-camera" onClick={toggleMultiCam}>
 										<LayoutGrid className="size-4" />
 									</Button>
 								)}

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -14,6 +14,7 @@ import { Progress } from "../components/ui/progress"
 import { Switch } from "../components/ui/switch"
 import { request, jsonProcessing } from "../js/request"
 import { detectGrayPad } from "../js/letterbox.js"
+import DetectionOverlay from "../components/DetectionOverlay.jsx"
 import toast from "../js/toast"
 import moment from "moment"
 
@@ -264,6 +265,7 @@ const ClipMakerFull = () => {
 	const [showBoxes, setShowBoxes] = useState(false)
 	const [contentPad, setContentPad] = useState({}) // { [camera]: {top,bot,left,right} } letterbox pad in 416-space
 	const [previewHeight, setPreviewHeight] = useState(240)
+	const [previewDims, setPreviewDims] = useState(null) // {w,h} natural size of the current single-cam frame
 
 	const canvasRef = useRef(null)
 	const imageCache = useRef({})
@@ -387,38 +389,9 @@ const ClipMakerFull = () => {
 			canvas.width = img.naturalWidth
 			canvas.height = img.naturalHeight
 		}
-		const ctx = canvas.getContext("2d")
-		ctx.drawImage(img, 0, 0)
-		if (showBoxes && boxesForScrub.length) {
-			const pad = contentPad[boxesForScrub[0].camera]
-			const uniform = Math.max(canvas.width, canvas.height) / DETECT_INPUT
-			const sx = pad ? canvas.width / (DETECT_INPUT - pad.left - pad.right) : uniform
-			const sy = pad ? canvas.height / (DETECT_INPUT - pad.top - pad.bot) : uniform
-			const ox = pad ? pad.left : 0
-			const oy = pad ? pad.top : 0
-			const font = Math.max(12, Math.round(canvas.width / 50))
-			ctx.lineWidth = Math.max(2, canvas.width / 320)
-			ctx.strokeStyle = "#34d399"
-			ctx.fillStyle = "#34d399"
-			ctx.font = `600 ${font}px sans-serif`
-			ctx.textBaseline = "bottom"
-			for (const d of boxesForScrub) {
-				const x = (d.box[0] - ox) * sx
-				const y = (d.box[1] - oy) * sy
-				const w = d.box[2] * sx
-				const h = d.box[3] * sy
-				ctx.strokeRect(x, y, w, h)
-				const label = `${d.type} ${Math.round(d.confidence * 100)}%`
-				const ly = Math.max(font + 2, y - 3)
-				ctx.save()
-				ctx.lineWidth = 3
-				ctx.strokeStyle = "#000"
-				ctx.strokeText(label, x + 3, ly)
-				ctx.fillText(label, x + 3, ly)
-				ctx.restore()
-			}
-		}
-	}, [scrubIdx, frames, imagesLoaded, showBoxes, boxesForScrub, contentPad])
+		setPreviewDims(d => d && d.w === img.naturalWidth && d.h === img.naturalHeight ? d : { w: img.naturalWidth, h: img.naturalHeight })
+		canvas.getContext("2d").drawImage(img, 0, 0)
+	}, [scrubIdx, frames, imagesLoaded])
 
 	const multiAllFrames = useMemo(() =>
 		multiCam ? Object.fromEntries(Object.entries(camStates).map(([id, s]) => [id, s.frames])) : {},
@@ -861,15 +834,28 @@ const ClipMakerFull = () => {
 				</>
 			) : (
 				<>
-					<div className="relative bg-black w-full flex items-center justify-center" style={{ height: previewHeight }}>
+					<div className="relative bg-black w-full grid place-items-center overflow-hidden" style={{ height: previewHeight, gridTemplate: "100% / 100%" }}>
 						<canvas
 							ref={canvasRef}
 							width={640}
 							height={360}
+							className="[grid-area:1/1]"
 							style={{ display: frames.length > 0 ? "block" : "none", maxWidth: "100%", maxHeight: "100%", width: "auto", height: "auto" }}
 						/>
+						{frames.length > 0 && previewDims && showBoxes && boxesForScrub.length > 0 && contentPad[boxesForScrub[0].camera] && (
+							<DetectionOverlay
+								boxes={boxesForScrub}
+								dims={{ w: DETECT_INPUT, h: DETECT_INPUT }}
+								pad={contentPad[boxesForScrub[0].camera]}
+								fit="none"
+								className="pointer-events-none [grid-area:1/1]"
+								style={{ maxWidth: "100%", maxHeight: "100%", width: "auto", height: "auto" }}
+								width={previewDims.w}
+								height={previewDims.h}
+							/>
+						)}
 						{frames.length === 0 && (
-							<ImageOff className="h-10 w-10 opacity-40 text-muted" />
+							<ImageOff className="h-10 w-10 opacity-40 text-muted [grid-area:1/1]" />
 						)}
 					</div>
 					<div className="relative w-full h-4 flex items-center cursor-ns-resize touch-none select-none group" onPointerDown={startResizeDrag}>

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -287,7 +287,7 @@ const ClipMakerFull = () => {
 		const c = cams[ci]
 		if (!showBoxes || !c || !c.detections.length || !c.frames.length) return []
 		const { timesMs, tol } = camViews[ci]
-		return boxesForScrub(c.detections, timesMs[nearestFrameIndex(timesMs, scrubMs)], tol)
+		return boxesForScrub(c.detections, timesMs, nearestFrameIndex(timesMs, scrubMs), tol)
 	}
 
 	const detectionMarkers = useMemo(() => {

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -17,7 +17,8 @@ import DetectionOverlay from "../components/DetectionOverlay.jsx"
 import ResizeHandle from "../components/ResizeHandle.jsx"
 import CameraGridMini from "../components/CameraGridMini.jsx"
 import usePreviewHeight from "../hooks/usePreviewHeight"
-import { padSlots } from "../js/grid.js"
+import { padSlots, gridShape } from "../js/grid.js"
+import { nearestFrameIndex, frameSpacingMs, boxesForScrub, fuseMarkers } from "../js/detections.js"
 import toast from "../js/toast"
 import moment from "moment"
 
@@ -232,34 +233,109 @@ const ClipMakerFull = () => {
 	const [number, setNumber] = useState(10)
 	const [fps, setFps] = useState(20)
 	const [skip, setSkip] = useState(1)
-	const [frames, setFrames] = useState([])
 	const [scrubIdx, setScrubIdx] = useState(0)
 	const [trimRange, setTrimRange] = useState([0, 100])
 	const [trimming, setTrimming] = useState(false)
-	const [imagesLoaded, setImagesLoaded] = useState(0)
-	const [fetching, setFetching] = useState(false)
-	const [generating, setGenerating] = useState(null)
 	const [submitting, setSubmitting] = useState(false)
 	const [pendingPreset, setPendingPreset] = useState(null)
 	const [savedDates, setSavedDates] = useState(null)
 	const [loadedParams, setLoadedParams] = useState(null) // {start,end,number,cams} of the last load; current inputs diverging = stale
-	const [detections, setDetections] = useState([])
 	const [showBoxes, setShowBoxes] = useState(false)
-	const [contentPad, setContentPad] = useState({}) // { [camera]: {top,bot,left,right} } letterbox pad in 416-space
-	const [previewDims, setPreviewDims] = useState(null) // {w,h} natural size of the current single-cam frame
+	const [multiCam, setMultiCam] = useState(false) // UI layout only: selector style + labels; data is always cams[]
+	const [selectedCams, setSelectedCams] = useState([]) // camera indices, up to 4
 
-	const canvasRef = useRef(null)
-	const imageCache = useRef({})
-	const loadSeq = useRef(0)
+	// one entry per active camera; single-cam = length 1
+	const [cams, setCams] = useState([]) // { id, idx, name, frames, imagesLoaded, fetching, generating, detections, contentPad, dims }
+
+	const canvasRefs = useRef({})  // { [camId]: canvas element }
+	const imageCaches = useRef({}) // { [camId]: { [url]: Image } }
+	const loadGenRef = useRef({})  // { [camId]: generation } — cancels stale image settles
+	const padLoading = useRef({})  // { [camId]: bool } — a contentPad measure is in flight
+	const loadSeq = useRef(0)      // cancels stale network responses
 	const navTimer = useRef(null)
 
-	const [multiCam, setMultiCam] = useState(false)
-	const [selectedCams, setSelectedCams] = useState([]) // camera indices, up to 4
-	const [camStates, setCamStates] = useState({}) // { [camId]: { frames, imagesLoaded, fetching } }
-	const [multiGenerating, setMultiGenerating] = useState({})
-	const multiCanvasRefs = useRef({})
-	const multiImageCache = useRef({})
-	const multiLoadGenRef = useRef({})
+	const activeIdxs = multiCam ? selectedCams : (camera != null ? [camera] : [])
+
+	const timeline = useMemo(() => {
+		const views = cams.map(c => {
+			const timesMs = c.frames.map(u => { const t = parseFrameTime(u); return t ? t.valueOf() : null })
+			return { timesMs, tol: frameSpacingMs(timesMs) }
+		})
+		const frameCount = Math.max(0, ...cams.map(c => c.frames.length))
+		let refIdx = 0
+		cams.forEach((c, i) => { if (c.frames.length > (cams[refIdx]?.frames.length ?? 0)) refIdx = i })
+		return { views, frameCount, refTimesMs: views[refIdx]?.timesMs ?? [] }
+	}, [cams])
+	const { views: camViews, frameCount, refTimesMs } = timeline
+
+	const scrubMs = frameCount > 0
+		? (refTimesMs[scrubIdx] ?? lerp(startDate, endDate, frameCount > 1 ? scrubIdx / (frameCount - 1) : 0).valueOf())
+		: null
+
+	const timeAtPct = (p) => {
+		if (frameCount > 0) {
+			const t = refTimesMs[Math.round(p / 100 * (frameCount - 1))]
+			if (t != null) return moment(t)
+		}
+		return lerp(startDate, endDate, p / 100)
+	}
+	const trimStart = timeAtPct(trimRange[0])
+	const trimEnd = timeAtPct(trimRange[1])
+	const scrubTime = scrubMs != null ? moment(scrubMs) : null
+
+	const boxesForCam = (ci) => {
+		const c = cams[ci]
+		if (!showBoxes || !c || !c.detections.length || !c.frames.length) return []
+		const { timesMs, tol } = camViews[ci]
+		return boxesForScrub(c.detections, timesMs[nearestFrameIndex(timesMs, scrubMs)], tol)
+	}
+
+	const detectionMarkers = useMemo(() => {
+		if (frameCount === 0) return []
+		const pcts = []
+		cams.forEach((c, ci) => {
+			const { tol } = camViews[ci]
+			c.detections.forEach(d => {
+				const v = moment(d.timestamp).valueOf()
+				if (!Number.isFinite(v)) return
+				const idx = nearestFrameIndex(refTimesMs, v)
+				const ft = refTimesMs[idx]
+				if (ft == null || Math.abs(ft - v) > tol) return
+				pcts.push((idx / Math.max(1, frameCount - 1)) * 100)
+			})
+		})
+		pcts.sort((a, b) => a - b)
+		return fuseMarkers(pcts, FUSE_PCT)
+	}, [cams, camViews, refTimesMs, frameCount])
+
+	const anyFetching = cams.some(c => c.fetching)
+	const anyDownloading = cams.some(c => c.frames.length > 0 && c.imagesLoaded < c.frames.length)
+	const anyGenerating = cams.some(c => c.generating)
+	const hasLoadedFrames = cams.some(c => c.frames.length > 0)
+	const loading = anyFetching || anyDownloading
+	const stoppable = anyDownloading
+
+	const currentCamIds = activeIdxs.map(i => cameras[i]?.id).filter(id => id != null).sort()
+	const paramsStale = !!loadedParams && hasLoadedFrames && (
+		!startDate.isSame(loadedParams.start) ||
+		!endDate.isSame(loadedParams.end) ||
+		number !== loadedParams.number ||
+		currentCamIds.join(",") !== loadedParams.cams.join(",")
+	)
+	const canGenerate = !submitting && !paramsStale && !loading && !anyGenerating &&
+		startDate.isBefore(endDate) && activeIdxs.length > 0
+
+	const totalFrames = cams.reduce((a, c) => a + c.frames.length, 0)
+	const loadedFrames = cams.reduce((a, c) => a + c.imagesLoaded, 0)
+	const progress = totalFrames ? Math.round(100 * loadedFrames / totalFrames) : 0
+
+	const previewCells = cams.length
+		? cams
+		: activeIdxs.map(i => cameras[i]).filter(Boolean).map(cam =>
+			({ id: cam.id, name: cam.name, frames: [], imagesLoaded: 0, fetching: false, detections: [], contentPad: null, dims: null }))
+	const cells = previewCells.length ? previewCells : [null]
+	const { cols, rows } = gridShape(cells.length)
+	const [previewHeight, , startResizeDrag] = usePreviewHeight(240, { rows })
 
 	useEffect(() => {
 		if (!isDesktop && multiCam) toggleMultiCam()
@@ -268,7 +344,7 @@ const ClipMakerFull = () => {
 	useEffect(() => () => { if (navTimer.current) clearTimeout(navTimer.current) }, [])
 
 	useEffect(() => {
-		if (!multiCam && camera != null && cameras.length > 0 && frames.length === 0 && !fetching) loadPreview()
+		if (!multiCam && camera != null && cameras.length > 0 && cams.length === 0 && !anyFetching) loadPreview(undefined, undefined, [camera])
 	}, [cameras])
 
 	useEffect(() => {
@@ -278,257 +354,77 @@ const ClipMakerFull = () => {
 		const idx = cameras.findIndex(c => String(c.id) === String(camParam))
 		if (idx < 0) return
 		setCamera(idx)
-		loadPreview(undefined, undefined, idx)
+		loadPreview(undefined, undefined, [idx])
 	}, [cameras])
 
-	const frameTimes = useMemo(() => frames.map(parseFrameTime), [frames])
-
+	const framesKey = useMemo(() => cams.map(c => `${c.id}:${c.frames.join(",")}`).join("|"), [cams])
 	useEffect(() => {
-		const canvas = canvasRef.current
-		if (frames.length === 0) {
-			imageCache.current = {}
-			if (canvas) canvas.getContext("2d").clearRect(0, 0, canvas.width, canvas.height)
-			return
-		}
 		const timers = []
-		const imgs = []
-		frames.forEach(url => {
-			if (imageCache.current[url]) return
-			const img = new Image()
-			let settled = false
-			let timer
-			const settle = () => {
-				if (settled) return
-				settled = true
-				clearTimeout(timer)
-				setImagesLoaded(n => n + 1)
-			}
-			img.onload = img.onerror = settle
-			timer = setTimeout(settle, 10000)
-			timers.push(timer)
-			imgs.push(img)
-			img.src = url
-			imageCache.current[url] = img
-		})
-		return () => {
-			timers.forEach(clearTimeout)
-			imgs.forEach(img => { img.onload = img.onerror = null })
-		}
-	}, [frames])
-
-	const detectionFrameIdx = useMemo(() => {
-		if (multiCam || detections.length === 0 || frames.length === 0) return []
-		const ftv = frameTimes.map(t => t ? t.valueOf() : null)
-		const valid = ftv.filter(v => v != null)
-		if (valid.length === 0) return detections.map(() => -1)
-		const uniqueValid = [...new Set(valid)]
-		const span = Math.max(...uniqueValid) - Math.min(...uniqueValid)
-		const tol = uniqueValid.length > 1 ? span / (uniqueValid.length - 1) : Infinity
-		return detections.map(d => {
-			const v = moment(d.timestamp).valueOf()
-			let idx = -1, diff = Infinity
-			ftv.forEach((tv, i) => {
-				if (tv == null) return
-				const dd = Math.abs(tv - v)
-				if (dd < diff) { diff = dd; idx = i }
-			})
-			return diff <= tol ? idx : -1
-		})
-	}, [multiCam, detections, frameTimes, frames.length])
-
-	const boxesForScrub = useMemo(() => {
-		if (multiCam || !showBoxes || detections.length === 0) return []
-		const here = detections.filter((_, i) => detectionFrameIdx[i] === scrubIdx)
-		if (here.length === 0) return []
-		const t = frameTimes[scrubIdx]?.valueOf()
-		let best = here[0], bd = Infinity
-		if (t != null) for (const d of here) {
-			const dd = Math.abs(moment(d.timestamp).valueOf() - t)
-			if (dd < bd) { bd = dd; best = d }
-		}
-		return here.filter(d => d.image === best.image)
-	}, [multiCam, showBoxes, detections, detectionFrameIdx, scrubIdx, frameTimes])
-
-	// detector letterboxes each camera's feed into a 416 square (top-left anchored); the feed
-	// aspect ratio sets the content region, which differs from the recorded frame's aspect. Measure
-	// it from a capture's gray padding (constant per camera) so boxes map per-axis, not uniformly.
-	useEffect(() => {
-		if (multiCam || detections.length === 0) return
-		const d = detections.find(d => d.image && d.camera != null)
-		if (!d || contentPad[d.camera]) return
-		const im = new Image()
-		im.onload = () => setContentPad(p => ({ ...p, [d.camera]: detectGrayPad(im) }))
-		im.src = `/object/captures/${d.image}`
-	}, [multiCam, detections, contentPad])
-
-	useEffect(() => {
-		const canvas = canvasRef.current
-		if (!canvas || frames.length === 0) return
-		const img = imageCache.current[frames[scrubIdx]]
-		if (!img?.complete || !img.naturalWidth) return
-		if (canvas.width !== img.naturalWidth || canvas.height !== img.naturalHeight) {
-			canvas.width = img.naturalWidth
-			canvas.height = img.naturalHeight
-		}
-		setPreviewDims(d => d && d.w === img.naturalWidth && d.h === img.naturalHeight ? d : { w: img.naturalWidth, h: img.naturalHeight })
-		canvas.getContext("2d").drawImage(img, 0, 0)
-	}, [scrubIdx, frames, imagesLoaded])
-
-	const multiAllFrames = useMemo(() =>
-		multiCam ? Object.fromEntries(Object.entries(camStates).map(([id, s]) => [id, s.frames])) : {},
-	[multiCam, camStates]
-	)
-
-	const multiFramesKey = useMemo(() =>
-		Object.entries(multiAllFrames).map(([id, f]) => `${id}:${f.join(",")}`).join("|"),
-	[multiAllFrames]
-	)
-
-	useEffect(() => {
-		if (!multiCam) return
-		const timers = []
-		Object.entries(multiAllFrames).forEach(([camId, camFrames]) => {
-			if (!multiImageCache.current[camId]) multiImageCache.current[camId] = {}
-			const newUrls = camFrames.filter(url => !multiImageCache.current[camId][url])
+		cams.forEach(c => {
+			const cache = imageCaches.current[c.id] || (imageCaches.current[c.id] = {})
+			const newUrls = c.frames.filter(u => !cache[u])
 			if (!newUrls.length) return
-			const gen = (multiLoadGenRef.current[camId] = (multiLoadGenRef.current[camId] || 0) + 1)
+			const gen = (loadGenRef.current[c.id] = (loadGenRef.current[c.id] || 0) + 1)
 			newUrls.forEach(url => {
 				const img = new Image()
-				let settled = false
-				let timer
+				let settled = false, timer
 				const settle = () => {
-					if (settled) return
-					if (multiLoadGenRef.current[camId] !== gen) return
+					if (settled || loadGenRef.current[c.id] !== gen) return
 					settled = true
 					clearTimeout(timer)
-					setCamStates(s => s[camId] ? ({
-						...s,
-						[camId]: { ...s[camId], imagesLoaded: (s[camId].imagesLoaded ?? 0) + 1 }
-					}) : s)
+					setCams(prev => prev.map(pc => pc.id === c.id ? { ...pc, imagesLoaded: pc.imagesLoaded + 1 } : pc))
 				}
 				img.onload = img.onerror = settle
 				timer = setTimeout(settle, 10000)
 				timers.push(timer)
 				img.src = url
-				multiImageCache.current[camId][url] = img
+				cache[url] = img
 			})
 		})
-		return () => { timers.forEach(clearTimeout) }
-	}, [multiCam, multiFramesKey])
+		return () => timers.forEach(clearTimeout)
+	}, [framesKey])
 
-	const multiFrameTimes = useMemo(() =>
-		multiCam ? Object.fromEntries(Object.entries(camStates).map(([id, s]) => [id, s.frames.map(parseFrameTime)])) : {},
-	[multiCam, camStates]
-	)
-
-	const multiFrameCount = useMemo(() => {
-		if (!multiCam) return 0
-		const counts = Object.values(camStates).map(s => s.frames.length).filter(n => n > 0)
-		return counts.length > 0 ? Math.max(...counts) : 0
-	}, [multiCam, camStates])
-
-	const multiRows = selectedCams.length > 0 ? Math.ceil(selectedCams.length / 2) : 2
-	const [previewHeight, , startResizeDrag] = usePreviewHeight(240, { rows: multiCam ? multiRows : 1 })
-
+	// measure each camera's letterbox pad once from a detection capture (constant per camera), so
+	// boxes map per-axis; the feed's aspect sets the content region and differs from the frame's.
 	useEffect(() => {
-		if (!multiCam) return
-		const pct = multiFrameCount > 1 ? scrubIdx / (multiFrameCount - 1) : 0
-		const currentTime = lerp(startDate, endDate, pct)
-		Object.entries(camStates).forEach(([camId, state]) => {
-			const canvas = multiCanvasRefs.current[camId]
-			if (!canvas || !state.frames.length) return
-			const times = multiFrameTimes[camId]
-			let bestIdx = 0
-			if (times?.length) {
-				let bestDiff = Infinity
-				times.forEach((t, i) => {
-					if (!t) return
-					const diff = Math.abs(t.valueOf() - currentTime.valueOf())
-					if (diff < bestDiff) { bestDiff = diff; bestIdx = i }
-				})
-			}
-			const img = multiImageCache.current[camId]?.[state.frames[bestIdx]]
+		cams.forEach(c => {
+			if (c.contentPad || padLoading.current[c.id] || !c.detections.length) return
+			const d = c.detections.find(d => d.image && d.camera != null)
+			if (!d) return
+			padLoading.current[c.id] = true
+			const im = new Image()
+			im.onload = () => { padLoading.current[c.id] = false; setCams(prev => prev.map(pc => pc.id === c.id ? { ...pc, contentPad: detectGrayPad(im) } : pc)) }
+			im.onerror = () => { padLoading.current[c.id] = false }
+			im.src = `/object/captures/${d.image}`
+		})
+	}, [cams])
+
+	// draw each camera's frame nearest the scrub time onto its canvas
+	useEffect(() => {
+		if (frameCount === 0) return
+		cams.forEach((c, ci) => {
+			const canvas = canvasRefs.current[c.id]
+			if (!canvas || !c.frames.length) return
+			const img = imageCaches.current[c.id]?.[c.frames[nearestFrameIndex(camViews[ci].timesMs, scrubMs)]]
 			if (!img?.complete || !img.naturalWidth) return
 			if (canvas.width !== img.naturalWidth || canvas.height !== img.naturalHeight) {
 				canvas.width = img.naturalWidth
 				canvas.height = img.naturalHeight
 			}
+			if (c.dims?.w !== img.naturalWidth || c.dims?.h !== img.naturalHeight) {
+				setCams(prev => prev.map(pc => pc.id === c.id ? { ...pc, dims: { w: img.naturalWidth, h: img.naturalHeight } } : pc))
+			}
 			canvas.getContext("2d").drawImage(img, 0, 0)
 		})
-	}, [multiCam, scrubIdx, camStates, multiFrameCount, multiFrameTimes, startDate, endDate])
-
-	const frameTime = (idx) => {
-		if (frames.length === 0) return null
-		return frameTimes[idx] ?? lerp(startDate, endDate, idx / Math.max(1, frames.length - 1))
-	}
-
-	const trimStart = useMemo(() => {
-		const idx = Math.round(trimRange[0] / 100 * Math.max(0, frames.length - 1))
-		return frameTime(idx) ?? lerp(startDate, endDate, trimRange[0] / 100)
-	}, [startDate, endDate, trimRange, frames.length, frameTimes])
-
-	const trimEnd = useMemo(() => {
-		const idx = Math.round(trimRange[1] / 100 * Math.max(0, frames.length - 1))
-		return frameTime(idx) ?? lerp(startDate, endDate, trimRange[1] / 100)
-	}, [startDate, endDate, trimRange, frames.length, frameTimes])
-
-	const scrubTime = useMemo(() => frameTime(scrubIdx),
-		[frameTimes, scrubIdx, startDate, endDate, frames.length]
-	)
-
-	const detectionMarkers = useMemo(() => {
-		if (multiCam || frames.length === 0 || detectionFrameIdx.length === 0) return []
-		const pcts = detectionFrameIdx
-			.filter(idx => idx >= 0)
-			.map(idx => (idx / Math.max(1, frames.length - 1)) * 100)
-			.sort((a, b) => a - b)
-		const out = []
-		for (const p of pcts) {
-			const last = out[out.length - 1]
-			if (last && p - last.end <= FUSE_PCT) last.end = p
-			else out.push({ start: p, end: p })
-		}
-		return out
-	}, [multiCam, frames.length, detectionFrameIdx])
-
-	const multiAnyFetching = multiCam && Object.values(camStates).some(s => s.fetching)
-	const multiAnyDownloading = multiCam && Object.values(camStates).some(s => s.frames.length > 0 && s.imagesLoaded < s.frames.length)
-	const multiAnyGenerating = Object.values(multiGenerating).some(Boolean)
-
-	const downloadingImages = frames.length > 0 && imagesLoaded < frames.length
-	const loading   = multiCam ? (multiAnyFetching || multiAnyDownloading) : (fetching || downloadingImages)
-	const stoppable = multiCam ? multiAnyDownloading : downloadingImages
-
-	const hasLoadedFrames = multiCam ? Object.values(camStates).some(s => s.frames.length > 0) : frames.length > 0
-	const currentCamIds = multiCam
-		? selectedCams.map(i => cameras[i]?.id).filter(id => id != null).sort()
-		: (camera != null && cameras[camera] ? [cameras[camera].id] : [])
-	const paramsStale = !!loadedParams && hasLoadedFrames && (
-		!startDate.isSame(loadedParams.start) ||
-		!endDate.isSame(loadedParams.end) ||
-		number !== loadedParams.number ||
-		currentCamIds.join(",") !== loadedParams.cams.join(",")
-	)
-
-	const canGenerate = !submitting && !paramsStale && (multiCam
-		? (!multiAnyFetching && !multiAnyDownloading && !multiAnyGenerating && startDate.isBefore(endDate) && selectedCams.length > 0)
-		: (generating === null && !loading && startDate.isBefore(endDate) && camera != null))
-
-	const multiScrubTime = useMemo(() => {
-		if (!multiCam || multiFrameCount === 0) return null
-		return lerp(startDate, endDate, multiFrameCount > 1 ? scrubIdx / (multiFrameCount - 1) : 0)
-	}, [multiCam, scrubIdx, multiFrameCount, startDate, endDate])
-
-	const activeFrameCount = multiCam ? multiFrameCount : frames.length
+	}, [scrubIdx, cams, frameCount, camViews, scrubMs])
 
 	const toggleMultiCam = () => {
 		setMultiCam(m => !m)
 		setSelectedCams([])
-		setCamStates({})
-		multiImageCache.current = {}
-		setFrames([])
-		setImagesLoaded(0)
-		setDetections([])
+		setCams([])
+		imageCaches.current = {}
+		loadGenRef.current = {}
+		padLoading.current = {}
 		setLoadedParams(null)
 		setTrimRange([0, 100])
 		setTrimming(false)
@@ -545,7 +441,7 @@ const ClipMakerFull = () => {
 		request(`/object/detections?${qs}`, { cache: "no-store" }, prom =>
 			jsonProcessing(prom, data => {
 				if (seq !== loadSeq.current) return
-				setDetections(Array.isArray(data) ? data : [])
+				setCams(prev => prev.map(c => c.id === camId ? { ...c, detections: Array.isArray(data) ? data : [] } : c))
 			}))
 	}
 
@@ -564,53 +460,35 @@ const ClipMakerFull = () => {
 		...(type === "video" ? { fps, skip } : { skip })
 	})
 
-	const loadPreview = (overrideStart, overrideEnd, camIdx = camera) => {
+	const loadPreview = (overrideStart, overrideEnd, idxs = activeIdxs) => {
 		if (loading) return
-		if (cameras[camIdx]?.id == null) return toast("No camera selected")
+		const ids = idxs.map(i => cameras[i]?.id)
+		if (!ids.length || ids.some(id => id == null)) return toast("No camera selected")
 		const start = moment(overrideStart ?? startDate)
 		const end   = moment(overrideEnd   ?? endDate)
-		setLoadedParams({ start, end, number, cams: [cameras[camIdx].id] })
-		setFetching(true)
-		setFrames([])
-		setImagesLoaded(0)
-		setTrimRange([0, 100])
-		setTrimming(false)
-		const camId = cameras[camIdx].id
-		const seq = ++loadSeq.current
-		loadDetections(camId, start, end, seq)
-		request("/convert/listFramesVideo", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: framesBody(camId, start, end)
-		}, prom => jsonProcessing(prom, data => {
-			if (seq !== loadSeq.current) return setFetching(false)
-			setFrames(data?.list ?? [])
-			setScrubIdx(0)
-			setFetching(false)
-		}))
-	}
-
-	const loadMultiPreview = (overrideStart, overrideEnd) => {
-		if (loading || !selectedCams.length) return
-		if (selectedCams.some(idx => cameras[idx]?.id == null)) return toast("No camera selected")
-		const start = moment(overrideStart ?? startDate)
-		const end   = moment(overrideEnd   ?? endDate)
-		setLoadedParams({ start, end, number, cams: selectedCams.map(idx => cameras[idx].id).sort() })
-		multiImageCache.current = {}
+		setLoadedParams({ start, end, number, cams: [...ids].sort() })
+		imageCaches.current = {}
+		loadGenRef.current = {}
+		padLoading.current = {}
 		setScrubIdx(0)
 		setTrimRange([0, 100])
 		setTrimming(false)
-		const camIds = selectedCams.map(idx => cameras[idx].id)
-		setCamStates(Object.fromEntries(camIds.map(id => [id, { frames: [], imagesLoaded: 0, fetching: true }])))
+		setCams(idxs.map(i => ({
+			id: cameras[i].id, idx: i, name: cameras[i].name,
+			frames: [], imagesLoaded: 0, fetching: true, generating: null,
+			detections: [], contentPad: null, dims: null
+		})))
 		const seq = ++loadSeq.current
-		camIds.forEach(camId => {
+		idxs.forEach(i => {
+			const camId = cameras[i].id
+			loadDetections(camId, start, end, seq)
 			request("/convert/listFramesVideo", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: framesBody(camId, start, end)
 			}, prom => jsonProcessing(prom, data => {
 				if (seq !== loadSeq.current) return
-				setCamStates(s => ({ ...s, [camId]: { frames: data?.list ?? [], imagesLoaded: 0, fetching: false } }))
+				setCams(prev => prev.map(c => c.id === camId ? { ...c, frames: data?.list ?? [], fetching: false } : c))
 			}))
 		})
 	}
@@ -625,8 +503,7 @@ const ClipMakerFull = () => {
 	const confirmPreset = () => {
 		setSavedDates(null)
 		setPendingPreset(null)
-		if (multiCam) loadMultiPreview()
-		else loadPreview()
+		loadPreview()
 	}
 
 	const cancelPreset = () => {
@@ -641,8 +518,7 @@ const ClipMakerFull = () => {
 	const zoomIn = () => {
 		setStartDate(trimStart)
 		setEndDate(trimEnd)
-		if (multiCam) loadMultiPreview(trimStart, trimEnd)
-		else loadPreview(trimStart, trimEnd)
+		loadPreview(trimStart, trimEnd)
 	}
 
 	const cancelTrim = () => {
@@ -652,57 +528,33 @@ const ClipMakerFull = () => {
 
 	const generate = (type) => {
 		if (!canGenerate) return
-		if (multiCam) { generateMulti(type); return }
-		if (cameras[camera]?.id == null) return toast("No camera selected")
+		const ids = activeIdxs.map(i => cameras[i]?.id)
+		if (!ids.length || ids.some(id => id == null)) return toast("No camera selected")
 		setSubmitting(true)
-		setGenerating(type)
-		const camId = cameras[camera].id
+		setCams(prev => prev.map(c => ids.includes(c.id) ? { ...c, generating: type } : c))
 		const endpoint = type === "video" ? "/convert/createVideo" : "/convert/createZip"
-		request(endpoint, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: createBody(camId, type)
-		}, prom => jsonProcessing(prom, data => {
-			setGenerating(null)
-			if (!data || data.error) {
-				setSubmitting(false)
-				toast("Generation failed")
-			} else if (!data.url) {
-				setSubmitting(false)
-				toast("No frames found")
-			} else {
-				toast(`${type === "video" ? "Video" : "Archive"} queued`)
-				navTimer.current = setTimeout(() => navigate("/recordings"), 1500)
-			}
-		}))
-	}
-
-	const generateMulti = (type) => {
-		if (selectedCams.some(idx => cameras[idx]?.id == null)) return toast("No camera selected")
-		setSubmitting(true)
-		const endpoint = type === "video" ? "/convert/createVideo" : "/convert/createZip"
-		const total = selectedCams.length
-		let done = 0, failed = 0
-		selectedCams.forEach(idx => {
-			const camId = cameras[idx].id
-			setMultiGenerating(g => ({ ...g, [camId]: type }))
+		const total = ids.length
+		let done = 0, failed = 0, lastFail = null
+		ids.forEach(camId => {
 			request(endpoint, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: createBody(camId, type)
 			}, prom => jsonProcessing(prom, data => {
-				setMultiGenerating(g => ({ ...g, [camId]: null }))
+				setCams(prev => prev.map(c => c.id === camId ? { ...c, generating: null } : c))
 				done++
 				if (!data || data.error || !data.url) {
 					failed++
-					toast(`Failed: ${cameras.find(c => c.id === camId)?.name ?? camId}`)
+					lastFail = data
+					if (total > 1) toast(`Failed: ${cameras.find(c => c.id === camId)?.name ?? camId}`)
 				}
 				if (done < total) return
 				if (failed === total) {
 					setSubmitting(false)
-					toast("Generation failed")
+					toast(total === 1 && lastFail && !lastFail.error && !lastFail.url ? "No frames found" : "Generation failed")
 				} else {
-					toast(`${type === "video" ? "Videos" : "Archives"} queued`)
+					const noun = type === "video" ? "Video" : "Archive"
+					toast(`${total > 1 ? noun + "s" : noun} queued`)
 					navTimer.current = setTimeout(() => navigate("/recordings"), 1500)
 				}
 			}))
@@ -726,114 +578,84 @@ const ClipMakerFull = () => {
 	}
 
 	const stopLoading = () => {
-		if (multiCam) {
-			setCamStates(s => Object.fromEntries(Object.entries(s).map(([id, state]) =>
-				[id, { ...state, frames: [], imagesLoaded: 0 }]
-			)))
-			multiImageCache.current = {}
-		} else {
-			setFrames([])
-			setImagesLoaded(0)
-			setDetections([])
-		}
-	}
-
-	const multiProgress = () => {
-		const vals = Object.values(camStates)
-		const total = vals.reduce((a, s) => a + s.frames.length, 0)
-		const loaded = vals.reduce((a, s) => a + s.imagesLoaded, 0)
-		return total ? Math.round(100 * loaded / total) : 0
+		setCams(prev => prev.map(c => ({ ...c, frames: [], imagesLoaded: 0, dims: null })))
+		imageCaches.current = {}
+		loadGenRef.current = {}
 	}
 
 	return (
 		<div className="flex flex-col gap-0">
 			<h1 className="px-2 pt-2 pb-1.5 text-lg font-semibold">clip maker</h1>
 
-			{multiCam ? (
-				<>
-					<div className="relative w-full grid grid-cols-2 gap-px bg-border" style={{ height: previewHeight * multiRows }}>
-						{[0, 1, 2, 3].map(i => {
-							const camIdx = selectedCams[i]
-							const cam = camIdx !== undefined ? cameras[camIdx] : null
-							const camId = cam?.id
-							const state = camId ? camStates[camId] : null
-							return (
-								<div key={i} className={`relative overflow-hidden flex items-center justify-center ${cam ? "bg-black" : "bg-muted/10"}`}>
-									{camId && (
-										<canvas
-											ref={el => { if (el) multiCanvasRefs.current[camId] = el; else delete multiCanvasRefs.current[camId] }}
-											width={1920} height={1080}
-											style={{
-												display: state?.frames?.length > 0 ? "block" : "none",
-												maxWidth: "100%", maxHeight: "100%", width: "auto", height: "auto"
-											}}
+			<div
+				className="relative w-full grid gap-px bg-border overflow-hidden"
+				style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`, height: previewHeight * rows }}
+			>
+				{cells.map((c, i) => {
+					const boxes = c ? boxesForCam(i) : []
+					return (
+						<div
+							key={c ? c.id : "empty"}
+							className="relative overflow-hidden grid place-items-center bg-black"
+							style={{ gridTemplate: "100% / 100%" }}
+						>
+							{c ? (
+								<>
+									<canvas
+										ref={el => { if (el) canvasRefs.current[c.id] = el; else delete canvasRefs.current[c.id] }}
+										width={640}
+										height={360}
+										className="[grid-area:1/1]"
+										style={{ display: c.frames.length > 0 ? "block" : "none", maxWidth: "100%", maxHeight: "100%", width: "auto", height: "auto" }}
+									/>
+									{showBoxes && c.contentPad && c.dims && boxes.length > 0 && (
+										<DetectionOverlay
+											boxes={boxes}
+											dims={{ w: DETECT_INPUT, h: DETECT_INPUT }}
+											pad={c.contentPad}
+											fit="none"
+											className="pointer-events-none [grid-area:1/1]"
+											style={{ maxWidth: "100%", maxHeight: "100%", width: "auto", height: "auto" }}
+											width={c.dims.w}
+											height={c.dims.h}
 										/>
 									)}
-									{!state?.frames?.length && (
-										<ImageOff className="size-4 opacity-20 text-muted" />
+									{c.frames.length === 0 && !c.fetching && (
+										<ImageOff className="h-10 w-10 opacity-40 text-muted [grid-area:1/1]" />
 									)}
-									{state?.fetching && (
+									{c.fetching && (
 										<div className="absolute inset-0 flex items-center justify-center bg-black/40">
 											<span className="text-xs text-muted">Loading…</span>
 										</div>
 									)}
-									{cam && (
+									{cells.length > 1 && (
 										<div className="absolute bottom-1 inset-x-0 flex justify-center pointer-events-none">
 											<span className="bg-accent/80 text-accent-foreground text-xs px-2 py-0.5 rounded-full">
-												{cam.name}
+												{c.name}
 											</span>
 										</div>
 									)}
-								</div>
-							)
-						})}
-					</div>
-					<ResizeHandle onPointerDown={startResizeDrag} />
-				</>
-			) : (
-				<>
-					<div className="relative bg-black w-full grid place-items-center overflow-hidden" style={{ height: previewHeight, gridTemplate: "100% / 100%" }}>
-						<canvas
-							ref={canvasRef}
-							width={640}
-							height={360}
-							className="[grid-area:1/1]"
-							style={{ display: frames.length > 0 ? "block" : "none", maxWidth: "100%", maxHeight: "100%", width: "auto", height: "auto" }}
-						/>
-						{frames.length > 0 && previewDims && showBoxes && boxesForScrub.length > 0 && contentPad[boxesForScrub[0].camera] && (
-							<DetectionOverlay
-								boxes={boxesForScrub}
-								dims={{ w: DETECT_INPUT, h: DETECT_INPUT }}
-								pad={contentPad[boxesForScrub[0].camera]}
-								fit="none"
-								className="pointer-events-none [grid-area:1/1]"
-								style={{ maxWidth: "100%", maxHeight: "100%", width: "auto", height: "auto" }}
-								width={previewDims.w}
-								height={previewDims.h}
-							/>
-						)}
-						{frames.length === 0 && (
-							<ImageOff className="h-10 w-10 opacity-40 text-muted [grid-area:1/1]" />
-						)}
-					</div>
-					<ResizeHandle onPointerDown={startResizeDrag} />
-				</>
-			)}
+								</>
+							) : (
+								<ImageOff className="h-10 w-10 opacity-40 text-muted [grid-area:1/1]" />
+							)}
+						</div>
+					)
+				})}
+			</div>
+			<ResizeHandle onPointerDown={startResizeDrag} />
 
 			<div className="flex flex-col px-8 py-1 gap-1">
 				{stoppable ? (
 					<div className="flex items-center gap-2">
-						<Progress
-							value={multiCam ? multiProgress() : Math.round(100 * imagesLoaded / frames.length)}
-							className="h-2 flex-1"
-						/>
+						<Progress value={progress} className="h-2 flex-1" />
 						<Button variant="outline" size="icon" className="size-8 shrink-0" onClick={stopLoading}>
 							<Square className="h-4 w-4" />
 						</Button>
 					</div>
-				) : activeFrameCount > 0 ? (
+				) : frameCount > 0 ? (
 					<CompoundSlider
-						frameCount={activeFrameCount}
+						frameCount={frameCount}
 						scrubIdx={scrubIdx}
 						onScrubChange={setScrubIdx}
 						trimRange={trimRange}
@@ -849,11 +671,11 @@ const ClipMakerFull = () => {
 						<div className="text-xs text-muted">
 							{trimming ? (
 								<span>{trimStart.format("MM/DD HH:mm:ss")} → {trimEnd.format("MM/DD HH:mm:ss")}</span>
-							) : (scrubTime ?? multiScrubTime) ? (
-								<span>{(scrubTime ?? multiScrubTime).format("MM/DD HH:mm:ss")}</span>
+							) : scrubTime ? (
+								<span>{scrubTime.format("MM/DD HH:mm:ss")}</span>
 							) : null}
 						</div>
-						{activeFrameCount > 0 && (
+						{frameCount > 0 && (
 							trimming ? (
 								<div className="flex gap-1">
 									<Button variant="outline" size="sm" className="h-6 px-2 text-xs" onClick={cancelTrim}>
@@ -866,7 +688,7 @@ const ClipMakerFull = () => {
 								</div>
 							) : (
 								<div className="flex items-center gap-2">
-									{!multiCam && detections.length > 0 && (
+									{cams.some(c => c.detections.length > 0) && (
 										<div
 											onClick={() => setShowBoxes(v => !v)}
 											className="flex items-center gap-1 cursor-pointer select-none text-xs text-muted"
@@ -1058,14 +880,14 @@ const ClipMakerFull = () => {
 											disabled={!canGenerate}
 											onClick={() => generate("video")}
 										>
-											{generating === "video" ? "Generating…" : multiCam ? `Video ×${selectedCams.length}` : "Video"}
+											{anyGenerating ? "Generating…" : activeIdxs.length > 1 ? `Video ×${activeIdxs.length}` : "Video"}
 										</Button>
 										<Button
 											variant="outline"
 											disabled={!canGenerate}
 											onClick={() => generate("zip")}
 										>
-											{generating === "zip" ? "Generating…" : multiCam ? `Archive ×${selectedCams.length}` : "Archive"}
+											{anyGenerating ? "Generating…" : activeIdxs.length > 1 ? `Archive ×${activeIdxs.length}` : "Archive"}
 										</Button>
 									</div>
 								</div>
@@ -1075,11 +897,11 @@ const ClipMakerFull = () => {
 					<Button
 						variant="outline"
 						className={`flex-1 ${paramsStale ? "ring-1 ring-accent text-accent" : ""}`}
-						onClick={multiCam ? () => loadMultiPreview() : confirmPreset}
-						disabled={loading || (multiCam ? !selectedCams.length : camera == null)}
+						onClick={confirmPreset}
+						disabled={loading || activeIdxs.length === 0}
 					>
 						<SkipBack className="size-4" />
-						{(fetching || multiAnyFetching) ? "Fetching…" : (downloadingImages || multiAnyDownloading) ? "Loading…" : (frames.length > 0 || Object.values(camStates).some(s => s.frames.length > 0)) ? "Reload Images" : "Load Images"}
+						{anyFetching ? "Fetching…" : anyDownloading ? "Loading…" : hasLoadedFrames ? "Reload Images" : "Load Images"}
 					</Button>
 				</div>
 				{paramsStale && (

--- a/command/frontend/app/ObjectDetections.jsx
+++ b/command/frontend/app/ObjectDetections.jsx
@@ -1,16 +1,19 @@
 import React, { useMemo, useRef, useState, useEffect } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import moment from "moment"
-import { RefreshCw, ScanEye, AlertCircle, ImageOff, ArrowUpDown } from "lucide-react"
+import { RefreshCw, ScanEye, AlertCircle, ImageOff } from "lucide-react"
 
 import useObjectDetections from "../hooks/useObjectDetections.js"
+import usePreviewHeight from "../hooks/usePreviewHeight"
 import { useRole } from "./AuthContext.jsx"
-import { Card } from "../components/ui/card"
 import { Badge } from "../components/ui/badge"
 import { Button } from "../components/ui/button"
 import toast from "../js/toast.js"
 import { detectGrayPad } from "../js/letterbox.js"
 import DetectionOverlay from "../components/DetectionOverlay.jsx"
+import ResizeHandle from "../components/ResizeHandle.jsx"
+import CameraGridMini from "../components/CameraGridMini.jsx"
+import { padSlots } from "../js/grid.js"
 
 const cameraName = (status, n) => status?.cameraNames?.[n] || `Camera ${n}`
 
@@ -90,38 +93,17 @@ const ObjectDetectionsMini = () => {
 		return result.slice(0, 4)
 	}, [groups])
 
-	const slots = [0, 1, 2, 3].map(i => lastPerCamera[i] ?? null)
+	const slots = padSlots(lastPerCamera)
 
 	return (
-		<Card className="h-full overflow-hidden cursor-pointer select-none transition-shadow" onClick={() => navigate("/objects")}>
-			<div className="relative flex-1 grid grid-cols-2 grid-rows-2 gap-px bg-border min-h-0 h-full">
-				{slots.map((g, i) => (
-					<div
-						key={i}
-						onClick={g ? (e) => { e.stopPropagation(); navigate(`/objects?camera=${g.camera}`) } : undefined}
-						className={`relative overflow-hidden ${g ? "bg-black" : "bg-muted/20"}`}
-					>
-						{g ? (
-							<DetectionImage key={g.image} image={g.image} boxes={g.boxes} cover />
-						) : (
-							<div className="absolute inset-0 flex items-center justify-center">
-								<ImageOff className="size-5 opacity-30 text-muted" />
-							</div>
-						)}
-						{g && (
-							<div className="absolute bottom-1.5 inset-x-0 flex justify-center pointer-events-none">
-								<span className="bg-accent/85 text-accent-foreground text-xs font-medium px-3 py-0.5 rounded-full">
-									{cameraName(status, g.camera)}
-								</span>
-							</div>
-						)}
-					</div>
-				))}
-				<div className="absolute inset-0 m-auto z-10 rounded-full shadow-lg size-14 flex items-center justify-center bg-accent text-accent-foreground" onClick={(e) => { e.stopPropagation(); navigate("/objects") }}>
-					<ScanEye className="size-6" />
-				</div>
-			</div>
-		</Card>
+		<CameraGridMini
+			slots={slots}
+			onActivate={() => navigate("/objects")}
+			onCellClick={g => navigate(`/objects?camera=${g.camera}`)}
+			cellLabel={g => cameraName(status, g.camera)}
+			centerIcon={<ScanEye className="size-6" />}
+			renderCell={g => <DetectionImage key={g.image} image={g.image} boxes={g.boxes} cover />}
+		/>
 	)
 }
 
@@ -134,21 +116,8 @@ const ObjectDetectionsFull = () => {
 	const cameras = status?.cameras ? Object.entries(status.cameras) : []
 	const [selectedCam, setSelectedCam] = useState(null)
 	const [scrubIdx, setScrubIdx] = useState(0)
-	const [previewHeight, setPreviewHeight] = useState(200)
+	const [previewHeight, , startResizeDrag] = usePreviewHeight(200)
 	const trackRef = useRef(null)
-
-	const startResizeDrag = (e) => {
-		e.preventDefault()
-		const el = e.currentTarget
-		el.setPointerCapture(e.pointerId)
-		const startY = e.clientY
-		const startH = previewHeight
-		const maxH = Math.min(window.innerWidth * 9 / 16, window.innerHeight * 2 / 3)
-		const move = (ev) => setPreviewHeight(Math.max(80, Math.min(maxH, startH + ev.clientY - startY)))
-		const up = () => { el.removeEventListener("pointermove", move); el.removeEventListener("pointerup", up) }
-		el.addEventListener("pointermove", move)
-		el.addEventListener("pointerup", up)
-	}
 
 	useEffect(() => {
 		if (selectedCam != null || cameras.length === 0) return
@@ -224,12 +193,7 @@ const ObjectDetectionsFull = () => {
 					<ImageOff className="size-8 opacity-20 text-muted" />
 				</div>
 			)}
-			<div className="relative w-full h-4 flex items-center cursor-ns-resize touch-none select-none group" onPointerDown={startResizeDrag}>
-				<div className="absolute inset-x-0 h-0.5 bg-border group-hover:bg-muted/40 transition-colors" />
-				<div className="absolute right-2 z-10 bg-bg">
-					<ArrowUpDown className="size-3 text-muted/60 group-hover:text-muted transition-colors" />
-				</div>
-			</div>
+			<ResizeHandle onPointerDown={startResizeDrag} grip={false} />
 
 			{camGroups.length > 1 && (
 				<div className="px-8 pt-1 pb-0">

--- a/command/frontend/app/ObjectDetections.jsx
+++ b/command/frontend/app/ObjectDetections.jsx
@@ -10,8 +10,7 @@ import { Badge } from "../components/ui/badge"
 import { Button } from "../components/ui/button"
 import toast from "../js/toast.js"
 import { detectGrayPad } from "../js/letterbox.js"
-
-const STROKE = "#34d399"
+import DetectionOverlay from "../components/DetectionOverlay.jsx"
 
 const cameraName = (status, n) => status?.cameraNames?.[n] || `Camera ${n}`
 
@@ -27,7 +26,7 @@ const groupDetections = (detections) => {
 
 const DetectionImage = ({ image, boxes, cover = false, height }) => {
 	const [dims, setDims] = useState({ w: 416, h: 416 })
-	const [pad, setPad] = useState({ top: 0, bot: 0 })
+	const [pad, setPad] = useState({ top: 0, bot: 0, left: 0, right: 0 })
 
 	const handleLoad = (e) => {
 		const img = e.target
@@ -35,8 +34,8 @@ const DetectionImage = ({ image, boxes, cover = false, height }) => {
 		setPad(detectGrayPad(img))
 	}
 
+	const contentW = dims.w - pad.left - pad.right
 	const contentH = dims.h - pad.top - pad.bot
-	const svgViewBox = `0 ${pad.top} ${dims.w} ${contentH}`
 
 	if (cover) {
 		return (
@@ -47,23 +46,7 @@ const DetectionImage = ({ image, boxes, cover = false, height }) => {
 					className="absolute inset-0 w-full h-full object-cover object-top"
 					onLoad={handleLoad}
 				/>
-				<svg
-					className="pointer-events-none absolute inset-0 w-full h-full"
-					viewBox={svgViewBox}
-					preserveAspectRatio="xMidYMin slice"
-				>
-					{boxes.map((d, i) => (
-						<g key={i}>
-							<rect x={d.box[0]} y={d.box[1]} width={d.box[2]} height={d.box[3]}
-								fill="none" stroke={STROKE} strokeWidth={2} rx={2} />
-							<text x={d.box[0] + 3} y={Math.max(pad.top + 12, d.box[1] - 4)}
-								fontSize={13} fill={STROKE}
-								style={{ paintOrder: "stroke", stroke: "#000", strokeWidth: 3, fontWeight: 600 }}>
-								{`${d.type} ${Math.round(d.confidence * 100)}%`}
-							</text>
-						</g>
-					))}
-				</svg>
+				<DetectionOverlay boxes={boxes} dims={dims} pad={pad} fit="xMidYMin slice" />
 			</div>
 		)
 	}
@@ -72,34 +55,23 @@ const DetectionImage = ({ image, boxes, cover = false, height }) => {
 		<div
 			className="relative w-full overflow-hidden rounded-md bg-surface-raised"
 			style={{
-				aspectRatio: `${dims.w} / ${contentH}`,
-				...(height != null ? { maxHeight: height, maxWidth: contentH > 0 ? height * dims.w / contentH : undefined, margin: "0 auto" } : {})
+				aspectRatio: `${contentW} / ${contentH}`,
+				...(height != null ? { maxHeight: height, maxWidth: contentH > 0 ? height * contentW / contentH : undefined, margin: "0 auto" } : {})
 			}}
 		>
 			<img
 				src={`/object/captures/${image}`}
 				alt="detection"
-				className="absolute w-full h-auto"
-				style={pad.top > 0 ? { top: `-${(pad.top / contentH) * 100}%` } : { top: 0 }}
+				className="absolute"
+				style={{
+					width: `${(dims.w / contentW) * 100}%`,
+					height: "auto",
+					left: pad.left > 0 ? `-${(pad.left / contentW) * 100}%` : 0,
+					top: pad.top > 0 ? `-${(pad.top / contentH) * 100}%` : 0
+				}}
 				onLoad={handleLoad}
 			/>
-			<svg
-				className="pointer-events-none absolute inset-0 w-full h-full"
-				viewBox={svgViewBox}
-				preserveAspectRatio="none"
-			>
-				{boxes.map((d, i) => (
-					<g key={i}>
-						<rect x={d.box[0]} y={d.box[1]} width={d.box[2]} height={d.box[3]}
-							fill="none" stroke={STROKE} strokeWidth={2} rx={2} />
-						<text x={d.box[0] + 3} y={Math.max(pad.top + 12, d.box[1] - 4)}
-							fontSize={13} fill={STROKE}
-							style={{ paintOrder: "stroke", stroke: "#000", strokeWidth: 3, fontWeight: 600 }}>
-							{`${d.type} ${Math.round(d.confidence * 100)}%`}
-						</text>
-					</g>
-				))}
-			</svg>
+			<DetectionOverlay boxes={boxes} dims={dims} pad={pad} fit="none" />
 		</div>
 	)
 }

--- a/command/frontend/components/CameraGridMini.jsx
+++ b/command/frontend/components/CameraGridMini.jsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { ImageOff } from "lucide-react"
+import { Card } from "./ui/card"
+
+const CameraGridMini = ({ slots, renderCell, cellLabel, onCellClick, centerIcon, onActivate }) => (
+	<Card className="h-full overflow-hidden cursor-pointer select-none transition-shadow" onClick={onActivate}>
+		<div className="relative flex-1 grid grid-cols-2 grid-rows-2 gap-px bg-border min-h-0 h-full">
+			{slots.map((slot, i) => (
+				<div
+					key={i}
+					onClick={slot ? (e) => { e.stopPropagation(); onCellClick(slot) } : undefined}
+					className={`relative overflow-hidden ${slot ? "bg-black" : "bg-muted/20"}`}
+				>
+					{slot ? renderCell(slot) : (
+						<div className="absolute inset-0 flex items-center justify-center">
+							<ImageOff className="size-5 opacity-30 text-muted" />
+						</div>
+					)}
+					{slot && cellLabel(slot) != null && (
+						<div className="absolute bottom-1.5 inset-x-0 flex justify-center pointer-events-none">
+							<span className="bg-accent/85 text-accent-foreground text-xs font-medium px-3 py-0.5 rounded-full">
+								{cellLabel(slot)}
+							</span>
+						</div>
+					)}
+				</div>
+			))}
+			<div className="absolute inset-0 m-auto z-10 rounded-full shadow-lg size-14 flex items-center justify-center bg-accent text-accent-foreground" onClick={(e) => { e.stopPropagation(); onActivate() }}>
+				{centerIcon}
+			</div>
+		</div>
+	</Card>
+)
+
+export default CameraGridMini

--- a/command/frontend/components/DetectionOverlay.jsx
+++ b/command/frontend/components/DetectionOverlay.jsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { contentViewBox } from "../js/detections.js"
+
+const STROKE = "#34d399"
+
+const DetectionOverlay = ({ boxes, dims, pad, fit = "none", className = "pointer-events-none absolute inset-0 w-full h-full", style, width, height }) => (
+	<svg
+		className={className}
+		style={style}
+		width={width}
+		height={height}
+		viewBox={contentViewBox(dims, pad)}
+		preserveAspectRatio={fit}
+	>
+		{boxes.map((d, i) => (
+			<g key={i}>
+				<rect x={d.box[0]} y={d.box[1]} width={d.box[2]} height={d.box[3]}
+					fill="none" stroke={STROKE} strokeWidth={2} rx={2} />
+				<text x={d.box[0] + 3} y={Math.max((pad?.top ?? 0) + 12, d.box[1] - 4)}
+					fontSize={13} fill={STROKE}
+					style={{ paintOrder: "stroke", stroke: "#000", strokeWidth: 3, fontWeight: 600 }}>
+					{`${d.type} ${Math.round(d.confidence * 100)}%`}
+				</text>
+			</g>
+		))}
+	</svg>
+)
+
+export { STROKE }
+export default DetectionOverlay

--- a/command/frontend/components/ResizeHandle.jsx
+++ b/command/frontend/components/ResizeHandle.jsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { ArrowUpDown } from "lucide-react"
+
+const ResizeHandle = ({ onPointerDown, grip = true }) => (
+	<div className="relative w-full h-4 flex items-center cursor-ns-resize touch-none select-none group" onPointerDown={onPointerDown}>
+		<div className="absolute inset-x-0 h-0.5 bg-border group-hover:bg-muted/40 transition-colors" />
+		{grip && (
+			<div className="absolute left-3 z-10 bg-bg pl-0.5 pr-1">
+				<div className="w-8 h-0.5 rounded-full bg-muted/30 group-hover:bg-muted/50 transition-colors" />
+			</div>
+		)}
+		<div className="absolute right-2 z-10 bg-bg">
+			<ArrowUpDown className="size-3 text-muted/60 group-hover:text-muted transition-colors" />
+		</div>
+	</div>
+)
+
+export default ResizeHandle

--- a/command/frontend/hooks/usePreviewHeight.js
+++ b/command/frontend/hooks/usePreviewHeight.js
@@ -1,0 +1,26 @@
+import { useState } from "react"
+import { previewMaxHeight, clampHeight } from "../js/previewHeight.js"
+
+const usePreviewHeight = (initial, { rows = 1 } = {}) => {
+	const [previewHeight, setPreviewHeight] = useState(initial)
+
+	const startResizeDrag = (e) => {
+		e.preventDefault()
+		const el = e.currentTarget
+		el.setPointerCapture(e.pointerId)
+		const startY = e.clientY
+		const startH = previewHeight
+		const maxH = previewMaxHeight(window.innerWidth, window.innerHeight, rows)
+		const move = (ev) => setPreviewHeight(clampHeight(startH, ev.clientY - startY, maxH))
+		const up = () => {
+			el.removeEventListener("pointermove", move)
+			el.removeEventListener("pointerup", up)
+		}
+		el.addEventListener("pointermove", move)
+		el.addEventListener("pointerup", up)
+	}
+
+	return [previewHeight, setPreviewHeight, startResizeDrag]
+}
+
+export default usePreviewHeight

--- a/command/frontend/js/detections.js
+++ b/command/frontend/js/detections.js
@@ -1,6 +1,51 @@
+import moment from "moment"
+
 const contentViewBox = (dims, pad = {}) => {
 	const { top = 0, bot = 0, left = 0, right = 0 } = pad
 	return `${left} ${top} ${dims.w - left - right} ${dims.h - top - bot}`
 }
 
-export { contentViewBox }
+const nearestFrameIndex = (timesMs, targetMs) => {
+	let bestIdx = 0, bestDiff = Infinity
+	for (let i = 0; i < timesMs.length; i++) {
+		const t = timesMs[i]
+		if (t == null) continue
+		const diff = Math.abs(t - targetMs)
+		if (diff < bestDiff) { bestDiff = diff; bestIdx = i }
+	}
+	return bestIdx
+}
+
+const frameSpacingMs = (timesMs) => {
+	const valid = [...new Set(timesMs.filter(t => t != null))]
+	if (valid.length <= 1) return Infinity
+	return (Math.max(...valid) - Math.min(...valid)) / (valid.length - 1)
+}
+
+const boxesForScrub = (detections, frameMs, tol) => {
+	if (frameMs == null) return []
+	const at = (d) => moment(d.timestamp).valueOf()
+	const here = detections.filter(d => {
+		const v = at(d)
+		return Number.isFinite(v) && Math.abs(v - frameMs) <= tol
+	})
+	if (!here.length) return []
+	let best = here[0], bestDiff = Infinity
+	for (const d of here) {
+		const diff = Math.abs(at(d) - frameMs)
+		if (diff < bestDiff) { bestDiff = diff; best = d }
+	}
+	return here.filter(d => d.image === best.image)
+}
+
+const fuseMarkers = (sortedPcts, fusePct) => {
+	const out = []
+	for (const p of sortedPcts) {
+		const last = out[out.length - 1]
+		if (last && p - last.end <= fusePct) last.end = p
+		else out.push({ start: p, end: p })
+	}
+	return out
+}
+
+export { contentViewBox, nearestFrameIndex, frameSpacingMs, boxesForScrub, fuseMarkers }

--- a/command/frontend/js/detections.js
+++ b/command/frontend/js/detections.js
@@ -1,0 +1,6 @@
+const contentViewBox = (dims, pad = {}) => {
+	const { top = 0, bot = 0, left = 0, right = 0 } = pad
+	return `${left} ${top} ${dims.w - left - right} ${dims.h - top - bot}`
+}
+
+export { contentViewBox }

--- a/command/frontend/js/detections.js
+++ b/command/frontend/js/detections.js
@@ -22,12 +22,13 @@ const frameSpacingMs = (timesMs) => {
 	return (Math.max(...valid) - Math.min(...valid)) / (valid.length - 1)
 }
 
-const boxesForScrub = (detections, frameMs, tol) => {
+const boxesForScrub = (detections, timesMs, scrubIdx, tol) => {
+	const frameMs = timesMs[scrubIdx]
 	if (frameMs == null) return []
 	const at = (d) => moment(d.timestamp).valueOf()
 	const here = detections.filter(d => {
 		const v = at(d)
-		return Number.isFinite(v) && Math.abs(v - frameMs) <= tol
+		return Number.isFinite(v) && nearestFrameIndex(timesMs, v) === scrubIdx && Math.abs(v - frameMs) <= tol
 	})
 	if (!here.length) return []
 	let best = here[0], bestDiff = Infinity

--- a/command/frontend/js/grid.js
+++ b/command/frontend/js/grid.js
@@ -1,3 +1,8 @@
 const padSlots = (arr, n = 4) => Array.from({ length: n }, (_, i) => arr[i] ?? null)
 
-export { padSlots }
+const gridShape = (n) => {
+	const cols = n <= 1 ? 1 : 2
+	return { cols, rows: Math.max(1, Math.ceil(n / cols)) }
+}
+
+export { padSlots, gridShape }

--- a/command/frontend/js/grid.js
+++ b/command/frontend/js/grid.js
@@ -1,0 +1,3 @@
+const padSlots = (arr, n = 4) => Array.from({ length: n }, (_, i) => arr[i] ?? null)
+
+export { padSlots }

--- a/command/frontend/js/previewHeight.js
+++ b/command/frontend/js/previewHeight.js
@@ -1,0 +1,7 @@
+const previewMaxHeight = (winW, winH, rows = 1) =>
+	Math.min(winW * 9 / 16, winH * 2 / 3) / rows
+
+const clampHeight = (startH, dy, maxH) =>
+	Math.max(80, Math.min(maxH, startH + dy))
+
+export { previewMaxHeight, clampHeight }

--- a/command/test/clipDetections.test.js
+++ b/command/test/clipDetections.test.js
@@ -32,17 +32,23 @@ describe("frameSpacingMs", () => {
 describe("boxesForScrub", () => {
 	const det = (image, ms) => ({ image, timestamp: new Date(ms).toISOString(), box: [0, 0, 1, 1], type: "person", confidence: 0.9 })
 
-	test("returns boxes of the image nearest the frame, within tolerance", () => {
+	test("returns boxes of the image nearest the scrub frame, within tolerance", () => {
 		const dets = [det("a", 0), det("a", 10), det("b", 1000)]
-		expect(boxesForScrub(dets, 5, 100).map(d => d.image)).toEqual(["a", "a"])
+		expect(boxesForScrub(dets, [0, 1000], 0, 100).map(d => d.image)).toEqual(["a", "a"])
 	})
 
 	test("excludes detections beyond tolerance", () => {
-		expect(boxesForScrub([det("a", 0)], 1000, 100)).toEqual([])
+		expect(boxesForScrub([det("a", 0)], [1000], 0, 100)).toEqual([])
+	})
+
+	test("a detection only shows on its nearest frame, not adjacent ones", () => {
+		const dets = [det("a", 60)]
+		expect(boxesForScrub(dets, [0, 100, 200], 1, 100).map(d => d.image)).toEqual(["a"])
+		expect(boxesForScrub(dets, [0, 100, 200], 0, 100)).toEqual([])
 	})
 
 	test("a null frame time yields nothing", () => {
-		expect(boxesForScrub([det("a", 0)], null, 100)).toEqual([])
+		expect(boxesForScrub([det("a", 0)], [null, 100], 0, 100)).toEqual([])
 	})
 })
 

--- a/command/test/clipDetections.test.js
+++ b/command/test/clipDetections.test.js
@@ -1,0 +1,72 @@
+const { nearestFrameIndex, frameSpacingMs, boxesForScrub, fuseMarkers } = require("../frontend/js/detections.js")
+const { gridShape } = require("../frontend/js/grid.js")
+
+describe("nearestFrameIndex", () => {
+	test("returns the index of the closest time", () => {
+		expect(nearestFrameIndex([0, 100, 200], 130)).toBe(1)
+		expect(nearestFrameIndex([0, 100, 200], 170)).toBe(2)
+	})
+
+	test("skips null times", () => {
+		expect(nearestFrameIndex([null, 100, null], 5000)).toBe(1)
+	})
+
+	test("defaults to 0 when all null or empty", () => {
+		expect(nearestFrameIndex([null, null], 5)).toBe(0)
+		expect(nearestFrameIndex([], 5)).toBe(0)
+	})
+})
+
+describe("frameSpacingMs", () => {
+	test("even spacing", () => {
+		expect(frameSpacingMs([0, 100, 200, 300])).toBe(100)
+	})
+
+	test("infinite for one or fewer distinct times", () => {
+		expect(frameSpacingMs([500])).toBe(Infinity)
+		expect(frameSpacingMs([null, null])).toBe(Infinity)
+		expect(frameSpacingMs([200, 200])).toBe(Infinity)
+	})
+})
+
+describe("boxesForScrub", () => {
+	const det = (image, ms) => ({ image, timestamp: new Date(ms).toISOString(), box: [0, 0, 1, 1], type: "person", confidence: 0.9 })
+
+	test("returns boxes of the image nearest the frame, within tolerance", () => {
+		const dets = [det("a", 0), det("a", 10), det("b", 1000)]
+		expect(boxesForScrub(dets, 5, 100).map(d => d.image)).toEqual(["a", "a"])
+	})
+
+	test("excludes detections beyond tolerance", () => {
+		expect(boxesForScrub([det("a", 0)], 1000, 100)).toEqual([])
+	})
+
+	test("a null frame time yields nothing", () => {
+		expect(boxesForScrub([det("a", 0)], null, 100)).toEqual([])
+	})
+})
+
+describe("fuseMarkers", () => {
+	test("fuses near ticks into a band, keeps far ones separate", () => {
+		expect(fuseMarkers([10, 11, 50], 1.5)).toEqual([{ start: 10, end: 11 }, { start: 50, end: 50 }])
+	})
+
+	test("empty in, empty out", () => {
+		expect(fuseMarkers([], 1.5)).toEqual([])
+	})
+})
+
+describe("gridShape", () => {
+	test("one camera is a single cell", () => {
+		expect(gridShape(1)).toEqual({ cols: 1, rows: 1 })
+	})
+
+	test("two cameras are one row", () => {
+		expect(gridShape(2)).toEqual({ cols: 2, rows: 1 })
+	})
+
+	test("three or four cameras fill a 2x2", () => {
+		expect(gridShape(3)).toEqual({ cols: 2, rows: 2 })
+		expect(gridShape(4)).toEqual({ cols: 2, rows: 2 })
+	})
+})

--- a/command/test/detectionOverlay.test.js
+++ b/command/test/detectionOverlay.test.js
@@ -1,0 +1,22 @@
+const { contentViewBox } = require("../frontend/js/detections.js")
+
+describe("contentViewBox", () => {
+	test("crops all four padded sides", () => {
+		expect(contentViewBox({ w: 416, h: 416 }, { top: 40, bot: 40, left: 10, right: 10 }))
+			.toBe("10 40 396 336")
+	})
+
+	test("passes through with zero pad", () => {
+		expect(contentViewBox({ w: 640, h: 360 }, { top: 0, bot: 0, left: 0, right: 0 }))
+			.toBe("0 0 640 360")
+	})
+
+	test("defaults missing pad fields to zero", () => {
+		expect(contentViewBox({ w: 416, h: 416 }, { top: 58, bot: 58 }))
+			.toBe("0 58 416 300")
+	})
+
+	test("treats undefined pad as no crop", () => {
+		expect(contentViewBox({ w: 100, h: 100 })).toBe("0 0 100 100")
+	})
+})

--- a/command/test/previewHeight.test.js
+++ b/command/test/previewHeight.test.js
@@ -1,0 +1,41 @@
+const { previewMaxHeight, clampHeight } = require("../frontend/js/previewHeight.js")
+const { padSlots } = require("../frontend/js/grid.js")
+
+describe("clampHeight", () => {
+	test("adds the drag delta to the start height", () => {
+		expect(clampHeight(200, 50, 600)).toBe(250)
+		expect(clampHeight(200, -30, 600)).toBe(170)
+	})
+
+	test("floors at 80", () => {
+		expect(clampHeight(100, -500, 600)).toBe(80)
+	})
+
+	test("ceils at maxH", () => {
+		expect(clampHeight(200, 5000, 600)).toBe(600)
+	})
+})
+
+describe("previewMaxHeight", () => {
+	test("takes the smaller of width- and height-derived caps", () => {
+		expect(previewMaxHeight(1600, 900, 1)).toBe(Math.min(900, 600))
+	})
+
+	test("divides by the row count for grids", () => {
+		expect(previewMaxHeight(1600, 900, 2)).toBe(300)
+	})
+})
+
+describe("padSlots", () => {
+	test("pads a short list with nulls up to four", () => {
+		expect(padSlots([{ id: 1 }])).toEqual([{ id: 1 }, null, null, null])
+	})
+
+	test("keeps the first n when longer", () => {
+		expect(padSlots([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4])
+	})
+
+	test("respects a custom length", () => {
+		expect(padSlots([], 2)).toEqual([null, null])
+	})
+})

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -445,18 +445,21 @@ describe("makeAuthorize CSRF protection", () => {
 	})
 
 	describe("Origin fallback when Sec-Fetch-Site is absent", () => {
-		beforeAll(() => { process.env.gateway_HOST = "cams.example.com" })
-		afterAll(() => { delete process.env.gateway_HOST })
-
 		test("rejects a mismatched Origin", async () => {
-			const { res, next } = run({ origin: "https://evil.example.net" })
+			const { res, next } = run({ origin: "https://evil.example.net", host: "cams.example.com" })
 			await new Promise(resolve => setImmediate(resolve))
 			expect(res.status).toHaveBeenCalledWith(403)
 			expect(next).not.toHaveBeenCalled()
 		})
 
 		test("allows a matching Origin", async () => {
-			const { next } = run({ origin: "https://cams.example.com" })
+			const { next } = run({ origin: "https://cams.example.com", host: "cams.example.com" })
+			await new Promise(resolve => setImmediate(resolve))
+			expect(next).toHaveBeenCalled()
+		})
+
+		test("allows a matching Origin reached via a LAN IP instead of the public hostname", async () => {
+			const { next } = run({ origin: "https://192.168.1.50:7922", host: "192.168.1.50:7922" })
 			await new Promise(resolve => setImmediate(resolve))
 			expect(next).toHaveBeenCalled()
 		})

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -1,7 +1,6 @@
 const secretKey = process.env.SECRETKEY
 const jwt = require("jsonwebtoken")
 const timingSafeCompare = require("./timingSafeCompare.js")
-const gatewayHost = require("./gatewayHost.js")
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"])
 const SAME_SITE_FETCH = new Set(["same-origin", "same-site", "none"])
@@ -14,8 +13,7 @@ const isCrossSite = (req) => {
 	if (site) return !SAME_SITE_FETCH.has(site)
 	const origin = req.headers.origin
 	if (!origin) return false
-	const expected = gatewayHost()
-	return !!expected && hostOf(origin) !== hostOf(expected)
+	return hostOf(origin) !== req.headers.host
 }
 
 const sessionCache = new Map()


### PR DESCRIPTION
Unifies ClipMaker's single-cam and multi-cam modes onto one `cams[]` array (single-cam = length 1), deleting the hand-synced parallel state that had drifted and shipped two live bugs. Landed as the tracking issue prescribed: children first (#318 → #317 → #319), then the array merge.

### Commits
- **#318** — `generateMulti` waited for nothing: it toasted "queued" and navigated away before any request resolved, so total failure looked like success. Now uses a completion counter; on total failure it stays put, shows the error, and resets `submitting`.
- **#317** — extracted a shared `<DetectionOverlay>` (image-source-agnostic SVG box layer with all-axis letterbox padding); adopted in `ObjectDetections.DetectionImage` and ClipMaker single-cam (deleted the canvas box math).
- **#319** — extracted `<ResizeHandle>` + `usePreviewHeight` + `<CameraGridMini>`, adopted in both ClipMaker and ObjectDetections.
- **#264** — collapsed both modes onto `cams[]`; deleted `camStates` / `multiImageCache` / `multiLoadGenRef` / `multiCanvasRefs` / `multiGenerating` / `loadMultiPreview` / `generateMulti`; unified the loader, generator, download and draw effects; **added per-camera detection fetch so detection boxes now render in every camera** (previously single-cam only).
- **Auth fix** — `isCrossSite()` in `lib/utils/auth.js` compared the request's `Origin` against a statically configured `gateway_HOST` env var when `Sec-Fetch-Site` was absent. Any client reached via a hostname/IP other than that exact config value (common on mobile, where `Sec-Fetch-Site` is more often missing and the access path differs from desktop) got a false `403`, which the frontend surfaced as an instant bounce back to `/login` right after a successful login. Now compares `Origin` against the request's own `Host` header instead — the standard CSRF-mitigation technique, and correct regardless of which hostname/IP the gateway is reached through.

### Impact
- `multiCam` references 46 → 7 (now a UI-layout flag only — the data forks are gone)
- `ClipMaker.jsx` 1149 → 917 lines

### Notes
- `multiCam` is intentionally kept as a thin selector/label flag; fully removing it would change the desktop selector UX (out of scope).
- The scrub/trim timeline is now uniform across both modes (reference-camera frame-time snapping, lerp fallback).

### Tests
The file had zero tests. Added:
- Unit tests (node Jest) for the extracted pure logic: viewBox/pad math, nearest-frame, marker fusing, grid shape, preview-height clamp.
- Playwright e2e (`clip.spec.js`): generate success→navigate / total-failure→stay, and single- + multi-cam box rendering.
- Updated `lib/test/auth.test.js` CSRF cases for the Origin/Host comparison change.

Verified: 119 Jest tests + 30 Playwright e2e pass, lint 0 errors (112 warnings < 150 budget), Vite build clean. `lib/` auth suite (140 tests) passes with the CSRF fix.

Closes #264
Closes #318
Closes #317
Closes #319
