### PR TITLE
Bound storage's memory socket buffering during outages

### DIFF
--- a/storage/backend/routes/lib/converter.js
+++ b/storage/backend/routes/lib/converter.js
@@ -12,10 +12,10 @@ module.exports = {
 		return randomID.generate() + "-" + moment.utc().format(dateFormat)
 	},
 
-	/** Emits only while `memory_ON`, so an ack is never registered with no server to answer it. */
+	/** Emits only while `memory_ON` and connected, so ender packets and their acks never buffer during a memory outage; the 24h orphan sweep reconciles drops. */
 	memoryEmitter: (label) => {
 		const client = memory.client(label)
-		return (event, ...args) => { if(process.env.memory_ON == "true") client.emit(event, ...args) }
+		return (event, ...args) => { if(process.env.memory_ON == "true" && client.connected) client.emit(event, ...args) }
 	},
     
 	filterList: (camera, start, end, skipEvery=1, callback) => {

--- a/storage/test/convert.test.js
+++ b/storage/test/convert.test.js
@@ -490,16 +490,15 @@ describe("Convert Routes", () => {
 			expect(archive.abort).toHaveBeenCalledTimes(1)
 		})
 
-		test("buffers the ender registration while disconnected and flushes it on reconnect", () => {
+		test("drops enders while disconnected instead of buffering them", () => {
 			memory.__client.connected = false
-			const { archive } = runZip()
-			expect(memory.__emitted.map(e => e.event)).not.toContain("saveProcessEnder")
+			const { output } = runZip()
+			output.emit("close")
 
 			memory.__client.connected = true
-			const saved = memory.__emitted.find(e => e.event === "saveProcessEnder")
-			expect(saved).toBeDefined()
-			saved.args[1](true)
-			expect(archive.abort).toHaveBeenCalledTimes(1)
+			const events = memory.__emitted.map(e => e.event)
+			expect(events).not.toContain("saveProcessEnder")
+			expect(events).not.toContain("deleteProcessEnder")
 		})
 
 		test("registers no ender while memory is off", () => {
@@ -562,16 +561,15 @@ describe("Convert Routes", () => {
 			expect(command.kill).toHaveBeenCalledTimes(1)
 		})
 
-		test("buffers the ender registration while disconnected and flushes it on reconnect", () => {
+		test("drops enders while disconnected instead of buffering them", () => {
 			memory.__client.connected = false
 			const command = runVideo()
-			expect(memory.__emitted.map(e => e.event)).not.toContain("saveProcessEnder")
+			command.emit("end")
 
 			memory.__client.connected = true
-			const saved = memory.__emitted.find(e => e.event === "saveProcessEnder")
-			expect(saved).toBeDefined()
-			saved.args[1](true)
-			expect(command.kill).toHaveBeenCalledTimes(1)
+			const events = memory.__emitted.map(e => e.event)
+			expect(events).not.toContain("saveProcessEnder")
+			expect(events).not.toContain("deleteProcessEnder")
 		})
 
 		test("registers no ender while memory is off", () => {


### PR DESCRIPTION
`memoryEmitter` in `storage/backend/routes/lib/converter.js` now emits only while the memory socket is connected. While the memory service is unreachable, `saveProcessEnder`/`deleteProcessEnder` packets are dropped instead of accumulating in socket.io-client's `sendBuffer`, so the ack closures no longer retain ffmpeg/archiver object graphs for the duration of the outage. The 24h orphan sweep already reconciles missed enders, so dropping while disconnected is safe.

Updated the two convert tests that encoded the old buffer-and-flush-on-reconnect behavior to assert enders are dropped while disconnected. Call sites in `video.js`/`zip.js` are untouched to stay conflict-free with #417/#413.

Fixes #416
