### PR TITLE
Count untracked per-camera leftovers in storage cap usage

### DIFF
--- a/storage/backend/lib/fsUsage.js
+++ b/storage/backend/lib/fsUsage.js
@@ -21,8 +21,11 @@ const untrackedSubdirBytes = async (dir, trackedNames) => {
 	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
 	const subdirs = entries.filter((entry) => entry.isDirectory())
 	const totals = await mapLimit(subdirs, FS_CONCURRENCY, async (entry) => {
-		const tracked = await trackedNames(entry.name)
-		return dirFileBytes(path.join(dir, entry.name), (name) => !tracked.has(name))
+		const subDir = path.join(dir, entry.name)
+		const subEntries = await fs.promises.readdir(subDir, { withFileTypes: true }).catch(() => [])
+		const fileNames = subEntries.filter((e) => e.isFile()).map((e) => e.name)
+		const tracked = await trackedNames(entry.name, fileNames)
+		return dirFileBytes(subDir, (name) => !tracked.has(name))
 	})
 	return totals.reduce((sum, bytes) => sum + bytes, 0)
 }

--- a/storage/backend/lib/fsUsage.js
+++ b/storage/backend/lib/fsUsage.js
@@ -7,9 +7,9 @@ const FS_CONCURRENCY = 64
 const CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH || "", "shared/captures")
 const OBJECT_CAPTURES_DIR = path.join(process.env.storage_FOLDERPATH || "", "objectCaptures")
 
-const dirFileBytes = async (dir) => {
+const dirFileBytes = async (dir, include = () => true) => {
 	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
-	const files = entries.filter((entry) => entry.isFile())
+	const files = entries.filter((entry) => entry.isFile() && include(entry.name))
 	const sizes = await mapLimit(files, FS_CONCURRENCY, async (entry) => {
 		const { size } = await fs.promises.stat(path.join(dir, entry.name)).catch(() => ({ size: 0 }))
 		return size
@@ -17,4 +17,14 @@ const dirFileBytes = async (dir) => {
 	return sizes.reduce((sum, size) => sum + size, 0)
 }
 
-module.exports = { FS_CONCURRENCY, CAPTURES_DIR, OBJECT_CAPTURES_DIR, dirFileBytes }
+const untrackedSubdirBytes = async (dir, trackedNames) => {
+	const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => [])
+	const subdirs = entries.filter((entry) => entry.isDirectory())
+	const totals = await mapLimit(subdirs, FS_CONCURRENCY, async (entry) => {
+		const tracked = await trackedNames(entry.name)
+		return dirFileBytes(path.join(dir, entry.name), (name) => !tracked.has(name))
+	})
+	return totals.reduce((sum, bytes) => sum + bytes, 0)
+}
+
+module.exports = { FS_CONCURRENCY, CAPTURES_DIR, OBJECT_CAPTURES_DIR, dirFileBytes, untrackedSubdirBytes }

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -5,7 +5,7 @@ const moment = require("moment")
 const { loadCameras, webhookAlert, mapLimit } = require("lib")
 
 const { pool, bulkPool } = require("../../lib/pool")
-const { FS_CONCURRENCY, CAPTURES_DIR, OBJECT_CAPTURES_DIR, dirFileBytes } = require("../../lib/fsUsage")
+const { FS_CONCURRENCY, CAPTURES_DIR, OBJECT_CAPTURES_DIR, dirFileBytes, untrackedSubdirBytes } = require("../../lib/fsUsage")
 
 const MAX_STUCK_BATCHES = 3
 
@@ -142,8 +142,9 @@ module.exports = {
 			const frameTotal = parseInt(frameTotalRows[0].total) || 0
 
 			const nonFrameBytes = await dirFileBytes(CAPTURES_DIR)
+			const untrackedBytes = await untrackedSubdirBytes(CAPTURES_DIR, trackedFrameNames)
 			const usedObjectBytes = await dirFileBytes(OBJECT_CAPTURES_DIR)
-			const totalUsedBytes = frameTotal + nonFrameBytes + usedObjectBytes
+			const totalUsedBytes = frameTotal + nonFrameBytes + untrackedBytes + usedObjectBytes
 
 			const targetBytes = maxGb * 0.9 * 1e9
 			if (totalUsedBytes <= targetBytes) return res.send({ cleaned: false })
@@ -226,6 +227,12 @@ module.exports = {
 			res.status(500).send({ error: true })
 		})
 	}
+}
+
+const trackedFrameNames = async (camera) => {
+	if (!/^\d+$/.test(camera)) return new Set()
+	const { rows } = await bulkPool.query("SELECT name FROM frame_files WHERE camera=$1", [camera])
+	return new Set(rows.map((row) => path.basename(row.name || "")))
 }
 
 const queryForMetric = (camera, metric) => {

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -229,9 +229,12 @@ module.exports = {
 	}
 }
 
-const trackedFrameNames = async (camera) => {
-	if (!/^\d+$/.test(camera)) return new Set()
-	const { rows } = await bulkPool.query("SELECT name FROM frame_files WHERE camera=$1", [camera])
+const trackedFrameNames = async (camera, fileNames) => {
+	if (!/^\d+$/.test(camera) || fileNames.length === 0) return new Set()
+	const { rows } = await bulkPool.query(
+		"SELECT name FROM frame_files WHERE camera=$1 AND name = ANY($2::text[])",
+		[camera, fileNames]
+	)
 	return new Set(rows.map((row) => path.basename(row.name || "")))
 }
 

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -457,7 +457,7 @@ describe("File Routes", () => {
 
 			test("counts untracked per-camera leftovers toward the cap and cleans", async () => {
 				process.env.storage_MAX_GB = "1"
-				const cameraDir = path.join("/tmp/storage-file-test", "shared/captures", "1")
+				const cameraDir = path.join(process.env.storage_FOLDERPATH, "shared/captures", "1")
 				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p) => {
 					if (String(p) === cameraDir) return Promise.resolve([
 						{ name: "tracked.jpg", isFile: () => true, isDirectory: () => false },
@@ -490,7 +490,7 @@ describe("File Routes", () => {
 
 			test("does not double-count tracked frames sitting in per-camera directories", async () => {
 				process.env.storage_MAX_GB = "1"
-				const cameraDir = path.join("/tmp/storage-file-test", "shared/captures", "1")
+				const cameraDir = path.join(process.env.storage_FOLDERPATH, "shared/captures", "1")
 				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p) => {
 					if (String(p) === cameraDir) return Promise.resolve([{ name: "tracked.jpg", isFile: () => true, isDirectory: () => false }])
 					if (String(p).endsWith("captures")) return Promise.resolve([{ name: "1", isFile: () => false, isDirectory: () => true }])

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -438,7 +438,7 @@ describe("File Routes", () => {
 				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "500000000" }] }))
 				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p) =>
 					Promise.resolve(String(p).endsWith("captures")
-						? [{ name: "big.mp4", isFile: () => true }]
+						? [{ name: "big.mp4", isFile: () => true, isDirectory: () => false }]
 						: []))
 				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ size: 2000000000 })
 				try {
@@ -448,6 +448,65 @@ describe("File Routes", () => {
 					expect(res.status).toBe(200)
 					expect(res.body).toEqual({ cleaned: false })
 					expect(bulkQuery).toHaveBeenCalledTimes(1)
+					expect(unlinkSpy).not.toHaveBeenCalled()
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
+
+			test("counts untracked per-camera leftovers toward the cap and cleans", async () => {
+				process.env.storage_MAX_GB = "1"
+				const cameraDir = path.join("/tmp/storage-file-test", "shared/captures", "1")
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p) => {
+					if (String(p) === cameraDir) return Promise.resolve([
+						{ name: "tracked.jpg", isFile: () => true, isDirectory: () => false },
+						{ name: "orphan.jpg", isFile: () => true, isDirectory: () => false }
+					])
+					if (String(p).endsWith("captures")) return Promise.resolve([{ name: "1", isFile: () => false, isDirectory: () => true }])
+					return Promise.resolve([])
+				})
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ size: 600000000 })
+				bulkQuery
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "500000000" }] }))
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ name: "tracked.jpg" }] }))
+					.mockImplementationOnce(() => Promise.resolve({ rows: [
+						{ id: 1, camera: "1", name: "tracked.jpg", size: "500000000" }
+					] }))
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ cleaned: true, deleted: 1 })
+					expect(bulkQuery.mock.calls[1]).toEqual(["SELECT name FROM frame_files WHERE camera=$1", ["1"]])
+					expect(stat).toHaveBeenCalledWith(path.join(cameraDir, "orphan.jpg"))
+					expect(stat).not.toHaveBeenCalledWith(path.join(cameraDir, "tracked.jpg"))
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
+
+			test("does not double-count tracked frames sitting in per-camera directories", async () => {
+				process.env.storage_MAX_GB = "1"
+				const cameraDir = path.join("/tmp/storage-file-test", "shared/captures", "1")
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p) => {
+					if (String(p) === cameraDir) return Promise.resolve([{ name: "tracked.jpg", isFile: () => true, isDirectory: () => false }])
+					if (String(p).endsWith("captures")) return Promise.resolve([{ name: "1", isFile: () => false, isDirectory: () => true }])
+					return Promise.resolve([])
+				})
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ size: 500000000 })
+				bulkQuery
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "500000000" }] }))
+					.mockImplementationOnce(() => Promise.resolve({ rows: [{ name: "tracked.jpg" }] }))
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ cleaned: false })
+					expect(stat).not.toHaveBeenCalled()
 					expect(unlinkSpy).not.toHaveBeenCalled()
 				} finally {
 					readdir.mockRestore()

--- a/storage/test/file.test.js
+++ b/storage/test/file.test.js
@@ -479,7 +479,10 @@ describe("File Routes", () => {
 						.set("Cookie", cookieWithBearerToken)
 					expect(res.status).toBe(200)
 					expect(res.body).toEqual({ cleaned: true, deleted: 1 })
-					expect(bulkQuery.mock.calls[1]).toEqual(["SELECT name FROM frame_files WHERE camera=$1", ["1"]])
+					expect(bulkQuery.mock.calls[1]).toEqual([
+						"SELECT name FROM frame_files WHERE camera=$1 AND name = ANY($2::text[])",
+						["1", ["tracked.jpg", "orphan.jpg"]]
+					])
 					expect(stat).toHaveBeenCalledWith(path.join(cameraDir, "orphan.jpg"))
 					expect(stat).not.toHaveBeenCalledWith(path.join(cameraDir, "tracked.jpg"))
 				} finally {
@@ -508,6 +511,30 @@ describe("File Routes", () => {
 					expect(res.body).toEqual({ cleaned: false })
 					expect(stat).not.toHaveBeenCalled()
 					expect(unlinkSpy).not.toHaveBeenCalled()
+				} finally {
+					readdir.mockRestore()
+					stat.mockRestore()
+				}
+			})
+
+			test("counts an entire non-numeric capture subdirectory as untracked", async () => {
+				process.env.storage_MAX_GB = "10"
+				const strayDir = path.join(process.env.storage_FOLDERPATH, "shared/captures", "lost+found")
+				const readdir = jest.spyOn(fs.promises, "readdir").mockImplementation((p) => {
+					if (String(p) === strayDir) return Promise.resolve([{ name: "stray.jpg", isFile: () => true, isDirectory: () => false }])
+					if (String(p).endsWith("captures")) return Promise.resolve([{ name: "lost+found", isFile: () => false, isDirectory: () => true }])
+					return Promise.resolve([])
+				})
+				const stat = jest.spyOn(fs.promises, "stat").mockResolvedValue({ size: 2000000 })
+				bulkQuery.mockImplementationOnce(() => Promise.resolve({ rows: [{ total: "1000000" }] }))
+				try {
+					const res = await supertest(app)
+						.post("/file/pathAutoClean")
+						.set("Cookie", cookieWithBearerToken)
+					expect(res.status).toBe(200)
+					expect(res.body).toEqual({ cleaned: false })
+					expect(bulkQuery).toHaveBeenCalledTimes(1)
+					expect(stat).toHaveBeenCalledWith(path.join(strayDir, "stray.jpg"))
 				} finally {
 					readdir.mockRestore()
 					stat.mockRestore()


### PR DESCRIPTION
autoClean's usage math only saw DB-tracked frame bytes plus top-level capture files, so orphaned frames left in per-camera directories (failed unlinks, deferred exports) were invisible to cap enforcement.

- `fsUsage.js`: `dirFileBytes` takes an optional filename filter; new `untrackedSubdirBytes` walks first-level subdirectories and sums only files not present in a tracked-name set.
- `file.js`: autoClean adds these untracked bytes to `totalUsedBytes`, resolving tracked names per camera directory from `frame_files` (avoids double-counting `frameTotal`). Prune loop untouched (#413).
- Tests: covers counting untracked leftovers and not double-counting tracked frames.

Fixes #412