### PR TITLE
Auth hardening: setup token, per-account lockout, CSRF defense

### DIFF
--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -37,8 +37,9 @@ const sharedAttempts = process.env.memory_ON == "true"
 const memoryClient = sharedAttempts ? memory.client("AUTH") : null
 if (memoryClient) auth.connectSessionSync(memoryClient)
 
-const rateLimit = ({ windowMs, max }) => {
+const rateLimit = ({ windowMs, max, keyFn }) => {
 	const local = memory.loginAttempts()
+	const getKey = keyFn || ((req) => `${req.ip || ""}:${req.path}`)
 	const reserveLocal = (key, cb) =>
 		local.loginReserve(key, max, windowMs, (blocked) => cb(blocked, () => local.loginRelease(key)))
 	const reserve = (key, cb) => {
@@ -52,7 +53,7 @@ const rateLimit = ({ windowMs, max }) => {
 		})
 	}
 	return (req, res, next) => {
-		const key = `${req.ip || ""}:${req.path}`
+		const key = getKey(req)
 		reserve(key, (blocked, release) => {
 			if (blocked) return res.status(429).json({ error: true, errors: "Too many attempts" })
 			res.on("finish", () => {
@@ -64,6 +65,7 @@ const rateLimit = ({ windowMs, max }) => {
 }
 
 const loginLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10 })
+const accountLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10, keyFn: (req) => `user:${String(req.body?.username ?? "")}` })
 
 app.get("/status", async (req, res) => {
 	try {
@@ -104,7 +106,7 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	}
 })
 
-app.post("/login", validateBody, loginLimiter, passwordCheck, login)
+app.post("/login", validateBody, loginLimiter, accountLimiter, passwordCheck, login)
 app.post("/verify", authorize, async (req, res) => {
 	try {
 		const result = await pool.query("SELECT force_password_change, theme FROM auth WHERE username = $1", [req.decoded.username])

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -77,7 +77,7 @@ app.get("/status", async (req, res) => {
 
 app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	const { username, password, token } = req.body
-	if (process.env.setup_TOKEN && !timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true })
+	if (!process.env.setup_TOKEN || !timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true })
 	if (typeof username !== "string") return res.status(400).json({ error: true })
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(username)) return res.status(400).json({ error: true, errors: "Username must be 3-50 characters and contain only letters, numbers, dashes, dots, and underscores." })
@@ -85,22 +85,16 @@ app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 		const hash = await hashPassword(password)
 		const result = await withTransaction(async (client) => {
 			await client.query("SELECT pg_advisory_xact_lock(1)")
-			if (process.env.setup_TOKEN) {
-				const noAdmin = (await client.query("SELECT 1 FROM auth WHERE role = 'admin' LIMIT 1")).rowCount === 0
-				const target = (await client.query("SELECT role FROM auth WHERE username = $1", [username])).rows[0]
-				const allowed = noAdmin && !target
-				if (!allowed) return { rowCount: 0 }
-				const upsert = await client.query(
-					"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
-					[username, hash]
-				)
-				await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1", [username])
-				return upsert
-			}
-			return client.query(
-				"INSERT INTO auth(username, hash, role) SELECT $1, $2, 'admin' WHERE NOT EXISTS (SELECT 1 FROM auth)",
+			const noAdmin = (await client.query("SELECT 1 FROM auth WHERE role = 'admin' LIMIT 1")).rowCount === 0
+			const target = (await client.query("SELECT role FROM auth WHERE username = $1", [username])).rows[0]
+			const allowed = noAdmin && !target
+			if (!allowed) return { rowCount: 0 }
+			const upsert = await client.query(
+				"INSERT INTO auth(username, hash, role) VALUES ($1, $2, 'admin') ON CONFLICT (username) DO UPDATE SET hash = EXCLUDED.hash, role = 'admin', force_password_change = FALSE, temp_password_expires = NULL",
 				[username, hash]
 			)
+			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1", [username])
+			return upsert
 		})
 		if (result.rowCount === 0) return res.status(403).json({ error: true })
 		auth.invalidateUser(username)

--- a/command/e2e/auth.spec.js
+++ b/command/e2e/auth.spec.js
@@ -3,12 +3,13 @@ const { json, mockApi } = require("./api")
 
 test.describe("authentication", () => {
 	test("first-time setup form is shown and submits", async ({ page }) => {
-		await mockApi(page, { "GET /authorization/status": json({ setup: false, tokenRequired: false }) })
+		await mockApi(page, { "GET /authorization/status": json({ setup: false, tokenRequired: true }) })
 		await page.goto("/")
 		await expect(page.getByText("Create your account")).toBeVisible()
 		await page.getByPlaceholder("username").fill("admin")
 		await page.getByPlaceholder("password", { exact: true }).fill("password123")
 		await page.getByPlaceholder("confirm password").fill("password123")
+		await page.getByPlaceholder("setup token").fill("boot-token")
 		await page.getByRole("button", { name: "Create Account" }).click()
 		await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible()
 	})
@@ -17,6 +18,13 @@ test.describe("authentication", () => {
 		await mockApi(page, { "GET /authorization/status": json({ setup: false, tokenRequired: true }) })
 		await page.goto("/")
 		await expect(page.getByPlaceholder("setup token")).toBeVisible()
+	})
+
+	test("setup is unavailable when no setup token is configured", async ({ page }) => {
+		await mockApi(page, { "GET /authorization/status": json({ setup: false, tokenRequired: false }) })
+		await page.goto("/")
+		await expect(page.getByText("Setup unavailable")).toBeVisible()
+		await expect(page.getByRole("button", { name: "Create Account" })).not.toBeVisible()
 	})
 
 	test("login page is shown when set up but not authenticated", async ({ page }) => {
@@ -44,7 +52,7 @@ test.describe("authentication", () => {
 	})
 
 	test("setup rejects a password shorter than 8 characters", async ({ page }) => {
-		await mockApi(page, { "GET /authorization/status": json({ setup: false, tokenRequired: false }) })
+		await mockApi(page, { "GET /authorization/status": json({ setup: false, tokenRequired: true }) })
 		await page.goto("/")
 		await page.getByPlaceholder("username").fill("admin")
 		await page.getByPlaceholder("password", { exact: true }).fill("short")

--- a/command/frontend/app/SetupForm.jsx
+++ b/command/frontend/app/SetupForm.jsx
@@ -35,6 +35,23 @@ const SetupForm = ({ trySetup, tokenRequired }) => {
 		if (e.key === "Enter") onSubmit()
 	}
 
+	if (!tokenRequired) {
+		return (
+			<div className="min-h-screen bg-bg flex items-center justify-center">
+				<Card className="w-80 bg-surface border-border">
+					<CardHeader className="items-center gap-2 pb-2">
+						<img src="/res/logo.png" alt="Chimera" className="h-12 w-12 object-contain" />
+						<CardTitle className="text-primary text-xl">Chimera</CardTitle>
+						<p className="text-muted text-sm">Setup unavailable</p>
+					</CardHeader>
+					<CardContent>
+						<p className="text-muted text-sm">Set the <code>setup_TOKEN</code> environment variable to create the admin account.</p>
+					</CardContent>
+				</Card>
+			</div>
+		)
+	}
+
 	return (
 		<div className="min-h-screen bg-bg flex items-center justify-center">
 			<Card className="w-80 bg-surface border-border">

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -37,25 +37,29 @@ describe("Authorization Routes", () => {
 	})
 
 	describe("POST /authorization/setup", () => {
-		test("returns 200 on first-time setup", async () => {
+		test("returns 200 on first-time setup with a valid setup_TOKEN", async () => {
+			process.env.setup_TOKEN = "boot-token"
 			const spy = jest.spyOn(auth, "invalidateUser")
+			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
+			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 0 }) // no admin exists
+			mockedPool.query.mockResolvedValueOnce({ rows: [] }) // target is a new user
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // upsert
 			const res = await supertest(app)
 				.post("/authorization/setup")
-				.send({ username: "admin", password: "password123" })
+				.send({ username: "admin", password: "password123", token: "boot-token" })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(spy).toHaveBeenCalled()
 		})
 
-		test("returns 403 when table already has a row", async () => {
-			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
-			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
-			mockedPool.query.mockResolvedValueOnce({ rowCount: 0 }) // INSERT
+		test("refuses setup when setup_TOKEN is not configured", async () => {
 			const res = await supertest(app)
 				.post("/authorization/setup")
 				.send({ username: "admin", password: "password123" })
 			expect(res.status).toBe(403)
 			expect(res.body).toEqual({ error: true })
+			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
 		})
 
 		test("allows admin recovery with a valid setup_TOKEN when no admin exists", async () => {

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -145,35 +145,39 @@ describe("Authorization Routes", () => {
 		})
 
 		test("returns 400 when username or password is missing", async () => {
+			process.env.setup_TOKEN = "boot-token"
 			const res = await supertest(app)
 				.post("/authorization/setup")
-				.send({ username: "admin" })
+				.send({ username: "admin", token: "boot-token" })
 			expect(res.status).toBe(400)
 			expect(res.body.error).toBe(true)
 		})
 
 		test("returns 400 for username containing slash", async () => {
+			process.env.setup_TOKEN = "boot-token"
 			const res = await supertest(app)
 				.post("/authorization/setup")
-				.send({ username: "bad/admin", password: "password123" })
+				.send({ username: "bad/admin", password: "password123", token: "boot-token" })
 			expect(res.status).toBe(400)
 			expect(res.body).toEqual({ error: true, errors: "Username must be 3-50 characters and contain only letters, numbers, dashes, dots, and underscores." })
 		})
 
 		test("returns 400 for a password shorter than 8 characters", async () => {
+			process.env.setup_TOKEN = "boot-token"
 			const res = await supertest(app)
 				.post("/authorization/setup")
-				.send({ username: "admin", password: "short" })
+				.send({ username: "admin", password: "short", token: "boot-token" })
 			expect(res.status).toBe(400)
 			expect(res.body).toEqual({ error: true, errors: "Password must be at least 8 characters." })
 		})
 
 		test("returns 500 when the transaction throws a generic error", async () => {
+			process.env.setup_TOKEN = "boot-token"
 			const errSpy = jest.spyOn(console, "error").mockImplementation(() => {})
 			mockedPool.query.mockRejectedValueOnce(new Error("db down"))
 			const res = await supertest(app)
 				.post("/authorization/setup")
-				.send({ username: "admin", password: "password123" })
+				.send({ username: "admin", password: "password123", token: "boot-token" })
 			expect(res.status).toBe(500)
 			expect(res.body).toEqual({ error: true })
 			expect(errSpy).toHaveBeenCalled()

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -284,6 +284,27 @@ describe("Authorization Routes", () => {
 		})
 	})
 
+	describe("CSRF protection on cookie-authed routes", () => {
+		const token = jwt.sign({ username: "test", role: "user", jti: "jti-user" }, "test-secret")
+
+		test("rejects a cross-site POST with 403", async () => {
+			const res = await supertest(app)
+				.post("/authorization/verify")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.set("Sec-Fetch-Site", "cross-site")
+			expect(res.status).toBe(403)
+			expect(res.body).toEqual({ error: "forbidden" })
+		})
+
+		test("allows a same-origin POST", async () => {
+			const res = await supertest(app)
+				.post("/authorization/verify")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.set("Sec-Fetch-Site", "same-origin")
+			expect(res.status).toBe(200)
+		})
+	})
+
 	describe("PUT /authorization/theme", () => {
 		test("returns 401 with no token", async () => {
 			const res = await supertest(app).put("/authorization/theme").send({ theme: "light" })

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -838,6 +838,18 @@ describe("Authorization Routes", () => {
 			}
 			expect(res.status).toBe(400)
 		})
+
+		test("locks a single account across distinct IPs", async () => {
+			let res
+			for (let i = 0; i < 11; i++) {
+				res = await supertest(app)
+					.post("/authorization/login")
+					.set("X-Forwarded-For", `198.51.100.${100 + i}`)
+					.send({ username: "lockme", password: "wrongpassword" })
+			}
+			expect(res.status).toBe(429)
+			expect(res.body).toEqual({ error: true, errors: "Too many attempts" })
+		})
 	})
 
 	describe("rateLimit (shared memory instance)", () => {

--- a/lib/test/auth.test.js
+++ b/lib/test/auth.test.js
@@ -403,6 +403,66 @@ describe("makeAuthorize cross-process session invalidation", () => {
 	})
 })
 
+describe("makeAuthorize CSRF protection", () => {
+	const token = jwt.sign({ username: "bob", jti: "csrf-jti" }, process.env.SECRETKEY)
+	const activeRow = { rows: [{ role: "user", revoked: false, last_seen: new Date() }], rowCount: 1 }
+	const run = (headers, method = "POST") => {
+		const pool = { query: jest.fn().mockResolvedValue(activeRow) }
+		const authorize = createAuthorize(pool)
+		const req = { method, path: "/x", headers, cookies: { bearertoken: `Bearer ${token}` } }
+		const res = makeRes()
+		const next = jest.fn()
+		authorize(req, res, next)
+		return { pool, res, next }
+	}
+
+	test("rejects a cross-site unsafe request before touching the database", async () => {
+		const { pool, res, next } = run({ "sec-fetch-site": "cross-site" })
+		await new Promise(resolve => setImmediate(resolve))
+		expect(res.status).toHaveBeenCalledWith(403)
+		expect(res.send).toHaveBeenCalledWith({ error: "forbidden" })
+		expect(pool.query).not.toHaveBeenCalled()
+		expect(next).not.toHaveBeenCalled()
+	})
+
+	test("allows a same-origin unsafe request", async () => {
+		const { res, next } = run({ "sec-fetch-site": "same-origin" })
+		await new Promise(resolve => setImmediate(resolve))
+		expect(next).toHaveBeenCalled()
+		expect(res.status).not.toHaveBeenCalledWith(403)
+	})
+
+	test("allows a cross-site safe (GET) request", async () => {
+		const { next } = run({ "sec-fetch-site": "cross-site" }, "GET")
+		await new Promise(resolve => setImmediate(resolve))
+		expect(next).toHaveBeenCalled()
+	})
+
+	test("allows an unsafe request lacking both Sec-Fetch-Site and Origin", async () => {
+		const { next } = run({})
+		await new Promise(resolve => setImmediate(resolve))
+		expect(next).toHaveBeenCalled()
+	})
+
+	describe("Origin fallback when Sec-Fetch-Site is absent", () => {
+		beforeAll(() => { process.env.gateway_HOST = "cams.example.com" })
+		afterAll(() => { delete process.env.gateway_HOST })
+
+		test("rejects a mismatched Origin", async () => {
+			const { res, next } = run({ origin: "https://evil.example.net" })
+			await new Promise(resolve => setImmediate(resolve))
+			expect(res.status).toHaveBeenCalledWith(403)
+			expect(next).not.toHaveBeenCalled()
+		})
+
+		test("allows a matching Origin", async () => {
+			const { next } = run({ origin: "https://cams.example.com" })
+			await new Promise(resolve => setImmediate(resolve))
+			expect(next).toHaveBeenCalled()
+		})
+	})
+})
+
 describe("makeAuthorize forced password change", () => {
 	const token = jwt.sign({ username: "bob", jti: "s1" }, process.env.SECRETKEY)
 	const forcedPool = () => ({ query: jest.fn().mockResolvedValue({ rows: [{ role: "user", force_password_change: true, revoked: false }], rowCount: 1 }) })

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -1,6 +1,22 @@
 const secretKey = process.env.SECRETKEY
 const jwt = require("jsonwebtoken")
 const timingSafeCompare = require("./timingSafeCompare.js")
+const gatewayHost = require("./gatewayHost.js")
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"])
+const SAME_SITE_FETCH = new Set(["same-origin", "same-site", "none"])
+
+const hostOf = (url) => { try { return new URL(url).host } catch (e) { return null } }
+
+const isCrossSite = (req) => {
+	if (SAFE_METHODS.has(req.method)) return false
+	const site = req.headers["sec-fetch-site"]
+	if (site) return !SAME_SITE_FETCH.has(site)
+	const origin = req.headers.origin
+	if (!origin) return false
+	const expected = gatewayHost()
+	return !!expected && hostOf(origin) !== hostOf(expected)
+}
 
 const sessionCache = new Map()
 const SESSION_CACHE_MS = 5000
@@ -115,6 +131,7 @@ const makeAuthorize = (pool, { schedulableUrls = [], forcedChangeAllowed = [] } 
 	} else {
 		const bearerTokenCookie = req.cookies && req.cookies.bearertoken
 		if (bearerTokenCookie && bearerTokenCookie.includes("Bearer")) {
+			if (isCrossSite(req)) return res.status(403).send({ error: "forbidden" })
 			verifyJwt(bearerTokenCookie.split(/%20|\s+/)[1], req, res, next, pool, forcedChangeAllowed)
 		} else unauthorized()
 	}


### PR DESCRIPTION
Combines three authentication/authorization hardening fixes into one PR. Supersedes and closes #334, #336, and #332.

### Included changes

- **Require setup token for admin bootstrap** (#321): `/setup` is refused (403) when `setup_TOKEN` is unset or mismatched, removing the unauthenticated first-caller-wins admin bootstrap. `SetupForm` shows a "set `setup_TOKEN`" notice when no token is configured.
- **Per-account login lockout** (#320): adds a per-username attempt limiter alongside the existing per-IP one on `POST /login`, throttling a distributed attacker (many IPs, one account). `rateLimit` now takes an optional `keyFn`; the account limiter keys on the submitted username (10 failed attempts / 15 min) and releases on success like the IP limiter.
- **CSRF defense beyond SameSite cookie** (#324): adds an Origin / Sec-Fetch-Site cross-site check in the shared `makeAuthorize` choke point for unsafe methods; fails closed only on a clear cross-site signal, no frontend changes.

### Note

While combining, the four `/setup` validation tests from #334 were updated to pass a valid `setup_TOKEN` — the mandatory-token change made them hit the new 403 guard before reaching validation, which also leaked a queued mock rejection into a later login test. With that fix the full suite is green.

Validated: `command/test/authorization.test.js` + `lib/test/auth.test.js` — 124 passed.

Closes #320
Closes #321
Closes #324
