### PR TITLE
Pass real pm2 status through livestream status dot

### DIFF
--- a/command/frontend/app/LiveVideo.jsx
+++ b/command/frontend/app/LiveVideo.jsx
@@ -56,7 +56,7 @@ const Feed = ({ video, hideLabel }) => (
 			<div className="pointer-events-none absolute left-2 top-2 flex items-center gap-1.5 rounded-md bg-black/55 px-2 py-0.5 backdrop-blur-sm">
 				<span
 					className={cn("size-2 rounded-full shrink-0", video.online ? "bg-emerald-500" : "bg-danger pointer-events-auto")}
-					title={video.online ? undefined : `Offline${video.restarts ? ` · ${video.restarts} restarts` : ""}`}
+					title={video.online ? undefined : `Offline${video.restarts ? ` · ${video.restarts} restart${video.restarts === 1 ? "" : "s"}` : ""}`}
 				/>
 				<span className="text-sm font-medium text-white">{video.camera}</span>
 			</div>

--- a/command/frontend/app/LiveVideo.jsx
+++ b/command/frontend/app/LiveVideo.jsx
@@ -54,7 +54,10 @@ const Feed = ({ video, hideLabel }) => (
 		<HlsPlayer src={video.url} className="absolute inset-0 h-full w-full object-contain" />
 		{!hideLabel && (
 			<div className="pointer-events-none absolute left-2 top-2 flex items-center gap-1.5 rounded-md bg-black/55 px-2 py-0.5 backdrop-blur-sm">
-				<span className={cn("size-2 rounded-full shrink-0", video.online ? "bg-emerald-500" : "bg-danger")} />
+				<span
+					className={cn("size-2 rounded-full shrink-0", video.online ? "bg-emerald-500" : "bg-danger pointer-events-auto")}
+					title={video.online ? undefined : `Offline${video.restarts ? ` · ${video.restarts} restarts` : ""}`}
+				/>
 				<span className="text-sm font-medium text-white">{video.camera}</span>
 			</div>
 		)}

--- a/command/frontend/hooks/useLiveVideo.js
+++ b/command/frontend/hooks/useLiveVideo.js
@@ -68,6 +68,8 @@ const useLiveVideo = (cameras) => {
 
 	useEffect(() => {
 		refresh()
+		const id = setInterval(refresh, 5000)
+		return () => clearInterval(id)
 	}, [cameras])
 
 	return [state, refresh, restartAll]

--- a/command/frontend/hooks/useLiveVideo.js
+++ b/command/frontend/hooks/useLiveVideo.js
@@ -14,18 +14,19 @@ const listVideos = (cameras, setState, seqRef) => {
 	}, (prom) => {
 		jsonProcessing(prom, (data) => {
 			if (seq !== seqRef.current) return
-			const nums = (Array.isArray(data) ? data : [])
-				.map((cam) => parseInt(cam.name.split("_")[3]))
-				.sort((a, b) => a - b)
+			const streams = (Array.isArray(data) ? data : [])
+				.map((cam) => ({ ...cam, num: parseInt(cam.name.split("_")[3]) }))
+				.sort((a, b) => a.num - b.num)
 			setState((old) => ({
 				...old,
 				loading: false,
 				lastUpdated: moment().format("h:mm:ss a"),
-				videoList: nums.map((num) => {
+				videoList: streams.map(({ num, status, restarts }) => {
 					const cam = cameras.find((c) => c.id === num)
 					return {
 						camera: cam ? cam.name : `Camera ${num}`,
-						online: true,
+						online: status === "online",
+						restarts,
 						url: `/livestream/feed/${num}/video.m3u8`
 					}
 				})

--- a/lib/utils/subprocess.js
+++ b/lib/utils/subprocess.js
@@ -39,7 +39,7 @@ const getProcessList = (processName, callback) => {
 		if(processName){
 			processList = processList.filter((p) => {
 				return p.name && p.name.includes(processName)
-			}).map(({name, pm2_env}) => ({name, status: pm2_env.status, restarts: pm2_env.unstable_restarts}))
+			}).map(({name, pm2_env}) => ({name, status: pm2_env.status, restarts: pm2_env.restart_time}))
 		}
 		callback({processList})
 	})

--- a/livestream/__mocks__/pm2.js
+++ b/livestream/__mocks__/pm2.js
@@ -5,8 +5,8 @@ module.exports = {
 		callback(null, processNames.map((name) => ({
 			name,
 			pm2_env: {
-				status: "on",
-				unstable_restarts: 0
+				status: "online",
+				restart_time: 0
 			}
 		})))
 	},

--- a/livestream/test/livestream.test.js
+++ b/livestream/test/livestream.test.js
@@ -3,7 +3,7 @@ const app = require("../backend/livestream.js")
 
 const processList = [1, 2, 3].map((i) => ({
 	name: `live_stream_cam_${i}`,
-	status: "on",
+	status: "online",
 	restarts: 0
 }))
 

--- a/storage/__mocks__/pm2.js
+++ b/storage/__mocks__/pm2.js
@@ -3,8 +3,8 @@ module.exports = {
 		callback(null, [{
 			name: "motion",
 			pm2_env: {
-				status: "on",
-				unstable_restarts: 0
+				status: "online",
+				restart_time: 0
 			}
 		}])
 	},

--- a/storage/test/motion.test.js
+++ b/storage/test/motion.test.js
@@ -8,7 +8,7 @@ jest.mock("pm2")
 
 const processList = [{
 	name: "motion",
-	status: "on",
+	status: "online",
 	restarts: 0
 }]
 


### PR DESCRIPTION
useLiveVideo hardcoded online: true for every camera, so the live view dot never reflected a dead stream. Now it keeps the status/restarts fields the backend already returns from processListMiddleware and sets online: status === "online". Offline dots get a native title tooltip with the restart count.

Closes #340