### PR TITLE
Validate existing schema columns in prepareDatabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npm run docker:up
 <details>
 <summary><b>Database schema</b></summary>
 
-Created idempotently by [prepareDatabase.js](chimera/prepareDatabase.js). Full config in [env.example](env.example).
+Created by [prepareDatabase.js](chimera/prepareDatabase.js): tables/indexes are created if missing, and an existing table is verified against the expected columns rather than assumed correct. Full config in [env.example](env.example).
 
 | Tables | Owner |
 |---|---|
@@ -108,5 +108,7 @@ Created idempotently by [prepareDatabase.js](chimera/prepareDatabase.js). Full c
 | `auth` · `sessions` | command |
 | `objects_detected` | object |
 | `task_runs` | schedule |
+
+**v6.0.0:** the `auth` table shape changed — there is no upgrade path from a v5 database. `prepareDatabase.js` now exits `1` and lists missing columns instead of booting against a stale schema. Run `npm run docker:delete` to drop the volume and start fresh (this destroys existing data).
 
 </details>

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npm run docker:up
 <details>
 <summary><b>Database schema</b></summary>
 
-Created by [prepareDatabase.js](chimera/prepareDatabase.js): tables/indexes are created if missing, and an existing table is verified against the expected columns rather than assumed correct. Full config in [env.example](env.example).
+Created by [prepareDatabase.js](chimera/prepareDatabase.js): tables/indexes are created if missing, and an existing table's column names (not types) are checked against what's expected rather than assumed correct. Full config in [env.example](env.example).
 
 | Tables | Owner |
 |---|---|

--- a/chimera/README.md
+++ b/chimera/README.md
@@ -26,7 +26,9 @@ Checks every required env var — all checks run (no short-circuit), so one run 
 ---
 # prepareDatabase.js
 
-Connects with `database_*` and runs each `CREATE TABLE`/`INDEX` once — idempotent (existing table → `42P07`, treated as success; indexes use `IF NOT EXISTS`). Any other error exits `1`.
+Connects with `database_*` and runs each `CREATE TABLE`/`INDEX` once. An existing table (`42P07`) is checked against `information_schema.columns` for the expected v6 columns — only a match is treated as success; missing columns exit `1` and list what's missing. Indexes use `IF NOT EXISTS`. Any other error exits `1`.
+
+No v5 → v6 upgrade path: v6 changed the `auth` table shape, so a v5 database will fail this check. Run `npm run docker:delete` to drop the volume and start fresh.
 
 Tables (owner): `frame_files`, `frame_deletes` (storage) · `auth`, `sessions` (command) · `objects_detected` (object) · `task_runs`, `scheduled_tasks` (schedule). Plus five indexes: `frame_files(camera, timestamp)`, `frame_files(timestamp)`, `objects_detected(camera, timestamp)`, `task_runs(ran_at)`, and `sessions(username)`.
 

--- a/chimera/README.md
+++ b/chimera/README.md
@@ -26,7 +26,7 @@ Checks every required env var — all checks run (no short-circuit), so one run 
 ---
 # prepareDatabase.js
 
-Connects with `database_*` and runs each `CREATE TABLE`/`INDEX` once. An existing table (`42P07`) is checked against `information_schema.columns` for the expected v6 columns — only a match is treated as success; missing columns exit `1` and list what's missing. Indexes use `IF NOT EXISTS`. Any other error exits `1`.
+Connects with `database_*` and runs each `CREATE TABLE`/`INDEX` once. An existing table (`42P07`) has its column names (not types) checked against `information_schema.columns` for the expected v6 shape — only a match is treated as success; missing columns exit `1` and list what's missing. Indexes use `IF NOT EXISTS`. Any other error exits `1`.
 
 No v5 → v6 upgrade path: v6 changed the `auth` table shape, so a v5 database will fail this check. Run `npm run docker:delete` to drop the volume and start fresh.
 

--- a/chimera/prepareDatabase.js
+++ b/chimera/prepareDatabase.js
@@ -12,31 +12,45 @@ const pool = new Pool({
 const creationTasks = [
 	{
 		query: "CREATE TABLE frame_files(ID SERIAL PRIMARY KEY, timestamp TIMESTAMPTZ, camera NUMERIC(10), name VARCHAR, size NUMERIC);",
-		description: "frame files table"
+		description: "frame files table",
+		table: "frame_files",
+		columns: ["id", "timestamp", "camera", "name", "size"],
 	},
 	{
 		query: "CREATE TABLE frame_deletes(ID SERIAL PRIMARY KEY, timestamp TIMESTAMPTZ, camera NUMERIC(10), size NUMERIC, count NUMERIC);",
-		description: "frame deletions table"
+		description: "frame deletions table",
+		table: "frame_deletes",
+		columns: ["id", "timestamp", "camera", "size", "count"],
 	},
 	{
 		query: "CREATE TABLE auth(ID SERIAL PRIMARY KEY, username VARCHAR(50) UNIQUE, hash VARCHAR, role VARCHAR(10) NOT NULL DEFAULT 'user', last_login TIMESTAMPTZ, force_password_change BOOLEAN NOT NULL DEFAULT FALSE, temp_password_expires TIMESTAMPTZ, theme VARCHAR(10) DEFAULT 'system');",
-		description: "authorization table"
+		description: "authorization table",
+		table: "auth",
+		columns: ["id", "username", "hash", "role", "last_login", "force_password_change", "temp_password_expires", "theme"],
 	},
 	{
 		query: "CREATE TABLE sessions(ID SERIAL PRIMARY KEY, username VARCHAR(50) REFERENCES auth(username) ON DELETE CASCADE, jti VARCHAR UNIQUE NOT NULL, issued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), last_seen TIMESTAMPTZ, ip VARCHAR(45), user_agent TEXT, revoked BOOLEAN NOT NULL DEFAULT FALSE);",
-		description: "sessions table"
+		description: "sessions table",
+		table: "sessions",
+		columns: ["id", "username", "jti", "issued_at", "last_seen", "ip", "user_agent", "revoked"],
 	},
 	{
 		query: "CREATE TABLE objects_detected(ID SERIAL PRIMARY KEY, camera NUMERIC(10), timestamp TIMESTAMPTZ DEFAULT NOW(), type VARCHAR(20), confidence NUMERIC(10, 6), box JSONB, image VARCHAR);",
-		description: "objects detected table"
+		description: "objects detected table",
+		table: "objects_detected",
+		columns: ["id", "camera", "timestamp", "type", "confidence", "box", "image"],
 	},
 	{
 		query: "CREATE TABLE task_runs(id SERIAL PRIMARY KEY, task_id TEXT NOT NULL, url TEXT NOT NULL, status TEXT NOT NULL, http_status INTEGER, error TEXT, ran_at TIMESTAMPTZ NOT NULL DEFAULT NOW());",
-		description: "task runs table"
+		description: "task runs table",
+		table: "task_runs",
+		columns: ["id", "task_id", "url", "status", "http_status", "error", "ran_at"],
 	},
 	{
 		query: "CREATE TABLE scheduled_tasks(id TEXT PRIMARY KEY, url TEXT NOT NULL, body JSONB NOT NULL, cron_string TEXT NOT NULL, running BOOLEAN NOT NULL DEFAULT TRUE, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW());",
-		description: "scheduled tasks table"
+		description: "scheduled tasks table",
+		table: "scheduled_tasks",
+		columns: ["id", "url", "body", "cron_string", "running", "created_at"],
 	},
 	{
 		query: "CREATE INDEX IF NOT EXISTS idx_frame_files_camera_timestamp ON frame_files(camera, timestamp);",
@@ -60,21 +74,37 @@ const creationTasks = [
 	},
 ]
 
-module.exports = { creationTasks }
+async function missingColumns(table, columns) {
+	const { rows } = await pool.query(
+		"SELECT column_name FROM information_schema.columns WHERE table_name = $1",
+		[table]
+	)
+	const existing = new Set(rows.map((r) => r.column_name))
+	return columns.filter((c) => !existing.has(c))
+}
+
+module.exports = { creationTasks, missingColumns }
 
 if (require.main === module) {
 	let issues = false
 	;(async () => {
-		for (const { query, description } of creationTasks) {
-			let tableExists
+		for (const { query, description, table, columns } of creationTasks) {
+			let ok
+			let detail = ""
 			try {
 				await pool.query(query)
-				tableExists = true
+				ok = true
 			} catch (e) {
-				tableExists = e && e.code == "42P07"
+				if (e && e.code == "42P07" && table) {
+					const missing = await missingColumns(table, columns)
+					ok = missing.length === 0
+					if (!ok) detail = ` — missing columns: ${missing.join(", ")}`
+				} else {
+					ok = false
+				}
 			}
-			if (!tableExists) issues = true
-			console.log(`${description} ${tableExists ? "✔️" : "❌"}`)
+			if (!ok) issues = true
+			console.log(`${description} ${ok ? "✔️" : "❌"}${detail}`)
 		}
 		process.exit(issues ? 1 : 0)
 	})()

--- a/chimera/prepareDatabase.js
+++ b/chimera/prepareDatabase.js
@@ -76,7 +76,7 @@ const creationTasks = [
 
 async function missingColumns(table, columns) {
 	const { rows } = await pool.query(
-		"SELECT column_name FROM information_schema.columns WHERE table_name = $1 AND table_schema = ANY(current_schemas(false))",
+		"SELECT column_name FROM information_schema.columns WHERE table_name = $1 AND table_schema = current_schema()",
 		[table]
 	)
 	const existing = new Set(rows.map((r) => r.column_name))
@@ -103,6 +103,7 @@ async function runCreationTasks() {
 				}
 			} else {
 				ok = false
+				if (e) detail = ` — ${e.message || e.code || e}`
 			}
 		}
 		if (!ok) issues = true
@@ -114,5 +115,10 @@ async function runCreationTasks() {
 module.exports = { creationTasks, missingColumns, runCreationTasks }
 
 if (require.main === module) {
-	runCreationTasks().then((issues) => process.exit(issues ? 1 : 0))
+	runCreationTasks()
+		.then((issues) => process.exit(issues ? 1 : 0))
+		.catch((e) => {
+			console.error(e)
+			process.exit(1)
+		})
 }

--- a/chimera/prepareDatabase.js
+++ b/chimera/prepareDatabase.js
@@ -76,36 +76,43 @@ const creationTasks = [
 
 async function missingColumns(table, columns) {
 	const { rows } = await pool.query(
-		"SELECT column_name FROM information_schema.columns WHERE table_name = $1",
+		"SELECT column_name FROM information_schema.columns WHERE table_name = $1 AND table_schema = ANY(current_schemas(false))",
 		[table]
 	)
 	const existing = new Set(rows.map((r) => r.column_name))
 	return columns.filter((c) => !existing.has(c))
 }
 
-module.exports = { creationTasks, missingColumns }
-
-if (require.main === module) {
+async function runCreationTasks() {
 	let issues = false
-	;(async () => {
-		for (const { query, description, table, columns } of creationTasks) {
-			let ok
-			let detail = ""
-			try {
-				await pool.query(query)
-				ok = true
-			} catch (e) {
-				if (e && e.code == "42P07" && table) {
+	for (const { query, description, table, columns } of creationTasks) {
+		let ok
+		let detail = ""
+		try {
+			await pool.query(query)
+			ok = true
+		} catch (e) {
+			if (e && e.code == "42P07" && table) {
+				try {
 					const missing = await missingColumns(table, columns)
 					ok = missing.length === 0
-					if (!ok) detail = ` — missing columns: ${missing.join(", ")}`
-				} else {
+					if (!ok) detail = ` — missing columns: ${missing.join(", ")}. Run 'npm run docker:delete' to reset the database.`
+				} catch (schemaError) {
 					ok = false
+					detail = ` — failed to verify schema: ${schemaError.message}`
 				}
+			} else {
+				ok = false
 			}
-			if (!ok) issues = true
-			console.log(`${description} ${ok ? "✔️" : "❌"}${detail}`)
 		}
-		process.exit(issues ? 1 : 0)
-	})()
+		if (!ok) issues = true
+		console.log(`${description} ${ok ? "✔️" : "❌"}${detail}`)
+	}
+	return issues
+}
+
+module.exports = { creationTasks, missingColumns, runCreationTasks }
+
+if (require.main === module) {
+	runCreationTasks().then((issues) => process.exit(issues ? 1 : 0))
 }

--- a/chimera/test/prepareDatabase.test.js
+++ b/chimera/test/prepareDatabase.test.js
@@ -1,8 +1,9 @@
 jest.mock("pg", () => ({ Pool: jest.fn(() => ({ query: jest.fn(), on: jest.fn() })) }))
 
 const { Pool } = require("pg")
-const { creationTasks } = require("../prepareDatabase.js")
+const { creationTasks, missingColumns } = require("../prepareDatabase.js")
 const poolConfig = Pool.mock.calls[0][0]
+const poolInstance = Pool.mock.results[0].value
 
 describe("prepareDatabase migration tasks", () => {
 	const find = (re) => creationTasks.find(t => re.test(t.query))
@@ -37,5 +38,25 @@ describe("prepareDatabase migration tasks", () => {
 			expect(typeof t.query).toBe("string")
 			expect(typeof t.description).toBe("string")
 		}
+	})
+
+	test("every CREATE TABLE task carries its table name and columns", () => {
+		for (const t of creationTasks.filter(t => /CREATE TABLE/.test(t.query))) {
+			expect(typeof t.table).toBe("string")
+			expect(Array.isArray(t.columns)).toBe(true)
+			expect(t.columns.length).toBeGreaterThan(0)
+		}
+	})
+
+	test("missingColumns reports columns absent from information_schema", async () => {
+		poolInstance.query.mockResolvedValueOnce({ rows: [{ column_name: "id" }, { column_name: "username" }, { column_name: "hash" }] })
+		const missing = await missingColumns("auth", ["id", "username", "hash", "role", "theme"])
+		expect(missing).toEqual(["role", "theme"])
+	})
+
+	test("missingColumns reports nothing when the schema matches", async () => {
+		poolInstance.query.mockResolvedValueOnce({ rows: [{ column_name: "id" }, { column_name: "url" }] })
+		const missing = await missingColumns("scheduled_tasks", ["id", "url"])
+		expect(missing).toEqual([])
 	})
 })

--- a/chimera/test/prepareDatabase.test.js
+++ b/chimera/test/prepareDatabase.test.js
@@ -1,7 +1,7 @@
 jest.mock("pg", () => ({ Pool: jest.fn(() => ({ query: jest.fn(), on: jest.fn() })) }))
 
 const { Pool } = require("pg")
-const { creationTasks, missingColumns } = require("../prepareDatabase.js")
+const { creationTasks, missingColumns, runCreationTasks } = require("../prepareDatabase.js")
 const poolConfig = Pool.mock.calls[0][0]
 const poolInstance = Pool.mock.results[0].value
 
@@ -58,5 +58,47 @@ describe("prepareDatabase migration tasks", () => {
 		poolInstance.query.mockResolvedValueOnce({ rows: [{ column_name: "id" }, { column_name: "url" }] })
 		const missing = await missingColumns("scheduled_tasks", ["id", "url"])
 		expect(missing).toEqual([])
+	})
+})
+
+describe("runCreationTasks", () => {
+	const columnRows = (columns) => ({ rows: columns.map((c) => ({ column_name: c })) })
+
+	beforeEach(() => {
+		poolInstance.query.mockReset()
+	})
+
+	test("an existing table (42P07) with all expected columns reports ok", async () => {
+		poolInstance.query.mockImplementation((query, params) => {
+			if (/information_schema/.test(query)) {
+				const task = creationTasks.find((t) => t.table === params[0])
+				return Promise.resolve(columnRows(task.columns))
+			}
+			if (/CREATE TABLE/.test(query)) return Promise.reject({ code: "42P07" })
+			return Promise.resolve({ rows: [] })
+		})
+		const issues = await runCreationTasks()
+		expect(issues).toBe(false)
+	})
+
+	test("an existing table (42P07) missing expected columns reports issues", async () => {
+		poolInstance.query.mockImplementation((query, params) => {
+			if (/information_schema/.test(query)) {
+				return params[0] === "auth" ? Promise.resolve(columnRows(["id", "username", "hash", "role"])) : Promise.resolve(columnRows(["id"]))
+			}
+			if (/CREATE TABLE/.test(query)) return Promise.reject({ code: "42P07" })
+			return Promise.resolve({ rows: [] })
+		})
+		const issues = await runCreationTasks()
+		expect(issues).toBe(true)
+	})
+
+	test("a schema-check failure after 42P07 reports issues instead of throwing", async () => {
+		poolInstance.query.mockImplementation((query) => {
+			if (/information_schema/.test(query)) return Promise.reject(new Error("connection lost"))
+			if (/CREATE TABLE/.test(query)) return Promise.reject({ code: "42P07" })
+			return Promise.resolve({ rows: [] })
+		})
+		await expect(runCreationTasks()).resolves.toBe(true)
 	})
 })

--- a/chimera/test/prepareDatabase.test.js
+++ b/chimera/test/prepareDatabase.test.js
@@ -48,6 +48,31 @@ describe("prepareDatabase migration tasks", () => {
 		}
 	})
 
+	const ddlColumns = (body) => {
+		const defs = []
+		let depth = 0
+		let cur = ""
+		for (const ch of body) {
+			if (ch === "(") depth++
+			else if (ch === ")") depth--
+			else if (ch === "," && depth === 0) {
+				defs.push(cur)
+				cur = ""
+				continue
+			}
+			cur += ch
+		}
+		defs.push(cur)
+		return defs.map(d => d.trim().split(/\s+/)[0].toLowerCase())
+	}
+
+	test("every CREATE TABLE task's table and columns match its DDL", () => {
+		for (const t of creationTasks.filter(t => /CREATE TABLE/.test(t.query))) {
+			const [, name, body] = /CREATE TABLE (\w+)\((.*)\);/.exec(t.query)
+			expect([t.table, t.columns]).toEqual([name.toLowerCase(), ddlColumns(body)])
+		}
+	})
+
 	test("missingColumns reports columns absent from information_schema", async () => {
 		poolInstance.query.mockResolvedValueOnce({ rows: [{ column_name: "id" }, { column_name: "username" }, { column_name: "hash" }] })
 		const missing = await missingColumns("auth", ["id", "username", "hash", "role", "theme"])
@@ -91,6 +116,14 @@ describe("runCreationTasks", () => {
 		})
 		const issues = await runCreationTasks()
 		expect(issues).toBe(true)
+	})
+
+	test("a non-42P07 failure reports the underlying error", async () => {
+		const log = jest.spyOn(console, "log").mockImplementation(() => {})
+		poolInstance.query.mockRejectedValue(Object.assign(new Error("permission denied for schema public"), { code: "42501" }))
+		await expect(runCreationTasks()).resolves.toBe(true)
+		expect(log).toHaveBeenCalledWith(expect.stringContaining("permission denied for schema public"))
+		log.mockRestore()
 	})
 
 	test("a schema-check failure after 42P07 reports issues instead of throwing", async () => {


### PR DESCRIPTION
## Summary
- `prepareDatabase.js` no longer treats `42P07` (table already exists) as automatic success. It now checks the existing table's columns against `information_schema.columns` for the expected v6 schema, exits 1, and lists exactly which columns are missing if it doesn't match.
- Documented in README.md and chimera/README.md that v6 has no upgrade path from v5, and that `npm run docker:delete` drops the volume to start fresh.

## Why
On a v5 database, `CREATE TABLE auth(...)` fails with `42P07` (table exists), which was caught and printed as `✔️`. Boot proceeded, but the v5 `auth` table shape is missing v6 columns (`role`, `temp_password_expires`, etc.), so every login 500s with `42703 undefined_column`. Nothing told the operator to start fresh.

## Test plan
- [x] `npx eslint chimera/prepareDatabase.js chimera/test/prepareDatabase.test.js` — clean
- [x] `npx jest --selectProjects chimera` — 87 passed, including new tests covering `missingColumns`

Closes #339