### PR TITLE
Handle 401/403 centrally in request.js

### DIFF
--- a/command/frontend/js/request.js
+++ b/command/frontend/js/request.js
@@ -1,5 +1,16 @@
+let unauthorizedHandled = false
+
+const handleUnauthorized = (url, res) => {
+	if (unauthorizedHandled) return res
+	if (res.status !== 401 && res.status !== 403) return res
+	if (String(url).startsWith("/authorization")) return res
+	unauthorizedHandled = true
+	window.location.assign("/login")
+	return res
+}
+
 const request = (url, opt, callback) => {
-	return callback(fetch(url, opt))
+	return callback(fetch(url, opt).then(res => handleUnauthorized(url, res)))
 }
 
 const authPromiseHandler = (prom) => prom.then(res => res.json()).catch(() => ({ error: true }))


### PR DESCRIPTION
Adds a central handler in request() so a session revoked mid-use no longer feeds {error:unauthorized} bodies into data hooks. On a 401/403 from any non-/authorization request it redirects once to /login (guarded flag prevents repeat redirects; /authorization probes are skipped so useAuth keeps owning the login flow and no loop occurs). No JS cookie-clearing since the auth cookie is httpOnly.

Closes #326