### PR TITLE
Add CSRF defense beyond SameSite cookie

### DIFF
--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -280,6 +280,27 @@ describe("Authorization Routes", () => {
 		})
 	})
 
+	describe("CSRF protection on cookie-authed routes", () => {
+		const token = jwt.sign({ username: "test", role: "user", jti: "jti-user" }, "test-secret")
+
+		test("rejects a cross-site POST with 403", async () => {
+			const res = await supertest(app)
+				.post("/authorization/verify")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.set("Sec-Fetch-Site", "cross-site")
+			expect(res.status).toBe(403)
+			expect(res.body).toEqual({ error: "forbidden" })
+		})
+
+		test("allows a same-origin POST", async () => {
+			const res = await supertest(app)
+				.post("/authorization/verify")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.set("Sec-Fetch-Site", "same-origin")
+			expect(res.status).toBe(200)
+		})
+	})
+
 	describe("PUT /authorization/theme", () => {
 		test("returns 401 with no token", async () => {
 			const res = await supertest(app).put("/authorization/theme").send({ theme: "light" })

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -403,6 +403,66 @@ describe("makeAuthorize cross-process session invalidation", () => {
 	})
 })
 
+describe("makeAuthorize CSRF protection", () => {
+	const token = jwt.sign({ username: "bob", jti: "csrf-jti" }, process.env.SECRETKEY)
+	const activeRow = { rows: [{ role: "user", revoked: false, last_seen: new Date() }], rowCount: 1 }
+	const run = (headers, method = "POST") => {
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const req = { method, path: "/x", headers, cookies: { bearertoken: `Bearer ${token}` } }
+		const res = makeRes()
+		const next = jest.fn()
+		authorize(req, res, next)
+		return { pool, res, next }
+	}
+
+	test("rejects a cross-site unsafe request before touching the database", async () => {
+		const { pool, res, next } = run({ "sec-fetch-site": "cross-site" })
+		await new Promise(resolve => setImmediate(resolve))
+		expect(res.status).toHaveBeenCalledWith(403)
+		expect(res.send).toHaveBeenCalledWith({ error: "forbidden" })
+		expect(pool.query).not.toHaveBeenCalled()
+		expect(next).not.toHaveBeenCalled()
+	})
+
+	test("allows a same-origin unsafe request", async () => {
+		const { res, next } = run({ "sec-fetch-site": "same-origin" })
+		await new Promise(resolve => setImmediate(resolve))
+		expect(next).toHaveBeenCalled()
+		expect(res.status).not.toHaveBeenCalledWith(403)
+	})
+
+	test("allows a cross-site safe (GET) request", async () => {
+		const { next } = run({ "sec-fetch-site": "cross-site" }, "GET")
+		await new Promise(resolve => setImmediate(resolve))
+		expect(next).toHaveBeenCalled()
+	})
+
+	test("allows an unsafe request lacking both Sec-Fetch-Site and Origin", async () => {
+		const { next } = run({})
+		await new Promise(resolve => setImmediate(resolve))
+		expect(next).toHaveBeenCalled()
+	})
+
+	describe("Origin fallback when Sec-Fetch-Site is absent", () => {
+		beforeAll(() => { process.env.gateway_HOST = "cams.example.com" })
+		afterAll(() => { delete process.env.gateway_HOST })
+
+		test("rejects a mismatched Origin", async () => {
+			const { res, next } = run({ origin: "https://evil.example.net" })
+			await new Promise(resolve => setImmediate(resolve))
+			expect(res.status).toHaveBeenCalledWith(403)
+			expect(next).not.toHaveBeenCalled()
+		})
+
+		test("allows a matching Origin", async () => {
+			const { next } = run({ origin: "https://cams.example.com" })
+			await new Promise(resolve => setImmediate(resolve))
+			expect(next).toHaveBeenCalled()
+		})
+	})
+})
+
 describe("makeAuthorize forced password change", () => {
 	const token = jwt.sign({ username: "bob", jti: "s1" }, process.env.SECRETKEY)
 	const forcedPool = () => ({ query: jest.fn().mockResolvedValue({ rows: [{ role: "user", force_password_change: true, revoked: false }], rowCount: 1 }) })

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -1,6 +1,22 @@
 const secretKey = process.env.SECRETKEY
 const jwt = require("jsonwebtoken")
 const timingSafeCompare = require("./timingSafeCompare.js")
+const gatewayHost = require("./gatewayHost.js")
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"])
+const SAME_SITE_FETCH = new Set(["same-origin", "same-site", "none"])
+
+const hostOf = (url) => { try { return new URL(url).host } catch (e) { return null } }
+
+const isCrossSite = (req) => {
+	if (SAFE_METHODS.has(req.method)) return false
+	const site = req.headers["sec-fetch-site"]
+	if (site) return !SAME_SITE_FETCH.has(site)
+	const origin = req.headers.origin
+	if (!origin) return false
+	const expected = gatewayHost()
+	return !!expected && hostOf(origin) !== hostOf(expected)
+}
 
 const sessionCache = new Map()
 const SESSION_CACHE_MS = 5000
@@ -115,6 +131,7 @@ const makeAuthorize = (pool, { schedulableUrls = [], forcedChangeAllowed = [] } 
 	} else {
 		const bearerTokenCookie = req.cookies && req.cookies.bearertoken
 		if (bearerTokenCookie && bearerTokenCookie.includes("Bearer")) {
+			if (isCrossSite(req)) return res.status(403).send({ error: "forbidden" })
 			verifyJwt(bearerTokenCookie.split(/%20|\s+/)[1], req, res, next, pool, forcedChangeAllowed)
 		} else unauthorized()
 	}


### PR DESCRIPTION
Adds an Origin / Sec-Fetch-Site cross-site check in the shared makeAuthorize choke point for unsafe methods; fails closed only on a clear cross-site signal, no frontend changes.

Closes #324