### PR TITLE
Require admin for livestream restart (#354)

### DIFF
--- a/command/frontend/app/LiveVideo.jsx
+++ b/command/frontend/app/LiveVideo.jsx
@@ -4,6 +4,7 @@ import useLiveVideo from "../hooks/useLiveVideo.js"
 import useCameras from "../hooks/useCameras.js"
 import useSquarifyVideos from "../hooks/useSquarifyVideo.js"
 import NavigateToRoute from "./NavigateToRoute.jsx"
+import { useRole } from "./AuthContext.jsx"
 import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "../components/ui/tabs"
 import { Button } from "../components/ui/button"
@@ -65,6 +66,7 @@ const Feed = ({ video, hideLabel }) => (
 )
 
 const LiveVideo = (props) => {
+	const isAdmin = useRole() === "admin"
 	const [cameras] = useCameras()
 	const [state, , restart] = useLiveVideo(cameras)
 	const [videos, setVideos] = useState([])
@@ -84,10 +86,12 @@ const LiveVideo = (props) => {
 		return (
 			<div className="flex flex-col gap-3">
 				<div className="flex justify-end">
-					<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} disabled={state.restarting} title="Restart all camera streams">
-						<RefreshCw className={cn("size-3.5", state.restarting && "animate-spin")} />
-						{state.restarting ? "Restarting…" : "Restart streams"}
-					</Button>
+					{isAdmin && (
+						<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} disabled={state.restarting} title="Restart all camera streams">
+							<RefreshCw className={cn("size-3.5", state.restarting && "animate-spin")} />
+							{state.restarting ? "Restarting…" : "Restart streams"}
+						</Button>
+					)}
 				</div>
 				{state.videoList.map((video) => (
 					<Feed key={video.url} video={video} />
@@ -100,10 +104,12 @@ const LiveVideo = (props) => {
 		return (
 			<div className="flex flex-col gap-2">
 				<div className="flex justify-end">
-					<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} disabled={state.restarting} title="Restart all camera streams">
-						<RefreshCw className={cn("size-3.5", state.restarting && "animate-spin")} />
-						{state.restarting ? "Restarting…" : "Restart streams"}
-					</Button>
+					{isAdmin && (
+						<Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={restart} disabled={state.restarting} title="Restart all camera streams">
+							<RefreshCw className={cn("size-3.5", state.restarting && "animate-spin")} />
+							{state.restarting ? "Restarting…" : "Restart streams"}
+						</Button>
+					)}
 				</div>
 				{videos.map((row, ri) => (
 					<div key={ri} className="grid gap-2" style={{ gridTemplateColumns: `repeat(${row.length}, minmax(0, 1fr))` }}>
@@ -123,9 +129,11 @@ const LiveVideo = (props) => {
 			<CardHeader className="flex flex-row items-center justify-between pb-2">
 				<CardTitle className="text-sm">Live Video</CardTitle>
 				<div className="flex items-center gap-1">
-					<Button variant="ghost" size="icon" className="size-6" onClick={restart} disabled={state.restarting} title="Restart streams">
-						<RefreshCw className={cn("size-3", state.restarting && "animate-spin")} />
-					</Button>
+					{isAdmin && (
+						<Button variant="ghost" size="icon" className="size-6" onClick={restart} disabled={state.restarting} title="Restart streams">
+							<RefreshCw className={cn("size-3", state.restarting && "animate-spin")} />
+						</Button>
+					)}
 					<NavigateToRoute to="/live" />
 				</div>
 			</CardHeader>

--- a/livestream/backend/routes/livestream.js
+++ b/livestream/backend/routes/livestream.js
@@ -1,6 +1,6 @@
 var express    = require("express")
 const path = require("path")
-const { subprocess } = require("lib")
+const { subprocess, auth } = require("lib")
 const memory = require("memory")
 
 const app = express.Router()
@@ -52,7 +52,7 @@ app.get("/status", (req, res, next) => {
 	next()
 }, subprocess.processListMiddleware)
 
-app.post("/restart", (req, res, next) => {
+app.post("/restart", auth.requireAdmin, (req, res, next) => {
 	const {camera} = req.body
 	if(!isCameraId(camera)){
 		res.status(400).send({})

--- a/livestream/test/livestream.test.js
+++ b/livestream/test/livestream.test.js
@@ -61,12 +61,12 @@ describe("Livestream Routes", () => {
 				.expect(401, done)
 		})
 
-		test("non-admin user passes the gate (400 without a camera)", (done) => {
+		test("non-admin user is forbidden from the gate", (done) => {
 			supertest(app)
 				.post("/livestream/restart")
 				.set("Cookie", "userCookie")
 				.send({})
-				.expect(400, done)
+				.expect(403, done)
 		})
 
 		test("admin passes the gate (400 without a camera)", (done) => {
@@ -80,7 +80,7 @@ describe("Livestream Routes", () => {
 		test("restarts a numeric camera", (done) => {
 			supertest(app)
 				.post("/livestream/restart")
-				.set("Cookie", "userCookie")
+				.set("Cookie", "validCookie")
 				.set("X-Forwarded-For", "10.0.0.1")
 				.send({ camera: 1 })
 				.expect(200, done)


### PR DESCRIPTION
Fixes the Medium-severity missing authorization on `POST /livestream/restart` — any authenticated user (incl. low-priv `user`) could force-restart camera ffmpeg workers (stream DoS).

## Changes
- `livestream/backend/routes/livestream.js`: adds `auth.requireAdmin` as the first handler on `POST /restart`. `GET /status` left open (non-admin viewers need it).
- `command/frontend/app/LiveVideo.jsx`: gates the "Restart streams" button on `role === "admin"` in all three render branches, matching every other privileged SPA action.

## Tests
- `livestream/test/livestream.test.js`: non-admin restart now asserts **403**; the numeric-camera success test switched to an admin cookie. Full suite: 690 passing.

Closes #354