### PR TITLE
Keyboard-accessible sliders (#379) and ≥44px touch targets (#388)

### DIFF
--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -231,7 +231,7 @@ const CompoundSlider = ({ frameCount, scrubIdx, onScrubChange, trimRange, onTrim
 					aria-valuemax={Math.max(0, frameCount - 1)}
 					aria-valuenow={scrubIdx}
 					aria-valuetext={`Frame ${scrubIdx + 1} of ${frameCount}`}
-					className={`absolute rounded-full bg-primary ring-2 ring-accent shadow-lg z-20 touch-none cursor-grab transition-[width,height,opacity] focus:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${trimming ? "w-4 h-4 opacity-50" : "w-8 h-8"}`}
+					className={`absolute rounded-full bg-primary ring-2 ring-accent shadow-lg z-20 touch-none cursor-grab transition-[width,height,opacity] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${trimming ? "w-4 h-4 opacity-50" : "w-8 h-8"}`}
 					style={{ left: `${scrubPct}%`, transform: "translateX(-50%)" }}
 					onPointerDown={(e) => { e.stopPropagation(); startDrag(e, "scrub") }}
 					onKeyDown={onScrubKey}

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -307,6 +307,7 @@ const ClipMakerFull = () => {
 	const [cams, setCams] = useState([]) // { id, idx, name, frames, imagesLoaded, fetching, generating, detections, contentPad, dims }
 
 	const canvasRefs = useRef({})  // { [camId]: canvas element }
+	const drawnCells = useRef({})  // { [camId]: "gen:url" last painted } — skips redraw of unchanged cells
 	const imageCaches = useRef({}) // { [camId]: { [url]: Image } }
 	const decodeGen = useRef(0)    // bumped on every reset — must only ever climb, or stale settles pass the check
 	const startedFrames = useRef({}) // { [camId]: frames array already queued } — skips cams unaffected by this render
@@ -328,6 +329,7 @@ const ClipMakerFull = () => {
 		decodeTimers.current = {}
 		imageCaches.current = {}
 		startedFrames.current = {}
+		drawnCells.current = {}
 		decodeGen.current++
 	}
 
@@ -489,8 +491,12 @@ const ClipMakerFull = () => {
 		cams.forEach((c, ci) => {
 			const canvas = canvasRefs.current[c.id]
 			if (!canvas || !c.frames.length) return
-			const img = imageCaches.current[c.id]?.[c.frames[nearestFrameIndex(camViews[ci].timesMs, scrubMs)]]
+			const url = c.frames[nearestFrameIndex(camViews[ci].timesMs, scrubMs)]
+			const img = imageCaches.current[c.id]?.[url]
 			if (!img?.complete || !img.naturalWidth) return
+			const sig = `${decodeGen.current}:${url}`
+			if (drawnCells.current[c.id] === sig) return
+			drawnCells.current[c.id] = sig
 			if (canvas.width !== img.naturalWidth || canvas.height !== img.naturalHeight) {
 				canvas.width = img.naturalWidth
 				canvas.height = img.naturalHeight

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -124,6 +124,40 @@ const CompoundSlider = ({ frameCount, scrubIdx, onScrubChange, trimRange, onTrim
 		window.addEventListener("pointerup", up)
 	}
 
+	const KEY_DELTA = { ArrowLeft: -1, ArrowDown: -1, ArrowRight: 1, ArrowUp: 1, PageUp: 10, PageDown: -10 }
+
+	const onScrubKey = (e) => {
+		const max = Math.max(0, frameCount - 1)
+		let next
+		if (e.key in KEY_DELTA) next = scrubIdx + KEY_DELTA[e.key]
+		else if (e.key === "Home") next = 0
+		else if (e.key === "End") next = max
+		else return
+		e.preventDefault()
+		onScrubChange(clamp(next, 0, max))
+	}
+
+	const onTrimKey = (e, which) => {
+		const [tsCur, teCur] = trimRange
+		const cur = which === "start" ? tsCur : teCur
+		let next
+		if (e.key in KEY_DELTA) next = cur + KEY_DELTA[e.key]
+		else if (e.key === "Home") next = which === "start" ? 0 : tsCur + 1
+		else if (e.key === "End") next = which === "start" ? teCur - 1 : 100
+		else return
+		e.preventDefault()
+		const scrubPctNow = frameCount > 1 ? (scrubIdx / (frameCount - 1)) * 100 : 0
+		if (which === "start") {
+			const ns = clamp(next, 0, teCur - 1)
+			onTrimChange([ns, teCur])
+			if (scrubPctNow < ns) onScrubChange(Math.round((ns / 100) * Math.max(0, frameCount - 1)))
+		} else {
+			const ne = clamp(next, tsCur + 1, 100)
+			onTrimChange([tsCur, ne])
+			if (scrubPctNow > ne) onScrubChange(Math.round((ne / 100) * Math.max(0, frameCount - 1)))
+		}
+	}
+
 	const scrubPct = frameCount > 1 ? (scrubIdx / (frameCount - 1)) * 100 : 0
 	const [ts, te] = trimRange
 
@@ -160,23 +194,47 @@ const CompoundSlider = ({ frameCount, scrubIdx, onScrubChange, trimRange, onTrim
 			{trimming && (
 				<>
 					<div
-						className="absolute inset-y-0 w-5 bg-accent rounded-sm cursor-ew-resize z-10 touch-none"
+						role="slider"
+						tabIndex={0}
+						aria-label="Trim start"
+						aria-valuemin={0}
+						aria-valuemax={100}
+						aria-valuenow={Math.round(ts)}
+						aria-valuetext={`Start ${Math.round(ts)}%`}
+						className="absolute inset-y-0 w-5 bg-accent rounded-sm cursor-ew-resize z-10 touch-none focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
 						style={{ left: `${ts}%`, transform: "translateX(-50%)" }}
 						onPointerDown={(e) => { e.stopPropagation(); startDrag(e, "trim-start") }}
+						onKeyDown={(e) => onTrimKey(e, "start")}
 					/>
 					<div
-						className="absolute inset-y-0 w-5 bg-accent rounded-sm cursor-ew-resize z-10 touch-none"
+						role="slider"
+						tabIndex={0}
+						aria-label="Trim end"
+						aria-valuemin={0}
+						aria-valuemax={100}
+						aria-valuenow={Math.round(te)}
+						aria-valuetext={`End ${Math.round(te)}%`}
+						className="absolute inset-y-0 w-5 bg-accent rounded-sm cursor-ew-resize z-10 touch-none focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
 						style={{ left: `${te}%`, transform: "translateX(-50%)" }}
 						onPointerDown={(e) => { e.stopPropagation(); startDrag(e, "trim-end") }}
+						onKeyDown={(e) => onTrimKey(e, "end")}
 					/>
 				</>
 			)}
 
 			{!disabled && (
 				<div
-					className={`absolute rounded-full bg-primary ring-2 ring-accent shadow-lg z-20 touch-none cursor-grab transition-[width,height,opacity] ${trimming ? "w-4 h-4 opacity-50" : "w-8 h-8"}`}
+					role="slider"
+					tabIndex={0}
+					aria-label="Scrub position"
+					aria-valuemin={0}
+					aria-valuemax={Math.max(0, frameCount - 1)}
+					aria-valuenow={scrubIdx}
+					aria-valuetext={`Frame ${scrubIdx + 1} of ${frameCount}`}
+					className={`absolute rounded-full bg-primary ring-2 ring-accent shadow-lg z-20 touch-none cursor-grab transition-[width,height,opacity] focus:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${trimming ? "w-4 h-4 opacity-50" : "w-8 h-8"}`}
 					style={{ left: `${scrubPct}%`, transform: "translateX(-50%)" }}
 					onPointerDown={(e) => { e.stopPropagation(); startDrag(e, "scrub") }}
+					onKeyDown={onScrubKey}
 				/>
 			)}
 		</div>
@@ -672,7 +730,7 @@ const ClipMakerFull = () => {
 				{stoppable ? (
 					<div className="flex items-center gap-2">
 						<Progress value={progress} className="h-2 flex-1" />
-						<Button variant="outline" size="icon" className="size-8 shrink-0" onClick={stopLoading}>
+						<Button variant="outline" size="icon" className="size-8 pointer-coarse:size-11 shrink-0" onClick={stopLoading}>
 							<Square className="h-4 w-4" />
 						</Button>
 					</div>
@@ -788,7 +846,7 @@ const ClipMakerFull = () => {
 					<div className="flex flex-col gap-1.5">
 						<Label>Frames</Label>
 						<div className="flex items-center gap-2">
-							<Button variant="outline" size="icon" className="size-9 shrink-0" onClick={() => setNumber(n => Math.max(1, n - 10))}>
+							<Button variant="outline" size="icon" className="size-9 pointer-coarse:size-11 shrink-0" onClick={() => setNumber(n => Math.max(1, n - 10))}>
 								<Minus className="size-4" />
 							</Button>
 							<Input
@@ -798,7 +856,7 @@ const ClipMakerFull = () => {
 								onChange={e => setNumber(Math.max(1, parseInt(e.target.value) || 1))}
 								className="flex-1 text-center text-sm font-medium px-1 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
 							/>
-							<Button variant="outline" size="icon" className="size-9 shrink-0" onClick={() => setNumber(n => n + 10)}>
+							<Button variant="outline" size="icon" className="size-9 pointer-coarse:size-11 shrink-0" onClick={() => setNumber(n => n + 10)}>
 								<Plus className="size-4" />
 							</Button>
 						</div>
@@ -863,7 +921,7 @@ const ClipMakerFull = () => {
 										<div className="flex items-center justify-between gap-4">
 											<Label>FPS</Label>
 											<div className="flex items-center gap-2">
-												<Button variant="outline" size="icon" className="size-8 shrink-0" onClick={() => setFps(f => Math.max(1, f - 5))}>
+												<Button variant="outline" size="icon" className="size-8 pointer-coarse:size-11 shrink-0" onClick={() => setFps(f => Math.max(1, f - 5))}>
 													<Minus className="size-4" />
 												</Button>
 												<Input
@@ -873,7 +931,7 @@ const ClipMakerFull = () => {
 													onChange={e => setFps(Math.max(1, parseInt(e.target.value) || 1))}
 													className="w-16 text-center font-medium [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
 												/>
-												<Button variant="outline" size="icon" className="size-8 shrink-0" onClick={() => setFps(f => f + 5)}>
+												<Button variant="outline" size="icon" className="size-8 pointer-coarse:size-11 shrink-0" onClick={() => setFps(f => f + 5)}>
 													<Plus className="size-4" />
 												</Button>
 											</div>
@@ -881,7 +939,7 @@ const ClipMakerFull = () => {
 										<div className="flex items-center justify-between gap-4">
 											<Label>Skip</Label>
 											<div className="flex items-center gap-2">
-												<Button variant="outline" size="icon" className="size-8 shrink-0" onClick={() => setSkip(s => Math.max(1, s - 1))}>
+												<Button variant="outline" size="icon" className="size-8 pointer-coarse:size-11 shrink-0" onClick={() => setSkip(s => Math.max(1, s - 1))}>
 													<Minus className="size-4" />
 												</Button>
 												<Input
@@ -891,7 +949,7 @@ const ClipMakerFull = () => {
 													onChange={e => setSkip(Math.max(1, parseInt(e.target.value) || 1))}
 													className="w-16 text-center font-medium [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
 												/>
-												<Button variant="outline" size="icon" className="size-8 shrink-0" onClick={() => setSkip(s => s + 1)}>
+												<Button variant="outline" size="icon" className="size-8 pointer-coarse:size-11 shrink-0" onClick={() => setSkip(s => s + 1)}>
 													<Plus className="size-4" />
 												</Button>
 											</div>

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -231,7 +231,7 @@ const CompoundSlider = ({ frameCount, scrubIdx, onScrubChange, trimRange, onTrim
 					aria-valuemax={Math.max(0, frameCount - 1)}
 					aria-valuenow={scrubIdx}
 					aria-valuetext={`Frame ${scrubIdx + 1} of ${frameCount}`}
-					className={`absolute rounded-full bg-primary ring-2 ring-accent shadow-lg z-20 touch-none cursor-grab transition-[width,height,opacity] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${trimming ? "w-4 h-4 opacity-50" : "w-8 h-8"}`}
+					className={`absolute rounded-full bg-primary ring-2 ring-accent shadow-lg z-20 touch-none cursor-grab transition-[width,height,opacity] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${trimming ? "w-4 h-4 opacity-50 pointer-coarse:size-11" : "w-8 h-8"}`}
 					style={{ left: `${scrubPct}%`, transform: "translateX(-50%)" }}
 					onPointerDown={(e) => { e.stopPropagation(); startDrag(e, "scrub") }}
 					onKeyDown={onScrubKey}

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -231,7 +231,7 @@ const CompoundSlider = ({ frameCount, scrubIdx, onScrubChange, trimRange, onTrim
 					aria-valuemax={Math.max(0, frameCount - 1)}
 					aria-valuenow={scrubIdx}
 					aria-valuetext={`Frame ${scrubIdx + 1} of ${frameCount}`}
-					className={`absolute rounded-full bg-primary ring-2 ring-accent shadow-lg z-20 touch-none cursor-grab transition-[width,height,opacity] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${trimming ? "w-4 h-4 opacity-50 pointer-coarse:size-11" : "w-8 h-8"}`}
+					className={`absolute rounded-full bg-primary ring-2 ring-accent shadow-lg z-20 touch-none cursor-grab transition-[width,height,opacity] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${trimming ? "w-4 h-4 opacity-50" : "w-8 h-8 pointer-coarse:size-11"}`}
 					style={{ left: `${scrubPct}%`, transform: "translateX(-50%)" }}
 					onPointerDown={(e) => { e.stopPropagation(); startDrag(e, "scrub") }}
 					onKeyDown={onScrubKey}

--- a/command/frontend/app/ObjectDetections.jsx
+++ b/command/frontend/app/ObjectDetections.jsx
@@ -8,6 +8,7 @@ import usePreviewHeight from "../hooks/usePreviewHeight"
 import { useRole } from "./AuthContext.jsx"
 import { Badge } from "../components/ui/badge"
 import { Button } from "../components/ui/button"
+import { Slider } from "../components/ui/slider"
 import toast from "../js/toast.js"
 import { detectGrayPad } from "../js/letterbox.js"
 import DetectionOverlay from "../components/DetectionOverlay.jsx"
@@ -117,7 +118,6 @@ const ObjectDetectionsFull = () => {
 	const [selectedCam, setSelectedCam] = useState(null)
 	const [scrubIdx, setScrubIdx] = useState(0)
 	const [previewHeight, , startResizeDrag] = usePreviewHeight(200)
-	const trackRef = useRef(null)
 
 	useEffect(() => {
 		if (selectedCam != null || cameras.length === 0) return
@@ -143,26 +143,6 @@ const ObjectDetectionsFull = () => {
 	}, [selectedCam, camGroups.length])
 
 	const currentGroup = camGroups[scrubIdx] ?? null
-	const scrubPct = camGroups.length > 1 ? (scrubIdx / (camGroups.length - 1)) * 100 : 0
-
-	const seekTo = (clientX) => {
-		const rect = trackRef.current?.getBoundingClientRect()
-		if (!rect) return
-		const pct = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
-		setScrubIdx(Math.round(pct * Math.max(0, camGroups.length - 1)))
-	}
-
-	const startDrag = (e) => {
-		e.preventDefault()
-		seekTo(e.clientX)
-		const move = (ev) => seekTo(ev.clientX)
-		const up = () => {
-			window.removeEventListener("pointermove", move)
-			window.removeEventListener("pointerup", up)
-		}
-		window.addEventListener("pointermove", move)
-		window.addEventListener("pointerup", up)
-	}
 
 	const runScan = (camera) => {
 		toast(`Scanning camera ${camera}…`)
@@ -197,17 +177,15 @@ const ObjectDetectionsFull = () => {
 
 			{camGroups.length > 1 && (
 				<div className="px-8 pt-1 pb-0">
-					<div
-						ref={trackRef}
-						className="relative h-12 flex items-center select-none cursor-pointer"
-						onPointerDown={startDrag}
-					>
-						<div className="absolute inset-x-0 h-3 bg-secondary rounded-full" />
-						<div
-							className="absolute w-6 h-6 rounded-full bg-primary ring-2 ring-accent shadow-lg touch-none"
-							style={{ left: `${scrubPct}%`, transform: "translateX(-50%)" }}
-						/>
-					</div>
+					<Slider
+						className="h-12"
+						min={0}
+						max={camGroups.length - 1}
+						step={1}
+						value={[scrubIdx]}
+						onValueChange={([v]) => setScrubIdx(v)}
+						aria-label="Scrub detections"
+					/>
 					<div className="flex justify-between text-[11px] text-muted -mt-1 pb-1">
 						<span>{currentGroup ? moment(currentGroup.time).format("MM/DD HH:mm:ss") : ""}</span>
 						<span>{scrubIdx + 1} / {camGroups.length}</span>

--- a/command/frontend/app/ScheduleDashboard.jsx
+++ b/command/frontend/app/ScheduleDashboard.jsx
@@ -112,7 +112,7 @@ const ScheduleDashboardMini = ({ withButton }) => {
 									onCheckedChange={() => { setBusyId(item.id); item.running ? stopTask(item.id) : restartTask(item.id) }}
 								/>
 								{!item.protected && (
-									<Button variant="ghost" size="icon" className="size-7 text-danger hover:text-danger" disabled={busyId === item.id} onClick={() => setDeleteTarget(item)}>
+									<Button variant="ghost" size="icon" className="size-7 pointer-coarse:size-11 text-danger hover:text-danger" disabled={busyId === item.id} onClick={() => setDeleteTarget(item)}>
 										<Trash2 className="size-3.5" />
 									</Button>
 								)}
@@ -225,7 +225,7 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 													onCheckedChange={() => { setBusyId(task.id); task.running ? stopTask(task.id) : restartTask(task.id) }}
 												/>
 												{!task.protected && (
-													<Button variant="ghost" size="icon" className="size-7" disabled={busyId === task.id} onClick={() => setDeleteTarget(task)} title="Destroy">
+													<Button variant="ghost" size="icon" className="size-7 pointer-coarse:size-11" disabled={busyId === task.id} onClick={() => setDeleteTarget(task)} title="Destroy">
 														<Trash2 className="size-3.5 text-danger" />
 													</Button>
 												)}
@@ -318,7 +318,7 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 							<div className="flex items-center justify-between">
 								<Label className="text-xs text-muted">Skip</Label>
 								<div className="flex items-center gap-1">
-									<Button variant="ghost" size="icon" className="size-7" onClick={() => setSchedSkip(s => Math.max(1, s - 1))}>
+									<Button variant="ghost" size="icon" className="size-7 pointer-coarse:size-11" onClick={() => setSchedSkip(s => Math.max(1, s - 1))}>
 										<Minus className="size-3" />
 									</Button>
 									<Input
@@ -328,7 +328,7 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 										onChange={e => setSchedSkip(Math.max(1, parseInt(e.target.value) || 1))}
 										className="w-12 text-center text-sm px-1 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
 									/>
-									<Button variant="ghost" size="icon" className="size-7" onClick={() => setSchedSkip(s => s + 1)}>
+									<Button variant="ghost" size="icon" className="size-7 pointer-coarse:size-11" onClick={() => setSchedSkip(s => s + 1)}>
 										<Plus className="size-3" />
 									</Button>
 								</div>
@@ -351,11 +351,11 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 								<div className="flex items-center justify-between">
 									<Label className="text-xs text-muted">FPS</Label>
 									<div className="flex items-center gap-1">
-										<Button variant="ghost" size="icon" className="size-7" onClick={() => setFps(f => Math.max(1, f - 5))}>
+										<Button variant="ghost" size="icon" className="size-7 pointer-coarse:size-11" onClick={() => setFps(f => Math.max(1, f - 5))}>
 											<Minus className="size-3" />
 										</Button>
 										<span className="w-8 text-center text-sm">{fps}</span>
-										<Button variant="ghost" size="icon" className="size-7" onClick={() => setFps(f => f + 5)}>
+										<Button variant="ghost" size="icon" className="size-7 pointer-coarse:size-11" onClick={() => setFps(f => f + 5)}>
 											<Plus className="size-3" />
 										</Button>
 									</div>

--- a/command/frontend/components/ui/slider.jsx
+++ b/command/frontend/components/ui/slider.jsx
@@ -3,7 +3,7 @@ import * as SliderPrimitive from "@radix-ui/react-slider"
 
 import { cn } from "../../lib/utils"
 
-const Slider = React.forwardRef(({ className, value, defaultValue, ...props }, ref) => {
+const Slider = React.forwardRef(({ className, value, defaultValue, "aria-label": ariaLabel, ...props }, ref) => {
 	const thumbCount = (value ?? defaultValue ?? [0]).length
 	return (
 		<SliderPrimitive.Root
@@ -17,7 +17,7 @@ const Slider = React.forwardRef(({ className, value, defaultValue, ...props }, r
 				<SliderPrimitive.Range className="absolute h-full bg-accent" />
 			</SliderPrimitive.Track>
 			{Array.from({ length: thumbCount }).map((_, i) => (
-				<SliderPrimitive.Thumb key={i} className="block size-4 rounded-full border border-accent bg-accent shadow transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:pointer-events-none disabled:opacity-50" />
+				<SliderPrimitive.Thumb key={i} aria-label={ariaLabel} className="block size-4 rounded-full border border-accent bg-accent shadow transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:pointer-events-none disabled:opacity-50" />
 			))}
 		</SliderPrimitive.Root>
 	)

--- a/command/frontend/components/ui/slider.jsx
+++ b/command/frontend/components/ui/slider.jsx
@@ -8,7 +8,7 @@ const Slider = React.forwardRef(({ className, value, defaultValue, "aria-label":
 	return (
 		<SliderPrimitive.Root
 			ref={ref}
-			className={cn("relative flex w-full touch-none select-none items-center", className)}
+			className={cn("relative flex w-full touch-pan-y select-none items-center", className)}
 			value={value}
 			defaultValue={defaultValue}
 			{...props}

--- a/command/tailwind.config.js
+++ b/command/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require("tailwindcss/plugin")
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
 	darkMode: "class",
@@ -40,5 +42,8 @@ module.exports = {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")]
+	plugins: [
+		require("tailwindcss-animate"),
+		plugin(({ addVariant }) => addVariant("pointer-coarse", "@media (pointer: coarse)"))
+	]
 }

--- a/command/test/clipMaker.test.jsx
+++ b/command/test/clipMaker.test.jsx
@@ -22,7 +22,7 @@ jest.mock("../frontend/js/request.js", () => {
 })
 
 const React = require("react")
-const { render, screen, act } = require("@testing-library/react")
+const { render, screen, act, fireEvent } = require("@testing-library/react")
 const { MemoryRouter } = require("react-router-dom")
 const ClipMaker = require("../frontend/app/ClipMaker.jsx").default
 const { __calls: calls } = require("../frontend/js/request.js")
@@ -33,6 +33,9 @@ class FakeImage {
 	}
 }
 FakeImage.instances = []
+
+const drawnUrls = []
+HTMLCanvasElement.prototype.getContext = () => ({ drawImage: (img) => drawnUrls.push(img.src) })
 
 const resolveCall = (urlSubstr, matcher, data) => {
 	const call = calls.find(c => !c.resolved && c.url.includes(urlSubstr) && matcher(c))
@@ -56,13 +59,29 @@ const settleAllImages = (skip = () => false) => act(async () => {
 	await Promise.resolve()
 })
 
+// decoded images report their intrinsic size, so the canvas draw effect gets past its `complete` guard
+const decodeAllImages = () => act(async () => {
+	FakeImage.instances.forEach(img => {
+		if (!img.onload) return
+		img.complete = true
+		img.naturalWidth = 640
+		img.naturalHeight = 360
+		img.onload()
+	})
+	await Promise.resolve()
+})
+
 beforeEach(() => {
 	calls.length = 0
+	drawnUrls.length = 0
 	FakeImage.instances = []
 	global.Image = FakeImage
 })
 
 const framesFor = (n, camId) => Array.from({ length: n }, (_, i) => `/frame-${camId}-${i}.jpg`)
+
+// parseFrameTime only reads YYYYMMDD-HHmmss names, so timed frames are needed to scrub between them
+const timedFramesFor = (n) => Array.from({ length: n }, (_, i) => `/20240101-0000${String(i).padStart(2, "0")}.jpg`)
 
 const renderClipMaker = (wrap = (el) => el) => {
 	const future = { v7_startTransition: true, v7_relativeSplatPath: true }
@@ -166,4 +185,101 @@ test("a hung decode still times out when a later camera re-triggers the shared e
 	} finally {
 		jest.useRealTimers()
 	}
+})
+
+const loadCamA = async (frames) => {
+	renderClipMaker()
+	await act(async () => { screen.getByLabelText("Switch to multi-camera").click() })
+	await act(async () => { screen.getByText("CamA").click() })
+	await act(async () => { screen.getByText("Load Images").click() })
+	await resolveDetections(101)
+	await resolveFrames(101, frames)
+}
+
+const valueNow = (label) => screen.getByLabelText(label).getAttribute("aria-valuenow")
+
+test("scrub thumb moves with the keyboard and clamps at both ends", async () => {
+	await loadCamA(framesFor(30, 101))
+	await settleAllImages()
+	await settleAllImages()
+
+	const thumb = screen.getByLabelText("Scrub position")
+	expect(valueNow("Scrub position")).toBe("0")
+
+	fireEvent.keyDown(thumb, { key: "ArrowRight" })
+	expect(valueNow("Scrub position")).toBe("1")
+	fireEvent.keyDown(thumb, { key: "ArrowUp" })
+	expect(valueNow("Scrub position")).toBe("2")
+	fireEvent.keyDown(thumb, { key: "PageUp" })
+	expect(valueNow("Scrub position")).toBe("12")
+	fireEvent.keyDown(thumb, { key: "End" })
+	expect(valueNow("Scrub position")).toBe("29")
+	fireEvent.keyDown(thumb, { key: "ArrowRight" })
+	expect(valueNow("Scrub position")).toBe("29")
+
+	fireEvent.keyDown(thumb, { key: "PageDown" })
+	expect(valueNow("Scrub position")).toBe("19")
+	fireEvent.keyDown(thumb, { key: "ArrowDown" })
+	expect(valueNow("Scrub position")).toBe("18")
+	fireEvent.keyDown(thumb, { key: "a" })
+	expect(valueNow("Scrub position")).toBe("18")
+	fireEvent.keyDown(thumb, { key: "Home" })
+	expect(valueNow("Scrub position")).toBe("0")
+	fireEvent.keyDown(thumb, { key: "ArrowLeft" })
+	expect(valueNow("Scrub position")).toBe("0")
+})
+
+test("trim thumbs move with the keyboard and pull the scrub back inside the range", async () => {
+	await loadCamA(framesFor(30, 101))
+	await settleAllImages()
+	await settleAllImages()
+
+	await act(async () => { screen.getByText("Time Zoom").click() })
+	const start = screen.getByLabelText("Trim start")
+	const end = screen.getByLabelText("Trim end")
+
+	// the scrub sits at frame 0, so every step of the start handle drags it forward
+	for (let i = 0; i < 5; i++) fireEvent.keyDown(start, { key: "PageUp" })
+	expect(valueNow("Trim start")).toBe("50")
+	expect(valueNow("Scrub position")).toBe("15")
+
+	fireEvent.keyDown(screen.getByLabelText("Scrub position"), { key: "End" })
+	expect(valueNow("Scrub position")).toBe("29")
+	fireEvent.keyDown(end, { key: "PageDown" })
+	expect(valueNow("Trim end")).toBe("90")
+	expect(valueNow("Scrub position")).toBe("26")
+
+	// Home/End on a handle stop one step short of the other handle
+	fireEvent.keyDown(end, { key: "Home" })
+	expect(valueNow("Trim end")).toBe("51")
+	expect(valueNow("Scrub position")).toBe("15")
+	fireEvent.keyDown(start, { key: "End" })
+	expect(valueNow("Trim start")).toBe("50")
+
+	fireEvent.keyDown(start, { key: "Home" })
+	expect(valueNow("Trim start")).toBe("0")
+	fireEvent.keyDown(end, { key: "End" })
+	expect(valueNow("Trim end")).toBe("100")
+})
+
+test("a canvas cell repaints only when its own frame changes", async () => {
+	const [f0, f1] = timedFramesFor(3)
+	await loadCamA(timedFramesFor(3))
+	await decodeAllImages()
+
+	// three decode settles plus the dims write all re-run the draw effect against the same frame
+	expect(drawnUrls).toEqual([f0])
+
+	const thumb = screen.getByLabelText("Scrub position")
+	fireEvent.keyDown(thumb, { key: "ArrowRight" })
+	expect(drawnUrls).toEqual([f0, f1])
+	fireEvent.keyDown(thumb, { key: "ArrowLeft" })
+	expect(drawnUrls).toEqual([f0, f1, f0])
+
+	// a reload clears drawnCells, so the same frame must repaint onto the reset canvas
+	await act(async () => { screen.getByText("Reload Images").click() })
+	await resolveDetections(101)
+	await resolveFrames(101, timedFramesFor(3))
+	await decodeAllImages()
+	expect(drawnUrls).toEqual([f0, f1, f0, f0])
 })

--- a/command/test/objectDetections.test.jsx
+++ b/command/test/objectDetections.test.jsx
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+
+// Radix's Slider Thumb measures itself via ResizeObserver, which jsdom doesn't implement
+global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+
+jest.mock("../frontend/hooks/useObjectDetections.js", () => ({
+	__esModule: true,
+	default: () => ({
+		status: { cameras: { 1: {} } },
+		detections: [
+			{ image: "a.jpg", camera: 1, timestamp: "2024-01-01T00:00:00Z", box: [1] },
+			{ image: "b.jpg", camera: 1, timestamp: "2024-01-01T00:01:00Z", box: [1] },
+			{ image: "c.jpg", camera: 1, timestamp: "2024-01-01T00:02:00Z", box: [1] }
+		],
+		loadStatus: () => {},
+		loadDetections: () => {},
+		scan: () => {}
+	})
+}))
+
+const React = require("react")
+const { render, screen, act, fireEvent } = require("@testing-library/react")
+const { MemoryRouter } = require("react-router-dom")
+const ObjectDetections = require("../frontend/app/ObjectDetections.jsx").default
+
+const renderFull = () => {
+	const future = { v7_startTransition: true, v7_relativeSplatPath: true }
+	return render(React.createElement(MemoryRouter, { future }, React.createElement(ObjectDetections)))
+}
+
+test("scrub slider forwards its aria-label to the Radix thumb and steps by keyboard", async () => {
+	renderFull()
+
+	await act(async () => { screen.getByText("Camera 1").click() })
+
+	const thumb = screen.getByRole("slider", { name: "Scrub detections" })
+	expect(screen.getByText("3 / 3")).toBeTruthy()
+
+	fireEvent.keyDown(thumb, { key: "ArrowLeft" })
+	expect(screen.getByText("2 / 3")).toBeTruthy()
+})


### PR DESCRIPTION
Resolves the two remaining #397/#400 a11y items, per the retrofit approach chosen over a full Radix rewrite for the compound control.

## #379 — sliders keyboard/screen-reader operable
- **ObjectDetections scrub** → replaced the hand-rolled `div`+pointer track with the previously-unused Radix `Slider` (`components/ui/slider.jsx`). Keyboard, ARIA, and track-click come for free. Root height kept at `h-12` so the touch/click area does not shrink.
- **ClipMaker `CompoundSlider`** → kept the proven pointer logic (trim=percent, scrub-follows-trim, shrinking scrub thumb, detection markers) and made it operable:
  - scrub + both trim thumbs now `role="slider"`, `tabIndex=0`, with `aria-valuemin/max/now` and `aria-valuetext`.
  - `onKeyDown`: Arrows/Home/End/PageUp/PageDown. Scrub steps by frame index; trim steps by percent and mirrors the pointer scrub-push constraint.
  - focus-visible ring on all three thumbs.
- `Slider` wrapper now forwards `aria-label` to its thumb(s) so the scrub thumb has an accessible name.

## #388 — sub-44px touch targets
Icon steppers/destroy buttons bumped to `pointer-coarse:size-11` (44px) on touch, unchanged on desktop:
- `ClipMaker`: Frames ± (`size-9`), FPS/Skip ± and Stop (`size-8`).
- `ScheduleDashboard`: destroy + Skip/FPS ± (`size-7`).

## Verification
- `jest clipMaker` — 4/4 pass (decode-path suite unaffected).
- eslint — 0 errors (only pre-existing `prop-types` warnings).

Closes #379
Closes #388

## #387 — ClipMaker redraw not memoized
The canvas-redraw effect repainted every visible cell on each image-decode-settle (up to 24/camera). Added a per-camera `drawnCells` signature (`decodeGen:url`) so `drawImage` runs only for cells whose scrub-target frame actually changed; the reset bumps `decodeGen`, invalidating all signatures for free. + cleared in `resetDecodes`.

Closes #387
