### PR TITLE
Confine autoClean unlink with path.basename

### DIFF
--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -181,7 +181,7 @@ module.exports = {
 				}
 
 				const removed = await mapLimit(batch, FS_CONCURRENCY, row =>
-					fs.promises.unlink(path.join(CAPTURES_DIR, row.camera.toString(), row.name))
+					fs.promises.unlink(path.join(CAPTURES_DIR, row.camera.toString(), path.basename(row.name)))
 						.then(() => true)
 						.catch((e) => e.code === "ENOENT")
 				)

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -414,6 +414,25 @@ describe("File Routes", () => {
 				expect(query).not.toHaveBeenCalled()
 			})
 
+			test("confines a traversal-laden frame name to the camera directory", async () => {
+				process.env.storage_MAX_GB = "1"
+				bulkQuery
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "1800000000" }] }))
+					.mockImplementationOnce(() => Promise.resolve({ rows: [
+						{ id: 1, camera: "1", name: "../../../../etc/passwd.jpg", size: "600000000" },
+						{ id: 2, camera: "1", name: "b.jpg", size: "600000000" }
+					] }))
+				const res = await supertest(app)
+					.post("/file/pathAutoClean")
+					.set("Cookie", cookieWithBearerToken)
+				expect(res.status).toBe(200)
+				const base = path.join("/tmp/storage-file-test", "shared/captures", "1")
+				expect(unlinkSpy).toHaveBeenCalledWith(path.join(base, "passwd.jpg"))
+				unlinkSpy.mock.calls.forEach(([p]) => {
+					expect(path.resolve(String(p)).startsWith(path.resolve(base) + path.sep)).toBe(true)
+				})
+			})
+
 			test("skips when non-frame artifacts dominate and deleting all frames can't reach target", async () => {
 				process.env.storage_MAX_GB = "1"
 				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "500000000" }] }))


### PR DESCRIPTION
Applies path.basename() to the autoClean unlink path so a traversal-laden frame_files.name cannot escape the captures dir, matching the sibling handler.

Closes #322