### PR TITLE
Require setup token for admin bootstrap

### DIFF
--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -77,7 +77,7 @@ app.get("/status", async (req, res) => {
 
 app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	const { username, password, token } = req.body
-	if (process.env.setup_TOKEN && !timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true })
+	if (!process.env.setup_TOKEN || !timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true })
 	if (typeof username !== "string") return res.status(400).json({ error: true })
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(username)) return res.status(400).json({ error: true, errors: "Username must be 3-50 characters and contain only letters, numbers, dashes, dots, and underscores." })
@@ -85,22 +85,16 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 		const hash = await hashPassword(password)
 		const result = await withTransaction(async (client) => {
 			await client.query("SELECT pg_advisory_xact_lock(1)")
-			if (process.env.setup_TOKEN) {
-				const noAdmin = (await client.query("SELECT 1 FROM auth WHERE role = 'admin' LIMIT 1")).rowCount === 0
-				const target = (await client.query("SELECT role FROM auth WHERE username = $1", [username])).rows[0]
-				const allowed = noAdmin && !target
-				if (!allowed) return { rowCount: 0 }
-				const upsert = await client.query(
-					"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
-					[username, hash]
-				)
-				await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1", [username])
-				return upsert
-			}
-			return client.query(
-				"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth)",
+			const noAdmin = (await client.query("SELECT 1 FROM auth WHERE role = 'admin' LIMIT 1")).rowCount === 0
+			const target = (await client.query("SELECT role FROM auth WHERE username = $1", [username])).rows[0]
+			const allowed = noAdmin && !target
+			if (!allowed) return { rowCount: 0 }
+			const upsert = await client.query(
+				"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
 				[username, hash]
 			)
+			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1", [username])
+			return upsert
 		})
 		if (result.rowCount === 0) return res.status(403).json({ error: true })
 		auth.invalidateUser(username)

--- a/command/frontend/app/SetupForm.jsx
+++ b/command/frontend/app/SetupForm.jsx
@@ -35,6 +35,23 @@ const SetupForm = ({ trySetup, tokenRequired }) => {
 		if (e.key === "Enter") onSubmit()
 	}
 
+	if (!tokenRequired) {
+		return (
+			<div className="min-h-screen bg-bg flex items-center justify-center">
+				<Card className="w-80 bg-surface border-border">
+					<CardHeader className="items-center gap-2 pb-2">
+						<img src="/res/logo.png" alt="Chimera" className="h-12 w-12 object-contain" />
+						<CardTitle className="text-primary text-xl">Chimera</CardTitle>
+						<p className="text-muted text-sm">Setup unavailable</p>
+					</CardHeader>
+					<CardContent>
+						<p className="text-muted text-sm">Set the <code>setup_TOKEN</code> environment variable to create the admin account.</p>
+					</CardContent>
+				</Card>
+			</div>
+		)
+	}
+
 	return (
 		<div className="min-h-screen bg-bg flex items-center justify-center">
 			<Card className="w-80 bg-surface border-border">

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -37,25 +37,29 @@ describe("Authorization Routes", () => {
 	})
 
 	describe("POST /authorization/setup", () => {
-		test("returns 200 on first-time setup", async () => {
+		test("returns 200 on first-time setup with a valid setup_TOKEN", async () => {
+			process.env.setup_TOKEN = "boot-token"
 			const spy = jest.spyOn(auth, "invalidateUser")
+			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
+			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 0 }) // no admin exists
+			mockedPool.query.mockResolvedValueOnce({ rows: [] }) // target is a new user
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // upsert
 			const res = await supertest(app)
 				.post("/authorization/setup")
-				.send({ username: "admin", password: "password123" })
+				.send({ username: "admin", password: "password123", token: "boot-token" })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(spy).toHaveBeenCalled()
 		})
 
-		test("returns 403 when table already has a row", async () => {
-			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
-			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
-			mockedPool.query.mockResolvedValueOnce({ rowCount: 0 }) // INSERT
+		test("refuses setup when setup_TOKEN is not configured", async () => {
 			const res = await supertest(app)
 				.post("/authorization/setup")
 				.send({ username: "admin", password: "password123" })
 			expect(res.status).toBe(403)
 			expect(res.body).toEqual({ error: true })
+			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
 		})
 
 		test("allows admin recovery with a valid setup_TOKEN when no admin exists", async () => {


### PR DESCRIPTION
Makes setup_TOKEN mandatory: /setup is refused (403) when the token is unset or mismatched, removing the unauthenticated first-caller-wins admin bootstrap. SetupForm shows a 'set setup_TOKEN' notice when no token is configured.

Closes #321