### PR TITLE
Add timeout to webhookAlert axios instance

### DIFF
--- a/lib/utils/webhookAlert.js
+++ b/lib/utils/webhookAlert.js
@@ -1,5 +1,6 @@
 const axios  = require("axios").default.create({
 	validateStatus: (status) => status == 200 || status == 204,
+	timeout: 10000,
 })
 
 module.exports = (content, level="default", isError=()=>{}) => {


### PR DESCRIPTION
Adds `timeout: 10000` to the shared axios instance in `lib/utils/webhookAlert.js`. Axios defaults to `timeout: 0`, so requests to a hung webhook endpoint stayed pending indefinitely, accumulating sockets and closures during an outage. Existing `lib/test/webhookAlert.test.js` suite passes.

Fixes #418