### PR TITLE
Add per-account login lockout

### DIFF
--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -37,8 +37,9 @@ const sharedAttempts = process.env.memory_ON == "true"
 const memoryClient = sharedAttempts ? memory.client("AUTH") : null
 if (memoryClient) auth.connectSessionSync(memoryClient)
 
-const rateLimit = ({ windowMs, max }) => {
+const rateLimit = ({ windowMs, max, keyFn }) => {
 	const local = memory.loginAttempts()
+	const getKey = keyFn || ((req) => `${req.ip || ""}:${req.path}`)
 	const reserveLocal = (key, cb) =>
 		local.loginReserve(key, max, windowMs, (blocked) => cb(blocked, () => local.loginRelease(key)))
 	const reserve = (key, cb) => {
@@ -52,7 +53,7 @@ const rateLimit = ({ windowMs, max }) => {
 		})
 	}
 	return (req, res, next) => {
-		const key = `${req.ip || ""}:${req.path}`
+		const key = getKey(req)
 		reserve(key, (blocked, release) => {
 			if (blocked) return res.status(429).json({ error: true, errors: "Too many attempts" })
 			res.on("finish", () => {
@@ -64,6 +65,7 @@ const rateLimit = ({ windowMs, max }) => {
 }
 
 const loginLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10 })
+const accountLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10, keyFn: (req) => `user:${String(req.body?.username ?? "")}` })
 
 app.get("/status", async (req, res) => {
 	try {
@@ -110,7 +112,7 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	}
 })
 
-app.post("/login", validateBody, loginLimiter, passwordCheck, login)
+app.post("/login", validateBody, loginLimiter, accountLimiter, passwordCheck, login)
 app.post("/verify", authorize, async (req, res) => {
 	try {
 		const result = await pool.query("SELECT force_password_change, theme FROM auth WHERE username = $1", [req.decoded.username])

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -834,6 +834,18 @@ describe("Authorization Routes", () => {
 			}
 			expect(res.status).toBe(400)
 		})
+
+		test("locks a single account across distinct IPs", async () => {
+			let res
+			for (let i = 0; i < 11; i++) {
+				res = await supertest(app)
+					.post("/authorization/login")
+					.set("X-Forwarded-For", `198.51.100.${100 + i}`)
+					.send({ username: "lockme", password: "wrongpassword" })
+			}
+			expect(res.status).toBe(429)
+			expect(res.body).toEqual({ error: true, errors: "Too many attempts" })
+		})
 	})
 
 	describe("rateLimit (shared memory instance)", () => {


### PR DESCRIPTION
Adds a per-username attempt limiter alongside the existing per-IP one on POST /login, so a distributed attacker (many IPs, one account) is throttled. rateLimit now takes an optional keyFn; the account limiter keys on the submitted username (10 failed attempts / 15 min), releasing on success like the IP limiter. Validated: full authorization suite green (85 tests) incl. a new cross-IP account-lockout test.

Closes #320