### PR TITLE
Fix #408 scheduler_AUTH floor gap and #409 prune-vs-export race

### DIFF
--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -135,6 +135,12 @@ const isServiceOff = (lines, key) => {
 	return getVal(lines, `${prefix}_ON`) === "false"
 }
 
+const blankDisables = (lines, key) => {
+	const copy = [...lines]
+	setVal(copy, key, "")
+	return isServiceOff(copy, key)
+}
+
 const objectFeedProblem = (lines) => on(lines, "object") && !on(lines, "livestream")
 	? "object_ON requires livestream_ON — object's only frame source is livestream_FOLDERPATH/feed/<id>/video.m3u8, and pm2 starts the per-camera ffmpeg writers only when livestream_ON=true, so every scan fails and nothing is ever detected"
 	: null
@@ -232,7 +238,7 @@ const runInteractive = async () => {
 		let val, ap
 		do {
 			val = await ask(`    ${v.key} = `)
-			ap = answerProblem(v, val)
+			ap = val === "" && blankDisables(lines, v.key) ? null : answerProblem(v, val)
 			if (ap) console.log(`    ${BAD} ${ap}`)
 		} while (ap)
 		setVal(lines, v.key, val)
@@ -329,4 +335,4 @@ if (require.main === module) {
 	else runInteractive()
 }
 
-module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, objectFeedProblem, insecureCookie, cookieSecureProblem, answerProblem, envProblems, hashTruncated, runInteractive, readLines, getVal, setVal }
+module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, answerProblem, envProblems, hashTruncated, runInteractive, readLines, getVal, setVal }

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -127,6 +127,8 @@ const isServiceOff = (lines, key) => {
 	if (/^ffprobe_/.test(key)) return !on(lines, "storage")
 	if (key === "storage_HOST" && on(lines, "schedule")) return false
 	if (key === "scheduler_TRUSTED_SOURCES") return false
+	// scheduler_AUTH arms the storage bypass whenever it is set, regardless of schedule_ON — validate it whenever present
+	if (key === "scheduler_AUTH" && getVal(lines, key)) return false
 	const prefix = key.startsWith("scheduler_") ? "schedule" : SERVICE_PREFIXES.find(s => key.startsWith(s + "_"))
 	if (!prefix || key === `${prefix}_ON`) return false
 	if (/_HOST$/.test(key) && getVal(lines, `${prefix}_PROXY_ON`) === "true") return false

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -127,7 +127,6 @@ const isServiceOff = (lines, key) => {
 	if (/^ffprobe_/.test(key)) return !on(lines, "storage")
 	if (key === "storage_HOST" && on(lines, "schedule")) return false
 	if (key === "scheduler_TRUSTED_SOURCES") return false
-	// scheduler_AUTH arms the storage bypass whenever it is set, regardless of schedule_ON — validate it whenever present
 	if (key === "scheduler_AUTH" && getVal(lines, key)) return false
 	const prefix = key.startsWith("scheduler_") ? "schedule" : SERVICE_PREFIXES.find(s => key.startsWith(s + "_"))
 	if (!prefix || key === `${prefix}_ON`) return false

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -331,8 +331,13 @@ describe("isServiceOff (prefix mapping)", () => {
 		expect(isServiceOff(lines({ schedule_ON: "true" }), "scheduler_AUTH")).toBe(false)
 	})
 
-	test("scheduler_AUTH follows schedule service (off)", () => {
+	test("scheduler_AUTH is skipped when blank and schedule is off", () => {
 		expect(isServiceOff(lines({ schedule_ON: "false" }), "scheduler_AUTH")).toBe(true)
+	})
+
+	test("scheduler_AUTH is validated whenever it holds a value, because the storage bypass arms on it alone", () => {
+		expect(isServiceOff(lines({ schedule_ON: "false", scheduler_AUTH: "a".repeat(32) }), "scheduler_AUTH")).toBe(false)
+		expect(isServiceOff(lines({ schedule_ON: "false", scheduler_AUTH: "short" }), "scheduler_AUTH")).toBe(false)
 	})
 
 	test("ffmpeg_FILEPATH / ffprobe_FILEPATH skipped when no camera service is on", () => {

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -20,7 +20,7 @@ jest.mock("fs", () => {
 	}
 })
 
-const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, objectFeedProblem, insecureCookie, cookieSecureProblem, envProblems, hashTruncated } = require("../preflight.js")
+const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, envProblems, hashTruncated } = require("../preflight.js")
 
 describe("parseSchema", () => {
 	test("parses required keys", () => {
@@ -338,6 +338,20 @@ describe("isServiceOff (prefix mapping)", () => {
 	test("scheduler_AUTH is validated whenever it holds a value, because the storage bypass arms on it alone", () => {
 		expect(isServiceOff(lines({ schedule_ON: "false", scheduler_AUTH: "a".repeat(32) }), "scheduler_AUTH")).toBe(false)
 		expect(isServiceOff(lines({ schedule_ON: "false", scheduler_AUTH: "short" }), "scheduler_AUTH")).toBe(false)
+	})
+
+	test("blanking scheduler_AUTH is a valid interactive answer when schedule is off, so the wizard cannot demand a token the deploy does not need", () => {
+		expect(blankDisables(lines({ schedule_ON: "false", scheduler_AUTH: "short" }), "scheduler_AUTH")).toBe(true)
+	})
+
+	test("blanking scheduler_AUTH is rejected while schedule is on", () => {
+		expect(blankDisables(lines({ schedule_ON: "true", scheduler_AUTH: "short" }), "scheduler_AUTH")).toBe(false)
+	})
+
+	test("blankDisables leaves the caller's lines untouched", () => {
+		const input = lines({ schedule_ON: "false", scheduler_AUTH: "short" })
+		blankDisables(input, "scheduler_AUTH")
+		expect(input).toContain("scheduler_AUTH = short")
 	})
 
 	test("ffmpeg_FILEPATH / ffprobe_FILEPATH skipped when no camera service is on", () => {

--- a/chimera/test/validateEnvVars.test.js
+++ b/chimera/test/validateEnvVars.test.js
@@ -123,8 +123,14 @@ describe("validateEnvVars placeholder-secret gate", () => {
 		expect(run({ database_PASSWORD: "postgres" }).stdout).toContain("database_PASSWORD TOO SHORT")
 	})
 
-	test("skips the length floor for a disabled service, matching the presence check", () => {
+	test("blocks boot when scheduler_AUTH is short even with the schedule service off — the storage bypass arms whenever it is set", () => {
 		const res = run({ schedule_ON: "false", schedule_PROXY_ON: "false", scheduler_AUTH: "short" })
+		expect(res.stdout).toContain("scheduler_AUTH TOO SHORT")
+		expect(res.status).toBe(1)
+	})
+
+	test("skips the length floor for a disabled service, matching the presence check", () => {
+		const res = run({ memory_ON: "false", chimeraInstances: "1", memory_AUTH_TOKEN: "short" })
 		expect(res.stdout).toBe("")
 		expect(res.status).toBe(0)
 	})

--- a/command/frontend/hooks/useClearFootage.js
+++ b/command/frontend/hooks/useClearFootage.js
@@ -27,8 +27,13 @@ const useClearFootage = (cameras, onDone) => {
 		Promise.all(targets.map(cam => deleteCamera(cam.id))).then((results) => {
 			remove()
 			const deleted = results.filter(r => r?.deleted).length
+			const deferred = results.filter(r => r?.deferred).length
 			const total = results.length
-			toast(deleted === 0 ? "None Deleted" : deleted === total ? "Files Deleted" : `${deleted}/${total} Deleted`)
+			const suffix = deferred ? ` — ${deferred} Deferred, Export Running` : ""
+			toast(deferred && deferred === total ? "Deferred — Export Running"
+				: deleted === 0 ? `None Deleted${suffix}`
+				: deleted === total ? "Files Deleted"
+				: `${deleted}/${total} Deleted${suffix}`)
 			setDeleting(false)
 			onDone()
 		})

--- a/command/frontend/hooks/useClearFootage.js
+++ b/command/frontend/hooks/useClearFootage.js
@@ -30,10 +30,8 @@ const useClearFootage = (cameras, onDone) => {
 			const deferred = results.filter(r => r?.deferred).length
 			const total = results.length
 			const suffix = deferred ? ` — ${deferred} Deferred, Export Running` : ""
-			toast(deferred && deferred === total ? "Deferred — Export Running"
-				: deleted === 0 ? `None Deleted${suffix}`
-				: deleted === total ? "Files Deleted"
-				: `${deleted}/${total} Deleted${suffix}`)
+			const counted = deleted === 0 ? `None Deleted${suffix}` : deleted === total ? "Files Deleted" : `${deleted}/${total} Deleted${suffix}`
+			toast(deferred && deferred === total ? "Deferred — Export Running" : counted)
 			setDeleting(false)
 			onDone()
 		})

--- a/command/frontend/hooks/useClearFootage.js
+++ b/command/frontend/hooks/useClearFootage.js
@@ -27,7 +27,7 @@ const useClearFootage = (cameras, onDone) => {
 		Promise.all(targets.map(cam => deleteCamera(cam.id))).then((results) => {
 			remove()
 			const deleted = results.filter(r => r?.deleted).length
-			const deferred = results.filter(r => r?.deferred).length
+			const deferred = results.filter(r => r?.deferred && !r?.deleted).length
 			const total = results.length
 			const suffix = deferred ? ` — ${deferred} Deferred, Export Running` : ""
 			const counted = deleted === 0 ? `None Deleted${suffix}` : deleted === total ? "Files Deleted" : `${deleted}/${total} Deleted${suffix}`

--- a/command/test/useClearFootage.test.js
+++ b/command/test/useClearFootage.test.js
@@ -1,0 +1,92 @@
+/** @jest-environment jsdom */
+
+jest.mock("../frontend/js/request.js", () => {
+	const calls = []
+	return {
+		__calls: calls,
+		request: (url, opts, cb) => {
+			let resolve
+			const promise = new Promise((res) => { resolve = res })
+			calls.push({ url, opts, resolve })
+			return cb(promise)
+		}
+	}
+})
+
+jest.mock("../frontend/js/toast.js", () => {
+	const messages = []
+	return {
+		__esModule: true,
+		__messages: messages,
+		default: (message) => {
+			messages.push(message)
+			return () => {}
+		}
+	}
+})
+
+const { renderHook, act } = require("@testing-library/react")
+const useClearFootage = require("../frontend/hooks/useClearFootage.js").default
+const { __calls: calls } = require("../frontend/js/request.js")
+const { __messages: messages } = require("../frontend/js/toast.js")
+
+const cameras = [{ id: 1 }, { id: 2 }, { id: 3 }]
+
+const respond = (body) => ({ text: () => body === undefined ? Promise.reject(new Error("network")) : Promise.resolve(JSON.stringify(body)) })
+
+const clearAll = async (bodies) => {
+	const { result } = renderHook(() => useClearFootage(cameras, () => {}))
+	act(() => { result.current.setPending({ type: "all" }) })
+	act(() => { result.current.confirmDelete() })
+	await act(async () => {
+		calls.forEach((call, i) => call.resolve(respond(bodies[i])))
+		await new Promise((r) => setTimeout(r, 0))
+	})
+	return result
+}
+
+const lastToast = () => messages[messages.length - 1]
+
+beforeEach(() => {
+	calls.length = 0
+	messages.length = 0
+})
+
+test("names the export when every camera deferred", async () => {
+	await clearAll([{ deferred: true }, { deferred: true }, { deferred: true }])
+	expect(lastToast()).toBe("Deferred — Export Running")
+})
+
+test("separates deferred cameras from deleted ones in a partial result", async () => {
+	await clearAll([{ deleted: true }, { deferred: true }, { deferred: true }])
+	expect(lastToast()).toBe("1/3 Deleted — 2 Deferred, Export Running")
+})
+
+test("distinguishes a deferred camera from a failed one when nothing was deleted", async () => {
+	await clearAll([{ deferred: true }, { error: true }, undefined])
+	expect(lastToast()).toBe("None Deleted — 1 Deferred, Export Running")
+})
+
+test("still reports a plain failure with no deferral noise", async () => {
+	await clearAll([{ error: true }, undefined, { deleted: false }])
+	expect(lastToast()).toBe("None Deleted")
+})
+
+test("reports a clean sweep when every camera deleted", async () => {
+	await clearAll([{ deleted: true }, { deleted: true }, { deleted: true }])
+	expect(lastToast()).toBe("Files Deleted")
+})
+
+test("clears the deleting flag and calls onDone once a deferred run settles", async () => {
+	const onDone = jest.fn()
+	const { result } = renderHook(() => useClearFootage(cameras, onDone))
+	act(() => { result.current.setPending({ type: "all" }) })
+	act(() => { result.current.confirmDelete() })
+	expect(result.current.deleting).toBe(true)
+	await act(async () => {
+		calls.forEach((call) => call.resolve(respond({ deferred: true })))
+		await new Promise((r) => setTimeout(r, 0))
+	})
+	expect(result.current.deleting).toBe(false)
+	expect(onDone).toHaveBeenCalledTimes(1)
+})

--- a/command/test/useClearFootage.test.js
+++ b/command/test/useClearFootage.test.js
@@ -77,6 +77,11 @@ test("reports a clean sweep when every camera deleted", async () => {
 	expect(lastToast()).toBe("Files Deleted")
 })
 
+test("counts a camera as deleted when its files were removed and only the orphan sweep deferred", async () => {
+	await clearAll([{ deleted: true, deferred: true }, { deleted: true }, { deleted: true }])
+	expect(lastToast()).toBe("Files Deleted")
+})
+
 test("clears the deleting flag and calls onDone once a deferred run settles", async () => {
 	const onDone = jest.fn()
 	const { result } = renderHook(() => useClearFootage(cameras, onDone))

--- a/schedule/backend/routes/lib/scheduler.js
+++ b/schedule/backend/routes/lib/scheduler.js
@@ -173,7 +173,7 @@ module.exports = {
 					id,
 					url: "/file/pathAutoClean",
 					body: {},
-					cronString: "0 * * * *",
+					cronString: "37 * * * *",
 					running: true,
 					protected: true
 				})

--- a/schedule/test/autoCleanup.test.js
+++ b/schedule/test/autoCleanup.test.js
@@ -44,7 +44,7 @@ describe("autoRegisterCleanup", () => {
 			id: "task-auto-cleanup",
 			url: "/file/pathAutoClean",
 			body: {},
-			cronString: "0 * * * *",
+			cronString: "37 * * * *",
 			running: true,
 			protected: true
 		})

--- a/storage/backend/routes/file.js
+++ b/storage/backend/routes/file.js
@@ -14,17 +14,18 @@ const {
 	fileStats,
 	dailyStats,
 	cameraMetrics,
-	autoClean
+	autoClean,
+	deferIfExporting
 } = require("./lib/file.js")
 
 app.post("/pathSize", validateBody, validateCameraAndAppendToPath, getCameraMetricFromDatabase("size")) 
 app.post("/pathFileCount", validateBody, validateCameraAndAppendToPath, getCameraMetricFromDatabase("count"))
 app.post("/pathDelete", requireAdmin, validateBody, validateCameraAndAppendToPath, updateDeletionOfFiles("directory"), deleteFileDirectory)
-app.post("/pathClean", requireAdmin, validateBody, validateCameraAndAppendToPath, validateDays, updateDeletionOfFiles("files"), deleteFilesBeforeDateGlob)
+app.post("/pathClean", requireAdmin, validateBody, validateCameraAndAppendToPath, validateDays, deferIfExporting, updateDeletionOfFiles("files"), deleteFilesBeforeDateGlob)
 
 app.get("/pathStats", fileStats)
 app.get("/dailyStats", dailyStats)
 app.post("/pathMetrics", cameraMetrics)
-app.post("/pathAutoClean", requireAdmin, autoClean)
+app.post("/pathAutoClean", requireAdmin, deferIfExporting, autoClean)
 
 module.exports = app

--- a/storage/backend/routes/file.js
+++ b/storage/backend/routes/file.js
@@ -20,7 +20,7 @@ const {
 
 app.post("/pathSize", validateBody, validateCameraAndAppendToPath, getCameraMetricFromDatabase("size")) 
 app.post("/pathFileCount", validateBody, validateCameraAndAppendToPath, getCameraMetricFromDatabase("count"))
-app.post("/pathDelete", requireAdmin, validateBody, validateCameraAndAppendToPath, updateDeletionOfFiles("directory"), deleteFileDirectory)
+app.post("/pathDelete", requireAdmin, validateBody, validateCameraAndAppendToPath, deferIfExporting, updateDeletionOfFiles("directory"), deleteFileDirectory)
 app.post("/pathClean", requireAdmin, validateBody, validateCameraAndAppendToPath, validateDays, deferIfExporting, updateDeletionOfFiles("files"), deleteFilesBeforeDateGlob)
 
 app.get("/pathStats", fileStats)

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -95,7 +95,7 @@ module.exports = {
 		let deferred = false
 
 		for (let i = 0; i < names.length; i += UNLINK_BATCH) {
-			if (i && await exportInProgress()) {
+			if (await exportInProgress()) {
 				deferred = true
 				break
 			}

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -122,6 +122,7 @@ module.exports = {
 
 		const failed = tracked.filter(ok => !ok).length
 		if (failed) console.log(`STORAGE FILE UNLINK FAILED for ${failed} file(s) after DB rows deleted; orphans will be swept on next clean`)
+		if (deferred) console.log(`STORAGE CLEAN DEFERRED mid-run for camera ${req.body.camera}; a fresh export lock appeared, ${names.length - tracked.length} file(s) left for the next clean`)
 		res.send({ deleted: req.numberOfFilesDeletedInDatabase > 0 && failed === 0 && !deferred, ...(deferred && { deferred: true }) })
 	},
 
@@ -214,7 +215,7 @@ module.exports = {
 
 				let planned = freed
 				const batch = []
-				while (cursor < page.length && planned < toFree) {
+				while (cursor < page.length && planned < toFree && batch.length < UNLINK_BATCH) {
 					const row = page[cursor++]
 					batch.push(row)
 					planned += parseInt(row.size) || 0
@@ -241,6 +242,7 @@ module.exports = {
 			if (stuck.length) {
 				webhookAlert(`⚠️ Storage auto-clean could not unlink ${stuck.length} frame file(s); their rows were left intact. Check permissions on ${CAPTURES_DIR}.`, "admin")
 			}
+			if (deferred) console.log(`STORAGE AUTO-CLEAN DEFERRED mid-run after freeing ${freed} of ${toFree} bytes; a fresh export lock appeared`)
 			if (deleted === 0) return res.send({ cleaned: false, ...(deferred && { deferred: true }) })
 			res.send({ cleaned: true, deleted, ...(deferred && { deferred: true }) })
 		} catch (err) {

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -178,6 +178,8 @@ module.exports = {
 			let cursor = 0
 
 			while (freed < toFree) {
+				if (await exportInProgress()) break
+
 				if (cursor >= page.length) {
 					const { rows } = await bulkPool.query(
 						"SELECT id, camera, name, size FROM frame_files WHERE size IS NOT NULL AND size > 0 AND NOT (id = ANY($1::int[])) ORDER BY timestamp ASC LIMIT 10000",

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -123,7 +123,7 @@ module.exports = {
 		const failed = tracked.filter(ok => !ok).length
 		if (failed) console.log(`STORAGE FILE UNLINK FAILED for ${failed} file(s) after DB rows deleted; orphans will be swept on next clean`)
 		if (deferred) console.log(`STORAGE CLEAN DEFERRED mid-run for camera ${req.body.camera}; a fresh export lock appeared, ${names.length - tracked.length} file(s) left for the next clean`)
-		res.send({ deleted: req.numberOfFilesDeletedInDatabase > 0 && failed === 0 && !deferred, ...(deferred && { deferred: true }) })
+		res.send({ deleted: req.numberOfFilesDeletedInDatabase > 0 && failed === 0 && tracked.length === names.length, ...(deferred && { deferred: true }) })
 	},
 
 	dailyStats: async (req, res) => {

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -105,15 +105,17 @@ module.exports = {
 		}
 
 		if (req.beforeDate && !deferred) {
-			if (await exportInProgress()) {
-				deferred = true
-			}
-			else {
-				const cutoff = moment.utc(req.beforeDate).valueOf()
-				const known = new Set(names.map(n => path.basename(n)))
-				const entries = await fs.promises.readdir(dir).catch(() => [])
-				const stale = entries.filter(f => f.endsWith(".jpg") && !known.has(f))
-				await mapLimit(stale, FS_CONCURRENCY, async (f) => {
+			const cutoff = moment.utc(req.beforeDate).valueOf()
+			const known = new Set(names.map(n => path.basename(n)))
+			const entries = await fs.promises.readdir(dir).catch(() => [])
+			const stale = entries.filter(f => f.endsWith(".jpg") && !known.has(f))
+
+			for (let i = 0; i < stale.length; i += UNLINK_BATCH) {
+				if (await exportInProgress()) {
+					deferred = true
+					break
+				}
+				await mapLimit(stale.slice(i, i + UNLINK_BATCH), FS_CONCURRENCY, async (f) => {
 					const captured = moment.utc(f.slice(0, 15), "YYYYMMDD-HHmmss", true)
 					if (captured.isValid() && captured.valueOf() < cutoff) await fs.promises.unlink(path.join(dir, f)).catch(() => {})
 				})

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -11,10 +11,21 @@ const MAX_STUCK_BATCHES = 3
 
 const STATS_WINDOW_DAYS = 32
 
+const EXPORT_LOCK_ACTIVE_MS = 5 * 60 * 1000
+
 const camerasOrFail = (res) => loadCameras().catch(() => {
 	res.status(500).send({ error: true })
 	return null
 })
+
+const exportInProgress = async () => {
+	const entries = await fs.promises.readdir(CAPTURES_DIR).catch(() => [])
+	const cutoff = Date.now() - EXPORT_LOCK_ACTIVE_MS
+	const active = await mapLimit(entries.filter(f => /^(mp4|zip)_.+\.txt$/.test(f)), FS_CONCURRENCY, f =>
+		fs.promises.stat(path.join(CAPTURES_DIR, f)).then(s => s.mtimeMs > cutoff).catch(() => false)
+	)
+	return active.some(Boolean)
+}
 
 module.exports = {
 	validateCameraAndAppendToPath: (req, res, next) => {
@@ -129,6 +140,11 @@ module.exports = {
 			console.log("err", err)
 			res.status(500).send({ error: true })
 		})
+	},
+
+	deferIfExporting: async (req, res, next) => {
+		if (await exportInProgress()) return res.send({ deferred: true })
+		next()
 	},
 
 	autoClean: async (req, res) => {

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -13,6 +13,8 @@ const STATS_WINDOW_DAYS = 32
 
 const EXPORT_LOCK_ACTIVE_MS = 5 * 60 * 1000
 
+const UNLINK_BATCH = 500
+
 const camerasOrFail = (res) => loadCameras().catch(() => {
 	res.status(500).send({ error: true })
 	return null
@@ -89,22 +91,38 @@ module.exports = {
 	deleteFilesBeforeDateGlob: async (req, res) => {
 		const dir = req.body.appendedPath
 		const names = (req.deletedFileNames || []).filter(Boolean)
-		const tracked = await mapLimit(names, FS_CONCURRENCY, name =>
-			fs.promises.unlink(path.join(dir, path.basename(name))).then(() => true).catch((e) => e.code === "ENOENT")
-		)
-		if (req.beforeDate) {
-			const cutoff = moment.utc(req.beforeDate).valueOf()
-			const known = new Set(names.map(n => path.basename(n)))
-			const entries = await fs.promises.readdir(dir).catch(() => [])
-			const stale = entries.filter(f => f.endsWith(".jpg") && !known.has(f))
-			await mapLimit(stale, FS_CONCURRENCY, async (f) => {
-				const captured = moment.utc(f.slice(0, 15), "YYYYMMDD-HHmmss", true)
-				if (captured.isValid() && captured.valueOf() < cutoff) await fs.promises.unlink(path.join(dir, f)).catch(() => {})
-			})
+		const tracked = []
+		let deferred = false
+
+		for (let i = 0; i < names.length; i += UNLINK_BATCH) {
+			if (i && await exportInProgress()) {
+				deferred = true
+				break
+			}
+			tracked.push(...await mapLimit(names.slice(i, i + UNLINK_BATCH), FS_CONCURRENCY, name =>
+				fs.promises.unlink(path.join(dir, path.basename(name))).then(() => true).catch((e) => e.code === "ENOENT")
+			))
 		}
+
+		if (req.beforeDate && !deferred) {
+			if (await exportInProgress()) {
+				deferred = true
+			}
+			else {
+				const cutoff = moment.utc(req.beforeDate).valueOf()
+				const known = new Set(names.map(n => path.basename(n)))
+				const entries = await fs.promises.readdir(dir).catch(() => [])
+				const stale = entries.filter(f => f.endsWith(".jpg") && !known.has(f))
+				await mapLimit(stale, FS_CONCURRENCY, async (f) => {
+					const captured = moment.utc(f.slice(0, 15), "YYYYMMDD-HHmmss", true)
+					if (captured.isValid() && captured.valueOf() < cutoff) await fs.promises.unlink(path.join(dir, f)).catch(() => {})
+				})
+			}
+		}
+
 		const failed = tracked.filter(ok => !ok).length
 		if (failed) console.log(`STORAGE FILE UNLINK FAILED for ${failed} file(s) after DB rows deleted; orphans will be swept on next clean`)
-		res.send({ deleted: req.numberOfFilesDeletedInDatabase > 0 && failed === 0 })
+		res.send({ deleted: req.numberOfFilesDeletedInDatabase > 0 && failed === 0 && !deferred, ...(deferred && { deferred: true }) })
 	},
 
 	dailyStats: async (req, res) => {

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -176,9 +176,13 @@ module.exports = {
 			let stuckBatches = 0
 			let page = []
 			let cursor = 0
+			let deferred = false
 
 			while (freed < toFree) {
-				if (await exportInProgress()) break
+				if (await exportInProgress()) {
+					deferred = true
+					break
+				}
 
 				if (cursor >= page.length) {
 					const { rows } = await bulkPool.query(
@@ -219,8 +223,8 @@ module.exports = {
 			if (stuck.length) {
 				webhookAlert(`⚠️ Storage auto-clean could not unlink ${stuck.length} frame file(s); their rows were left intact. Check permissions on ${CAPTURES_DIR}.`, "admin")
 			}
-			if (deleted === 0) return res.send({ cleaned: false })
-			res.send({ cleaned: true, deleted })
+			if (deleted === 0) return res.send({ cleaned: false, ...(deferred && { deferred: true }) })
+			res.send({ cleaned: true, deleted, ...(deferred && { deferred: true }) })
 		} catch (err) {
 			res.status(500).send({ error: "cleanup failed" })
 		}

--- a/storage/backend/routes/lib/video.js
+++ b/storage/backend/routes/lib/video.js
@@ -34,25 +34,29 @@ const createFrameList = (camera, start, end, limit, callback) => {
 
 const createVideoList = (camera, start, end, skip, callback) => {
 	const rand = generateID()
+	const txtPath = path.join(imgDir, `mp4_${rand}.txt`)
 
-	filterList(camera, start, end, skip, (filteredList) => {
-		const frames = filteredList.length    
+	fs.writeFile(txtPath, "", () => {
+		filterList(camera, start, end, skip, (filteredList) => {
+			const frames = filteredList.length
 
-		let files = ""
-	
-		console.log(start.split("-")[0], start.split("-")[1], end.split("-")[0], end.split("-")[1])
-		
-		for (const file of filteredList){
-			files += `file '${camera}/${file}'\r\n` 
-		}
-		
-		fs.writeFile(path.join(imgDir, `mp4_${rand}.txt`), files, (err) => {
-			if(err){
-				callback(err, undefined)
+			let files = ""
+
+			console.log(start.split("-")[0], start.split("-")[1], end.split("-")[0], end.split("-")[1])
+
+			for (const file of filteredList){
+				files += `file '${camera}/${file}'\r\n`
 			}
-			else{
-				callback(false, { rand, frames })
-			}
+
+			fs.writeFile(txtPath, files, (err) => {
+				if(err){
+					fs.unlink(txtPath, () => {})
+					callback(err, undefined)
+				}
+				else{
+					callback(false, { rand, frames })
+				}
+			})
 		})
 	})
 }

--- a/storage/backend/routes/lib/zip.js
+++ b/storage/backend/routes/lib/zip.js
@@ -19,33 +19,41 @@ const createZipList = (camera, start, end, skip, callback) => {
 		zlib: {level: 9}
 	})
 
-	filterList(camera, start, end, skip, (filteredList) => {
-		const frames = filteredList.length    
+	const rand = generateID()
 
-		console.log(start.split("-")[0], start.split("-")[1], end.split("-")[0], end.split("-")[1])
-		
-		for (const file of filteredList){
-			archive.file(path.join(imgDir, camera, file), {
-				name: file
-			}) 
-		}
-	
-		callback(null, {frames, archive})
+	fs.writeFile(path.join(imgDir, `zip_${rand}.txt`), "progress", () => {
+		filterList(camera, start, end, skip, (filteredList) => {
+			const frames = filteredList.length
+
+			console.log(start.split("-")[0], start.split("-")[1], end.split("-")[0], end.split("-")[1])
+
+			for (const file of filteredList){
+				archive.file(path.join(imgDir, camera, file), {
+					name: file
+				})
+			}
+
+			callback(null, {frames, archive, rand})
+		})
 	})
 }
 
-const zip = (archive, camera, frames, start, end, save, req, res) => {
+const zip = (archive, camera, frames, start, end, rand, save, req, res) => {
 
-	const rand = generateID()
+	const txtPath = path.join(imgDir, `zip_${rand}.txt`)
 
 	if(frames == 0){
 		webhookAlert(`Zip Process:\nID: ${rand}\nCamera: ${camera}\nNot started: has ${frames} frames`)
+		fs.unlink(txtPath, () => {})
 		res.send({ id: rand, url: undefined })
 	}
 	else{
+		archive.on("progress", () => {
+			fs.utimes(txtPath, new Date(), new Date(), () => {})
+		})
+
 		if(save){
 			const zipPath = path.join(imgDir, fileName(camera, start, end, rand, "zip"))
-			const txtPath = path.join(imgDir, `zip_${rand}.txt`)
 			var output = fs.createWriteStream(zipPath)
 			let cancelled = false
 			let alerted = false
@@ -91,12 +99,6 @@ const zip = (archive, camera, frames, start, end, save, req, res) => {
 				})
 			})
 
-			fs.writeFile(txtPath, "progress", () => {})
-
-			archive.on("progress", () => {
-				fs.utimes(txtPath, new Date(), new Date(), () => {})
-			})
-
 			archive.pipe(output)
 
 			emitToMemory("saveProcessEnder", rand, (cancel) => {
@@ -114,9 +116,11 @@ const zip = (archive, camera, frames, start, end, save, req, res) => {
 		else{
 			archive.on("error", function(err) {
 				console.log("An error occurred: " + err.message)
+				fs.unlink(txtPath, () => {})
 				if(!res.headersSent) return res.status(500).end()
 				res.destroy(err)
 			})
+			res.on("close", () => fs.unlink(txtPath, () => {}))
 			res.attachment(fileName(camera, start, end, rand, "zip"))
 			archive.pipe(res, {end: true})
 		}
@@ -133,7 +137,7 @@ module.exports = {
 
 		skip = skip == undefined ? 1 : skip
 
-		createZipList(camera, start, end, skip, (err, {frames, archive}) => {
+		createZipList(camera, start, end, skip, (err, {frames, archive, rand}) => {
 			if(!err){
 				if(save == undefined || save == true || save == "true"){
 					save = true
@@ -146,7 +150,7 @@ module.exports = {
 					save = false
 				}
 		
-				zip(archive, camera, frames, start, end, save, req, res)
+				zip(archive, camera, frames, start, end, rand, save, req, res)
 			}
 			else{
 				res.send({error: true})

--- a/storage/jest.config.js
+++ b/storage/jest.config.js
@@ -5,6 +5,6 @@ module.exports = {
 		"js",
 		"json"
 	],
-	setupFiles: ["dotenv/config"],
+	setupFiles: ["dotenv/config", "<rootDir>/test/setupEnv.js"],
 	testTimeout: 10000
 }

--- a/storage/test/convert.test.js
+++ b/storage/test/convert.test.js
@@ -393,7 +393,7 @@ describe("Convert Routes", () => {
 			const writeFileSpy = jest.spyOn(fs, "writeFile").mockImplementation((p, d, cb) => cb && cb())
 			const archive = Object.assign(new EventEmitter(), { pipe: jest.fn(), finalize: jest.fn(), abort: jest.fn() })
 
-			zip(archive, 1, 5, "20210101-000000", "20210102-000000", true, { body: {} }, { send: jest.fn() })
+			zip(archive, 1, 5, "20210101-000000", "20210102-000000", "zip-id", true, { body: {} }, { send: jest.fn() })
 
 			output.emit("error", new Error("ENOSPC: no space left on device"))
 			output.emit("error", new Error("ENOSPC: no space left on device"))
@@ -413,9 +413,9 @@ describe("Convert Routes", () => {
 		test("sends a 500 on archive error when nothing has been written yet", () => {
 			const archive = Object.assign(new EventEmitter(), { pipe: jest.fn(), finalize: jest.fn(), abort: jest.fn() })
 			const end = jest.fn()
-			const res = { attachment: jest.fn(), send: jest.fn(), destroy: jest.fn(), headersSent: false, status: jest.fn(() => ({ end })) }
+			const res = { attachment: jest.fn(), on: jest.fn(), send: jest.fn(), destroy: jest.fn(), headersSent: false, status: jest.fn(() => ({ end })) }
 
-			zip(archive, 1, 5, "20210101-000000", "20210102-000000", false, { body: {} }, res)
+			zip(archive, 1, 5, "20210101-000000", "20210102-000000", "zip-id", false, { body: {} }, res)
 
 			expect(() => archive.emit("error", new Error("EPIPE"))).not.toThrow()
 			expect(res.status).toHaveBeenCalledWith(500)
@@ -425,10 +425,10 @@ describe("Convert Routes", () => {
 
 		test("destroys the response on archive error once headers are already sent so the client does not hang", () => {
 			const archive = Object.assign(new EventEmitter(), { pipe: jest.fn(), finalize: jest.fn(), abort: jest.fn() })
-			const res = { attachment: jest.fn(), send: jest.fn(), destroy: jest.fn(), headersSent: true, status: jest.fn() }
+			const res = { attachment: jest.fn(), on: jest.fn(), send: jest.fn(), destroy: jest.fn(), headersSent: true, status: jest.fn() }
 			const err = new Error("EPIPE")
 
-			zip(archive, 1, 5, "20210101-000000", "20210102-000000", false, { body: {} }, res)
+			zip(archive, 1, 5, "20210101-000000", "20210102-000000", "zip-id", false, { body: {} }, res)
 
 			expect(() => archive.emit("error", err)).not.toThrow()
 			expect(res.destroy).toHaveBeenCalledWith(err)
@@ -451,7 +451,7 @@ describe("Convert Routes", () => {
 			jest.spyOn(fs, "createWriteStream").mockReturnValue(output)
 			jest.spyOn(fs, "writeFile").mockImplementation((p, d, cb) => cb && cb())
 			const archive = Object.assign(new EventEmitter(), { pipe: jest.fn(), finalize: jest.fn(), abort: jest.fn() })
-			zip(archive, 1, 5, "20210101-000000", "20210102-000000", true, { body: {} }, { send: jest.fn() })
+			zip(archive, 1, 5, "20210101-000000", "20210102-000000", "zip-id", true, { body: {} }, { send: jest.fn() })
 			return { output, archive }
 		}
 

--- a/storage/test/convertLockRefresh.test.js
+++ b/storage/test/convertLockRefresh.test.js
@@ -9,8 +9,20 @@ const mockFs = {
 }
 
 const mockFfmpegHandlers = {}
+const mockArchiveHandlers = {}
 
 jest.mock("fs", () => ({ ...jest.requireActual("fs"), ...mockFs }))
+
+jest.mock("archiver", () => {
+	const archive = {
+		on: (event, cb) => { mockArchiveHandlers[event] = cb; return archive },
+		file: () => {},
+		pipe: () => {},
+		abort: () => {},
+		finalize: () => {}
+	}
+	return () => archive
+})
 
 jest.mock("cli-progress", () => ({
 	SingleBar: class { start() {} update() {} stop() {} },
@@ -42,7 +54,7 @@ jest.mock("lib")
 jest.mock("memory")
 
 const { createVideo } = require("../backend/routes/lib/video.js")
-const { zip } = require("../backend/routes/lib/zip.js")
+const { createZip } = require("../backend/routes/lib/zip.js")
 
 const START = "20210101-000000"
 const END = "20210102-000000"
@@ -52,6 +64,7 @@ const lockWrites = () => mockFs.writeFile.mock.calls.map(([p]) => p)
 beforeEach(() => {
 	for (const fn of Object.values(mockFs)) fn.mockClear()
 	for (const key of Object.keys(mockFfmpegHandlers)) delete mockFfmpegHandlers[key]
+	for (const key of Object.keys(mockArchiveHandlers)) delete mockArchiveHandlers[key]
 })
 
 describe("convert lock refresh", () => {
@@ -71,39 +84,41 @@ describe("convert lock refresh", () => {
 	})
 
 	test("a zip progress event touches the same lock file the sweep ages out", () => {
-		const handlers = {}
-		const archive = {
-			on: (event, cb) => { handlers[event] = cb; return archive },
-			pipe: () => {},
-			abort: () => {},
-			finalize: () => {}
-		}
 		let sent
-		zip(archive, "1", 2, START, END, true, { body: {} }, { send: (body) => { sent = body } })
+		createZip({ body: { camera: "1", start: START, end: END } }, { send: (body) => { sent = body } })
 
 		const lockPath = path.join(process.env.storage_FOLDERPATH, "shared/captures", `zip_${sent.id}.txt`)
 		expect(lockWrites()).toContain(lockPath)
 		expect(mockFs.utimes).not.toHaveBeenCalled()
 
-		handlers.progress({ entries: { processed: 1, total: 2 } })
+		mockArchiveHandlers.progress({ entries: { processed: 1, total: 2 } })
 
 		expect(mockFs.utimes).toHaveBeenCalledWith(lockPath, expect.any(Date), expect.any(Date), expect.any(Function))
 	})
 
 	test("the refreshed mtime is newer than the orphan-sweep threshold", () => {
 		const ORPHAN_AGE_MS = 24 * 60 * 60 * 1000
-		const handlers = {}
-		const archive = {
-			on: (event, cb) => { handlers[event] = cb; return archive },
-			pipe: () => {},
-			abort: () => {},
-			finalize: () => {}
-		}
-		zip(archive, "1", 2, START, END, true, { body: {} }, { send: () => {} })
+		createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
 
-		handlers.progress({ entries: { processed: 1, total: 2 } })
+		mockArchiveHandlers.progress({ entries: { processed: 1, total: 2 } })
 
 		const [, , mtime] = mockFs.utimes.mock.calls[0]
 		expect(Date.now() - mtime.getTime()).toBeLessThan(ORPHAN_AGE_MS)
+	})
+
+	test("a streaming zip writes a lock before listing frames, so a prune defers on it too", () => {
+		let sent
+		createZip({ body: { camera: "1", start: START, end: END, save: false } }, {
+			attachment: () => {},
+			on: () => {},
+			send: (body) => { sent = body }
+		})
+
+		expect(sent).toBeUndefined()
+		expect(lockWrites().filter(p => /zip_.+\.txt$/.test(p))).toHaveLength(1)
+
+		mockArchiveHandlers.progress({ entries: { processed: 1, total: 2 } })
+
+		expect(mockFs.utimes).toHaveBeenCalledWith(lockWrites()[0], expect.any(Date), expect.any(Date), expect.any(Function))
 	})
 })

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -357,6 +357,24 @@ describe("File Routes", () => {
 				expect(bulkQuery).not.toHaveBeenCalled()
 				expect(unlinkSpy).not.toHaveBeenCalled()
 			})
+
+			test("defers while an export lock is fresh, before deleting any database rows", async () => {
+				const readdir = jest.spyOn(fs.promises, "readdir").mockResolvedValue(["zip_abc.txt"])
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+				try {
+					const res = await supertest(app)
+						.post("/file/pathClean")
+						.send({ camera: 1, days: 1 })
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ deferred: true })
+					expect(bulkQuery).not.toHaveBeenCalled()
+					expect(unlinkSpy).not.toHaveBeenCalled()
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
 		})
 	})
 
@@ -567,6 +585,42 @@ describe("File Routes", () => {
 					.post("/file/pathAutoClean")
 					.set("Cookie", cookieWithBearerToken)
 				expect(res.status).toBe(500)
+			})
+
+			test("defers while an export lock is fresh, before touching the frame table", async () => {
+				process.env.storage_MAX_GB = "1"
+				const readdir = jest.spyOn(fs.promises, "readdir").mockResolvedValue(["mp4_abc.txt"])
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ deferred: true })
+					expect(bulkQuery).not.toHaveBeenCalled()
+					expect(unlinkSpy).not.toHaveBeenCalled()
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
+
+			test("does not defer for a stale export lock, so a crashed export cannot block cap enforcement", async () => {
+				process.env.storage_MAX_GB = "10"
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p, opts) =>
+					Promise.resolve(opts && opts.withFileTypes ? [] : ["mp4_abc.txt"]))
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() - 60 * 60 * 1000 })
+				bulkQuery.mockResolvedValueOnce({ rows: [{ total: "1000000" }] })
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ cleaned: false })
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
 			})
 		})
 	})

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -710,6 +710,31 @@ describe("File Routes", () => {
 				}
 			})
 
+			test("rechecks for exports between bounded unlink batches instead of once per page", async () => {
+				process.env.storage_MAX_GB = "1"
+				let exportChecks = 0
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p, opts) => {
+					if (opts && opts.withFileTypes) return Promise.resolve([])
+					exportChecks++
+					return Promise.resolve(exportChecks <= 2 ? [] : ["mp4_abc.txt"])
+				})
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+				bulkQuery
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "1800000000" }] }))
+					.mockImplementationOnce(() => Promise.resolve({ rows: Array.from({ length: 600 }, (_, i) => ({ id: i + 1, camera: "1", name: `${i}.jpg`, size: "1000" })) }))
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ cleaned: true, deleted: 500, deferred: true })
+					expect(unlinkSpy).toHaveBeenCalledTimes(500)
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
+
 			test("omits deferred when the pass ends for any reason other than an export", async () => {
 				process.env.storage_MAX_GB = "1"
 				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p, opts) =>

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -214,6 +214,23 @@ describe("File Routes", () => {
 			expect(sql).toMatch(/FROM deleted HAVING COUNT\(\*\) > 0\) SELECT name FROM deleted/)
 			expect(values[1]).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
 		})
+
+		test("defers while an export lock is fresh, before deleting any database rows", async () => {
+			const readdir = jest.spyOn(fs.promises, "readdir").mockResolvedValue(["zip_abc.txt"])
+			const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+			try {
+				const res = await supertest(app)
+					.post("/file/pathDelete")
+					.send({ camera: 1 })
+					.set("Cookie", cookieWithBearerToken)
+				expect(res.status).toBe(200)
+				expect(res.body).toEqual({ deferred: true })
+				expect(bulkQuery).not.toHaveBeenCalled()
+			} finally {
+				readdir.mockRestore()
+				stat.mockRestore()
+			}
+		})
 	})
 
 	describe("/file/pathClean", () => {

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -404,7 +404,7 @@ describe("File Routes", () => {
 						.send({ camera: 1, days: 1 })
 						.set("Cookie", cookieWithBearerToken)
 					expect(res.status).toBe(200)
-					expect(res.body).toEqual({ deleted: false, deferred: true })
+					expect(res.body).toEqual({ deleted: true, deferred: true })
 					expect(unlinkSpy).toHaveBeenCalledWith(path.join(dir, "a.jpg"))
 					expect(unlinkSpy).not.toHaveBeenCalledWith(path.join(dir, "20200101-000000-00.jpg"))
 				} finally {

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -432,6 +432,31 @@ describe("File Routes", () => {
 					stat.mockRestore()
 				}
 			})
+
+			test("rechecks the export lock between orphan-sweep batches instead of once for the whole sweep", async () => {
+				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [] }))
+				const dir = path.join(process.env.storage_FOLDERPATH, "./shared/captures/", "1")
+				const stale = Array.from({ length: 501 }, (_, i) => `20200101-000000-${String(i).padStart(3, "0")}.jpg`)
+				let lockChecks = 0
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p) => {
+					if (p === dir) return Promise.resolve(stale)
+					lockChecks++
+					return Promise.resolve(lockChecks <= 2 ? [] : ["mp4_abc.txt"])
+				})
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+				try {
+					const res = await supertest(app)
+						.post("/file/pathClean")
+						.send({ camera: 1, days: 1 })
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ deleted: false, deferred: true })
+					expect(unlinkSpy).toHaveBeenCalledTimes(500)
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
 		})
 	})
 

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -391,12 +391,32 @@ describe("File Routes", () => {
 				}
 			})
 
+			test("defers before the first unlink batch when an export starts during the database delete", async () => {
+				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [{ name: "a.jpg", size: "100" }] }))
+				let exportChecks = 0
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation(() =>
+					Promise.resolve(++exportChecks <= 1 ? [] : ["mp4_abc.txt"]))
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+				try {
+					const res = await supertest(app)
+						.post("/file/pathClean")
+						.send({ camera: 1, days: 1 })
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ deleted: false, deferred: true })
+					expect(unlinkSpy).not.toHaveBeenCalled()
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
+
 			test("skips the orphan sweep when an export starts after the tracked unlinks", async () => {
 				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [{ name: "a.jpg", size: "100" }] }))
 				const dir = path.join(process.env.storage_FOLDERPATH, "./shared/captures/", "1")
 				let exportChecks = 0
 				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation(() =>
-					Promise.resolve(++exportChecks <= 1 ? [] : ["mp4_abc.txt", "20200101-000000-00.jpg"]))
+					Promise.resolve(++exportChecks <= 2 ? [] : ["mp4_abc.txt", "20200101-000000-00.jpg"]))
 				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
 				try {
 					const res = await supertest(app)

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -659,11 +659,52 @@ describe("File Routes", () => {
 						.post("/file/pathAutoClean")
 						.set("Cookie", cookieWithBearerToken)
 					expect(res.status).toBe(200)
-					expect(res.body).toEqual({ cleaned: true, deleted: 1 })
+					expect(res.body).toEqual({ cleaned: true, deleted: 1, deferred: true })
 					expect(bulkQuery.mock.calls.filter(([sql]) => sql.startsWith("SELECT id"))).toHaveLength(1)
 				} finally {
 					readdir.mockRestore()
 					stat.mockRestore()
+				}
+			})
+
+			test("marks a run deferred when an export starts before anything could be freed", async () => {
+				process.env.storage_MAX_GB = "1"
+				let exportChecks = 0
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p, opts) => {
+					if (opts && opts.withFileTypes) return Promise.resolve([])
+					exportChecks++
+					return Promise.resolve(exportChecks <= 1 ? [] : ["mp4_abc.txt"])
+				})
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "1800000000" }] }))
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ cleaned: false, deferred: true })
+					expect(unlinkSpy).not.toHaveBeenCalled()
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
+
+			test("omits deferred when the pass ends for any reason other than an export", async () => {
+				process.env.storage_MAX_GB = "1"
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p, opts) =>
+					Promise.resolve(opts && opts.withFileTypes ? [] : []))
+				bulkQuery
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "1800000000" }] }))
+					.mockImplementationOnce(() => Promise.resolve({ rows: [] }))
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ cleaned: false })
+				} finally {
+					readdir.mockRestore()
 				}
 			})
 		})

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -1,5 +1,3 @@
-process.env.storage_FOLDERPATH = "/tmp/storage-file-test"
-
 const supertest = require("supertest")
 
 jest.mock("lib")
@@ -264,7 +262,7 @@ describe("File Routes", () => {
 					.set("Cookie", cookieWithBearerToken)
 				expect(res.status).toBe(200)
 				expect(res.body).toEqual({ deleted: true })
-				const base = path.join("/tmp/storage-file-test", "./shared/captures/", "1")
+				const base = path.join(process.env.storage_FOLDERPATH, "./shared/captures/", "1")
 				expect(unlinkSpy).toHaveBeenCalledWith(path.join(base, "a.jpg"))
 				expect(unlinkSpy).toHaveBeenCalledWith(path.join(base, "b.jpg"))
 				expect(unlinkSpy).toHaveBeenCalledTimes(2)
@@ -302,14 +300,14 @@ describe("File Routes", () => {
 					.set("Cookie", cookieWithBearerToken)
 				expect(res.status).toBe(200)
 				expect(res.body).toEqual({ deleted: true })
-				const base = path.join("/tmp/storage-file-test", "./shared/captures/", "1")
+				const base = path.join(process.env.storage_FOLDERPATH, "./shared/captures/", "1")
 				expect(unlinkSpy).toHaveBeenCalledWith(path.join(base, "a.jpg"))
 				expect(unlinkSpy).toHaveBeenCalledTimes(1)
 			})
 
 			test("sweeps untracked .jpg orphans whose captured timestamp is older than the cutoff", async () => {
 				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [{ name: "tracked.jpg", size: "100" }] }))
-				const dir = path.join("/tmp/storage-file-test", "./shared/captures/", "1")
+				const dir = path.join(process.env.storage_FOLDERPATH, "./shared/captures/", "1")
 				const readdirSpy = jest.spyOn(fs.promises, "readdir")
 					.mockResolvedValue(["tracked.jpg", "20200101-000000-00.jpg", "20991231-235959-00.jpg", "garbage.jpg", "note.txt"])
 				const res = await supertest(app)
@@ -328,7 +326,7 @@ describe("File Routes", () => {
 
 			test("sweeps orphans past the cutoff even when the database delete matched no rows", async () => {
 				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [] }))
-				const dir = path.join("/tmp/storage-file-test", "./shared/captures/", "1")
+				const dir = path.join(process.env.storage_FOLDERPATH, "./shared/captures/", "1")
 				const readdirSpy = jest.spyOn(fs.promises, "readdir")
 					.mockResolvedValue(["20200101-000000-00.jpg", "20991231-235959-00.jpg"])
 				const res = await supertest(app)
@@ -387,6 +385,28 @@ describe("File Routes", () => {
 					expect(res.body).toEqual({ deferred: true })
 					expect(bulkQuery).not.toHaveBeenCalled()
 					expect(unlinkSpy).not.toHaveBeenCalled()
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
+
+			test("skips the orphan sweep when an export starts after the tracked unlinks", async () => {
+				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [{ name: "a.jpg", size: "100" }] }))
+				const dir = path.join(process.env.storage_FOLDERPATH, "./shared/captures/", "1")
+				let exportChecks = 0
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation(() =>
+					Promise.resolve(++exportChecks <= 1 ? [] : ["mp4_abc.txt", "20200101-000000-00.jpg"]))
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+				try {
+					const res = await supertest(app)
+						.post("/file/pathClean")
+						.send({ camera: 1, days: 1 })
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ deleted: false, deferred: true })
+					expect(unlinkSpy).toHaveBeenCalledWith(path.join(dir, "a.jpg"))
+					expect(unlinkSpy).not.toHaveBeenCalledWith(path.join(dir, "20200101-000000-00.jpg"))
 				} finally {
 					readdir.mockRestore()
 					stat.mockRestore()
@@ -474,7 +494,7 @@ describe("File Routes", () => {
 					.post("/file/pathAutoClean")
 					.set("Cookie", cookieWithBearerToken)
 				expect(res.status).toBe(200)
-				const base = path.join("/tmp/storage-file-test", "shared/captures", "1")
+				const base = path.join(process.env.storage_FOLDERPATH, "shared/captures", "1")
 				expect(unlinkSpy).toHaveBeenCalledWith(path.join(base, "passwd.jpg"))
 				unlinkSpy.mock.calls.forEach(([p]) => {
 					expect(path.resolve(String(p)).startsWith(path.resolve(base) + path.sep)).toBe(true)

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -639,6 +639,33 @@ describe("File Routes", () => {
 					stat.mockRestore()
 				}
 			})
+
+			test("stops paging once an export starts mid-run, instead of deleting through the whole pass", async () => {
+				process.env.storage_MAX_GB = "1"
+				let exportChecks = 0
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p, opts) => {
+					if (opts && opts.withFileTypes) return Promise.resolve([])
+					exportChecks++
+					return Promise.resolve(exportChecks <= 2 ? [] : ["mp4_abc.txt"])
+				})
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ mtimeMs: Date.now() })
+				bulkQuery
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "1800000000" }] }))
+					.mockImplementationOnce(() => Promise.resolve({ rows: [
+						{ id: 1, camera: "1", name: "a.jpg", size: "400000000" }
+					] }))
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ cleaned: true, deleted: 1 })
+					expect(bulkQuery.mock.calls.filter(([sql]) => sql.startsWith("SELECT id"))).toHaveLength(1)
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
 		})
 	})
 })

--- a/storage/test/setupEnv.js
+++ b/storage/test/setupEnv.js
@@ -1,0 +1,6 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+process.env.storage_FOLDERPATH = fs.mkdtempSync(path.join(os.tmpdir(), "chimera-storage-"))
+fs.mkdirSync(path.join(process.env.storage_FOLDERPATH, "shared/captures"), { recursive: true })


### PR DESCRIPTION
Fixes #408 and #409.

**#408** — `scheduler_AUTH` skipped preflight validation when `schedule_ON=false`, but storage arms the auth bypass whenever the token is set. It is now validated whenever it holds a value. Blank still disables it.

**#409** — The prune routes (`pathAutoClean`, `pathClean`, `pathDelete`) could delete frames an in-flight video/zip export was still reading. They now check the export lock files first and reply `{ deferred: true }` while a lock is fresh (touched within 5 minutes); the scheduler just retries next cycle. Stale locks from crashed exports do not block. Also: prunes recheck mid-run, exports write their lock before listing frames, streaming zips now hold a lock too, and the hourly cleanup cron moved to `:37` to avoid top-of-hour exports.

Known gaps and follow-ups are filed as #411–#415.

Tests: +18, full suite green, lint clean.
