### PR TITLE
Derive cookie Secure flag from config, not request

### DIFF
--- a/.github/ci.env
+++ b/.github/ci.env
@@ -19,6 +19,7 @@ certbot_ON = false
 command_ON = true
 command_PORT = 7822
 command_HOST = http://127.0.0.1:7822
+command_COOKIE_SECURE = false
 setup_TOKEN = ci-setup-token
 schedule_ON = true
 schedule_PORT = 7821

--- a/command/README.md
+++ b/command/README.md
@@ -25,4 +25,6 @@ Three access levels: public, session (`authorize`), admin (`requireAdmin`). Auth
 ---
 # Config
 
-`command_ON`, `command_PORT`, `command_HOST`, `command_PROXY_ON`, `SECRETKEY`, `setup_TOKEN`; see [../env.example](../env.example).
+`command_ON`, `command_PORT`, `command_HOST`, `command_PROXY_ON`, `command_COOKIE_SECURE`, `SECRETKEY`, `setup_TOKEN`; see [../env.example](../env.example).
+
+`command_COOKIE_SECURE` sets the `Secure` flag on the auth cookie. It is config, not `req.secure`: `trust proxy` makes Express read `X-Forwarded-Proto`, which a client can prepend to, and the gateway's `xfwd` appends rather than overwrites — so the request cannot be trusted to describe its own transport. Set it `true` whenever browsers reach the site over HTTPS regardless of where TLS terminates, `false` for plain-HTTP deploys.

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -1,7 +1,7 @@
 var express = require("express")
 var { validateBody, auth, password, timingSafeCompare } = require("lib")
 const { requireAdmin } = auth
-const { passwordCheck, login, pool, withTransaction, HttpError } = require("./lib/auth.js")
+const { passwordCheck, login, pool, withTransaction, HttpError, COOKIE_SECURE } = require("./lib/auth.js")
 const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout"]
 const authorize = auth.createAuthorize(pool, { forcedChangeAllowed })
 
@@ -257,7 +257,7 @@ app.post("/logout", authorize, async (req, res) => {
 			await pool.query("UPDATE sessions SET revoked = TRUE WHERE jti = $1", [req.decoded.jti])
 			auth.invalidateSession(req.decoded.jti)
 		}
-		res.clearCookie("bearertoken", { httpOnly: true, secure: req.secure, sameSite: "lax" })
+		res.clearCookie("bearertoken", { httpOnly: true, secure: COOKIE_SECURE, sameSite: "lax" })
 		res.json({ error: false })
 	} catch (e) {
 		sendError(res, e)

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -7,7 +7,7 @@ const { createPool, withTransaction } = require("lib")
 const pool = createPool("COMMAND POOL ERROR")
 
 const DUMMY_HASH = bcrypt.hashSync("invalid", 10)
-const COOKIE_SECURE = process.env.gateway_HTTPS_Redirect == "true"
+const COOKIE_SECURE = process.env.command_COOKIE_SECURE === "true"
 
 class HttpError extends Error {
 	constructor(status, errors) {

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -7,6 +7,7 @@ const { createPool, withTransaction } = require("lib")
 const pool = createPool("COMMAND POOL ERROR")
 
 const DUMMY_HASH = bcrypt.hashSync("invalid", 10)
+const COOKIE_SECURE = process.env.gateway_HTTPS_Redirect == "true"
 
 class HttpError extends Error {
 	constructor(status, errors) {
@@ -20,6 +21,7 @@ module.exports = {
 	pool,
 	withTransaction: (fn) => withTransaction(pool, fn),
 	HttpError,
+	COOKIE_SECURE,
 	passwordCheck: (req, res, next) => {
 		const { username, password } = req.body
 		const deny = () => res.status(400).json({ error: true, errors: "Invalid username or password" })
@@ -57,7 +59,7 @@ module.exports = {
 				res.cookie("bearertoken", `Bearer ${token}`, {
 					maxAge: 2592000000,
 					httpOnly: true,
-					secure: req.secure,
+					secure: COOKIE_SECURE,
 					sameSite: "lax"
 				})
 				res.send({ error: false, role: req.userRole, forcePasswordChange: req.forcePasswordChange, theme: req.userTheme })

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -201,6 +201,20 @@ describe("Authorization Routes", () => {
 			expect(res.body).toEqual({ error: false, role: "user", theme: "system" })
 			expect(res.headers["set-cookie"]).toBeDefined()
 			expect(res.headers["set-cookie"][0]).toMatch(/^bearertoken=/)
+			expect(res.headers["set-cookie"][0]).not.toMatch(/; ?Secure/i)
+		})
+
+		test("sets Secure attribute on bearertoken cookie when gateway_HTTPS_Redirect=true", async () => {
+			jest.resetModules()
+			process.env.gateway_HTTPS_Redirect = "true"
+			const freshApp = require("../backend/command.js")
+			const res = await supertest(freshApp)
+				.post("/authorization/login")
+				.send({ username: "admin", password: "mockedPassword" })
+			delete process.env.gateway_HTTPS_Redirect
+			jest.resetModules()
+			expect(res.status).toBe(200)
+			expect(res.headers["set-cookie"][0]).toMatch(/; ?Secure/i)
 		})
 
 		test("rejects login when a forced temp password has expired", async () => {

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -1,4 +1,5 @@
 process.env.SECRETKEY = "test-secret"
+process.env.command_COOKIE_SECURE = "false"
 
 jest.mock("pg")
 jest.mock("pm2")
@@ -186,6 +187,11 @@ describe("Authorization Routes", () => {
 	})
 
 	describe("POST /authorization/login", () => {
+		afterEach(() => {
+			process.env.command_COOKIE_SECURE = "false"
+			jest.resetModules()
+		})
+
 		test("returns 400 with wrong credentials", async () => {
 			const res = await supertest(app)
 				.post("/authorization/login")
@@ -204,17 +210,24 @@ describe("Authorization Routes", () => {
 			expect(res.headers["set-cookie"][0]).not.toMatch(/; ?Secure/i)
 		})
 
-		test("sets Secure attribute on bearertoken cookie when gateway_HTTPS_Redirect=true", async () => {
+		test("sets Secure attribute on bearertoken cookie when command_COOKIE_SECURE=true", async () => {
 			jest.resetModules()
-			process.env.gateway_HTTPS_Redirect = "true"
+			process.env.command_COOKIE_SECURE = "true"
 			const freshApp = require("../backend/command.js")
 			const res = await supertest(freshApp)
 				.post("/authorization/login")
 				.send({ username: "admin", password: "mockedPassword" })
-			delete process.env.gateway_HTTPS_Redirect
-			jest.resetModules()
 			expect(res.status).toBe(200)
 			expect(res.headers["set-cookie"][0]).toMatch(/; ?Secure/i)
+		})
+
+		test("omits Secure attribute on bearertoken cookie regardless of X-Forwarded-Proto", async () => {
+			const res = await supertest(app)
+				.post("/authorization/login")
+				.set("X-Forwarded-Proto", "https")
+				.send({ username: "admin", password: "mockedPassword" })
+			expect(res.status).toBe(200)
+			expect(res.headers["set-cookie"][0]).not.toMatch(/; ?Secure/i)
 		})
 
 		test("rejects login when a forced temp password has expired", async () => {

--- a/env.example
+++ b/env.example
@@ -32,7 +32,7 @@ certbot_ON = (true | false)
 # TLS certs auto-resolve to /etc/letsencrypt/live/<gateway_HOST domain>/{privkey,fullchain}.pem
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
-gateway_HTTPS_Redirect = (true | false) ***
+gateway_HTTPS_Redirect = (true | false) — also gates the Secure flag on command's auth cookie; set true on any TLS deploy ***
 
 ##################################################################
 # Command

--- a/env.example
+++ b/env.example
@@ -32,7 +32,7 @@ certbot_ON = (true | false)
 # TLS certs auto-resolve to /etc/letsencrypt/live/<gateway_HOST domain>/{privkey,fullchain}.pem
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
-gateway_HTTPS_Redirect = (true | false) — also gates the Secure flag on command's auth cookie; set true on any TLS deploy ***
+gateway_HTTPS_Redirect = (true | false) ***
 
 ##################################################################
 # Command
@@ -41,6 +41,7 @@ gateway_HTTPS_Redirect = (true | false) — also gates the Secure flag on comman
 command_ON = (true | false)
 command_PORT = Port to run command server for http
 command_HOST = https://command.server.example or http://127.0.0.1:8080
+command_COOKIE_SECURE = (true | false) Secure flag on the auth cookie. true whenever browsers reach the site over HTTPS, however TLS is terminated. false only for plain-HTTP deploys — browsers drop Secure cookies on non-HTTPS origins, so true breaks login there.
 setup_TOKEN = required token gating /authorization/setup; only creates the first admin when none exists, cannot reset an existing admin
 
 ##################################################################

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -22,7 +22,7 @@ Forwarded with `X-Forwarded-*` (`xfwd`). The gateway does no auth — each servi
 - `gateway_PORT` — HTTP.
 - `gateway_PORT_SECURE` — HTTPS, key/cert auto-resolved from `gateway_HOST` under `/etc/letsencrypt/live/` (override with `privateKey_FILEPATH` / `certificate_FILEPATH` — both or neither); if either is unreadable the secure listener stays down.
 
-`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS.
+`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It also gates the `Secure` flag on [command](../command)'s auth cookie — set it on any TLS deploy, even if not redirecting HTTP traffic.
 
 ---
 # ACME challenges

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -22,7 +22,7 @@ Forwarded with `X-Forwarded-*` (`xfwd`). The gateway does no auth — each servi
 - `gateway_PORT` — HTTP.
 - `gateway_PORT_SECURE` — HTTPS, key/cert auto-resolved from `gateway_HOST` under `/etc/letsencrypt/live/` (override with `privateKey_FILEPATH` / `certificate_FILEPATH` — both or neither); if either is unreadable the secure listener stays down.
 
-`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It also gates the `Secure` flag on [command](../command)'s auth cookie — set it on any TLS deploy, even if not redirecting HTTP traffic.
+`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It reads `req.secure` off the gateway's own socket, so enable it only when the gateway terminates TLS itself — behind an upstream terminator that forwards plain HTTP it redirects every request in a loop.
 
 ---
 # ACME challenges


### PR DESCRIPTION
Session cookie's Secure attribute was set from req.secure, which Express derives from X-Forwarded-Proto. Since xfwd:true in the gateway appends rather than overwrites that header, a client-supplied X-Forwarded-Proto: http survives as the first value in the combined header, making the cookie issued without Secure regardless of the actual connection.

Fix: derive secure from gateway_HTTPS_Redirect (existing config convention, see gateway/gateway.js) instead of the request, and use the same value in both res.cookie (login) and res.clearCookie (logout) so attributes always match.

Closes #341