### PR TITLE
refresh export lock on interval, not progress events

### DIFF
--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -13,7 +13,6 @@ const STATS_WINDOW_DAYS = 32
 
 const EXPORT_LOCK_ACTIVE_MS = 5 * 60 * 1000
 
-// Comfortably under a third of EXPORT_LOCK_ACTIVE_MS, so a couple of missed ticks can't cross the threshold.
 const EXPORT_LOCK_REFRESH_MS = EXPORT_LOCK_ACTIVE_MS / 3
 
 const UNLINK_BATCH = 500

--- a/storage/backend/routes/lib/file.js
+++ b/storage/backend/routes/lib/file.js
@@ -13,6 +13,9 @@ const STATS_WINDOW_DAYS = 32
 
 const EXPORT_LOCK_ACTIVE_MS = 5 * 60 * 1000
 
+// Comfortably under a third of EXPORT_LOCK_ACTIVE_MS, so a couple of missed ticks can't cross the threshold.
+const EXPORT_LOCK_REFRESH_MS = EXPORT_LOCK_ACTIVE_MS / 3
+
 const UNLINK_BATCH = 500
 
 const camerasOrFail = (res) => loadCameras().catch(() => {
@@ -30,6 +33,9 @@ const exportInProgress = async () => {
 }
 
 module.exports = {
+	EXPORT_LOCK_ACTIVE_MS,
+	EXPORT_LOCK_REFRESH_MS,
+
 	validateCameraAndAppendToPath: (req, res, next) => {
 		const camera = parseInt(req.body.camera)
 		if(camera == req.body.camera){

--- a/storage/backend/routes/lib/video.js
+++ b/storage/backend/routes/lib/video.js
@@ -9,6 +9,7 @@ const {
 	fileName,
 	memoryEmitter,
 }              = require("./converter.js")
+const { EXPORT_LOCK_REFRESH_MS } = require("./file.js")
 const {webhookAlert, alertTime, gatewayHost} = require("lib")
 
 ffmpeg.setFfmpegPath(process.env.ffmpeg_FILEPATH)
@@ -91,6 +92,11 @@ const video = (camera, fps, frames, start, end, rand, save, req, res) => {
 		const mp4Path = path.join(imgDir, fileName(camera, start, end, rand, "mp4"))
 		let cancelled = false
 
+		const refreshLock = setInterval(() => {
+			fs.utimes(txtPath, new Date(), new Date(), () => {})
+		}, EXPORT_LOCK_REFRESH_MS)
+		refreshLock.unref()
+
 		let videoCreator = ffmpeg(imgDir+`/mp4_${rand}.txt`)
 			.inputFormat("concat") //ffmpeg(slash(path.join(imgDir,"img.txt"))).inputFormat('concat');
 			.outputFPS(fps)
@@ -99,9 +105,9 @@ const video = (camera, fps, frames, start, end, rand, save, req, res) => {
 			.toFormat("mp4")
 			.on("progress", function(progress) {
 				bar.update(Math.round((progress.frames/frames)*100))
-				fs.utimes(txtPath, new Date(), new Date(), () => {})
 			})
 			.on("end", () => {
+				clearInterval(refreshLock)
 				bar.stop()
 				emitToMemory("deleteProcessEnder", rand)
 				fs.unlink(txtPath, () => {
@@ -112,6 +118,7 @@ const video = (camera, fps, frames, start, end, rand, save, req, res) => {
 			})
 
 		videoCreator.on("error", function(err) {
+			clearInterval(refreshLock)
 			console.log("An error occurred: " + err.message)
 			emitToMemory("deleteProcessEnder", rand)
 			if(!save){
@@ -129,6 +136,7 @@ const video = (camera, fps, frames, start, end, rand, save, req, res) => {
 		emitToMemory("saveProcessEnder", rand, (cancel) => {
 			if(!cancel) return
 			cancelled = true
+			clearInterval(refreshLock)
 			videoCreator.kill()
 		})
 

--- a/storage/backend/routes/lib/zip.js
+++ b/storage/backend/routes/lib/zip.js
@@ -8,6 +8,7 @@ const {
 	fileName,
 	memoryEmitter,
 }              = require("./converter.js")
+const { EXPORT_LOCK_REFRESH_MS } = require("./file.js")
 const {webhookAlert, alertTime, gatewayHost} = require("lib")
 
 const emitToMemory = memoryEmitter("ZIP PROCESS")
@@ -48,9 +49,10 @@ const zip = (archive, camera, frames, start, end, rand, save, req, res) => {
 		res.send({ id: rand, url: undefined })
 	}
 	else{
-		archive.on("progress", () => {
+		const refreshLock = setInterval(() => {
 			fs.utimes(txtPath, new Date(), new Date(), () => {})
-		})
+		}, EXPORT_LOCK_REFRESH_MS)
+		refreshLock.unref()
 
 		if(save){
 			const zipPath = path.join(imgDir, fileName(camera, start, end, rand, "zip"))
@@ -64,6 +66,7 @@ const zip = (archive, camera, frames, start, end, rand, save, req, res) => {
 			}
 
 			output.on("error", (err) => {
+				clearInterval(refreshLock)
 				cancelled = true
 				console.log("ZIP OUTPUT ERROR: " + err.message)
 				emitToMemory("deleteProcessEnder", rand)
@@ -76,6 +79,7 @@ const zip = (archive, camera, frames, start, end, rand, save, req, res) => {
 			webhookAlert(`ZIP Started:\nID: ${rand}\nCamera: ${camera}\nFrames: ${frames}\nStart: ${alertTime(start, dateFormat).format("dddd, MMMM Do YYYY, h:mm:ss a z")}\nEnd: ${alertTime(end, dateFormat).format("dddd, MMMM Do YYYY, h:mm:ss a z")}`)
 
 			output.on("close", () => {
+				clearInterval(refreshLock)
 				emitToMemory("deleteProcessEnder", rand)
 				fs.unlink(txtPath, () => {
 					if(cancelled){
@@ -89,6 +93,7 @@ const zip = (archive, camera, frames, start, end, rand, save, req, res) => {
 			})
 
 			archive.on("error", function(err) {
+				clearInterval(refreshLock)
 				console.log("An error occurred: " + err.message)
 				emitToMemory("deleteProcessEnder", rand)
 				fs.unlink(txtPath, () => {
@@ -104,6 +109,7 @@ const zip = (archive, camera, frames, start, end, rand, save, req, res) => {
 			emitToMemory("saveProcessEnder", rand, (cancel) => {
 				if(!cancel) return
 				cancelled = true
+				clearInterval(refreshLock)
 				archive.abort()
 			})
 
@@ -115,12 +121,16 @@ const zip = (archive, camera, frames, start, end, rand, save, req, res) => {
 		}
 		else{
 			archive.on("error", function(err) {
+				clearInterval(refreshLock)
 				console.log("An error occurred: " + err.message)
 				fs.unlink(txtPath, () => {})
 				if(!res.headersSent) return res.status(500).end()
 				res.destroy(err)
 			})
-			res.on("close", () => fs.unlink(txtPath, () => {}))
+			res.on("close", () => {
+				clearInterval(refreshLock)
+				fs.unlink(txtPath, () => {})
+			})
 			res.attachment(fileName(camera, start, end, rand, "zip"))
 			archive.pipe(res, {end: true})
 		}

--- a/storage/test/convertLockRefresh.test.js
+++ b/storage/test/convertLockRefresh.test.js
@@ -1,11 +1,13 @@
 const path = require("path")
 
+const mockOutputHandlers = {}
+
 const mockFs = {
 	utimes: jest.fn((p, atime, mtime, cb) => cb && cb(null)),
 	writeFile: jest.fn((p, data, cb) => cb && cb(null)),
 	unlink: jest.fn((p, cb) => cb && cb(null)),
 	readdir: jest.fn((p, cb) => cb(null, ["20210101-000000-00.jpg", "20210101-120000-00.jpg"])),
-	createWriteStream: jest.fn(() => ({ on: () => {} }))
+	createWriteStream: jest.fn(() => ({ on: (event, cb) => { mockOutputHandlers[event] = cb } }))
 }
 
 const mockFfmpegHandlers = {}
@@ -55,27 +57,50 @@ jest.mock("memory")
 
 const { createVideo } = require("../backend/routes/lib/video.js")
 const { createZip } = require("../backend/routes/lib/zip.js")
+const { EXPORT_LOCK_ACTIVE_MS, EXPORT_LOCK_REFRESH_MS } = require("../backend/routes/lib/file.js")
+const memory = require("memory")
 
 const START = "20210101-000000"
 const END = "20210102-000000"
 
 const lockWrites = () => mockFs.writeFile.mock.calls.map(([p]) => p)
 
+const zipLockPath = () => lockWrites().find(p => /zip_.+\.txt$/.test(p))
+
+const cancelEnder = () => {
+	const saved = memory.__emitted.find(e => e.event === "saveProcessEnder")
+	saved.args[1](true)
+}
+
 beforeEach(() => {
+	jest.useFakeTimers()
 	for (const fn of Object.values(mockFs)) fn.mockClear()
 	for (const key of Object.keys(mockFfmpegHandlers)) delete mockFfmpegHandlers[key]
 	for (const key of Object.keys(mockArchiveHandlers)) delete mockArchiveHandlers[key]
+	for (const key of Object.keys(mockOutputHandlers)) delete mockOutputHandlers[key]
+	memory.__emitted.length = 0
+	process.env.memory_ON = "true"
+})
+
+afterEach(() => {
+	jest.useRealTimers()
+	delete process.env.memory_ON
 })
 
 describe("convert lock refresh", () => {
-	test("a video progress event touches the same lock file the sweep ages out", (done) => {
+	test("the refresh period comfortably undercuts the active-lock threshold", () => {
+		expect(EXPORT_LOCK_REFRESH_MS).toBeLessThan(EXPORT_LOCK_ACTIVE_MS)
+		expect(EXPORT_LOCK_REFRESH_MS * 2).toBeLessThan(EXPORT_LOCK_ACTIVE_MS)
+	})
+
+	test("a video job with no progress events still gets its lock refreshed by the interval", (done) => {
 		createVideo({ body: { camera: "1", start: START, end: END } }, {
 			send: ({ id }) => {
 				const lockPath = path.join(process.env.storage_FOLDERPATH, "shared/captures", `mp4_${id}.txt`)
 				expect(lockWrites()).toContain(lockPath)
 				expect(mockFs.utimes).not.toHaveBeenCalled()
 
-				mockFfmpegHandlers.progress({ frames: 1 })
+				jest.advanceTimersByTime(EXPORT_LOCK_REFRESH_MS)
 
 				expect(mockFs.utimes).toHaveBeenCalledWith(lockPath, expect.any(Date), expect.any(Date), expect.any(Function))
 				done()
@@ -83,7 +108,7 @@ describe("convert lock refresh", () => {
 		})
 	})
 
-	test("a zip progress event touches the same lock file the sweep ages out", () => {
+	test("a zip job with no progress events still gets its lock refreshed by the interval", () => {
 		let sent
 		createZip({ body: { camera: "1", start: START, end: END } }, { send: (body) => { sent = body } })
 
@@ -91,16 +116,47 @@ describe("convert lock refresh", () => {
 		expect(lockWrites()).toContain(lockPath)
 		expect(mockFs.utimes).not.toHaveBeenCalled()
 
-		mockArchiveHandlers.progress({ entries: { processed: 1, total: 2 } })
+		jest.advanceTimersByTime(EXPORT_LOCK_REFRESH_MS)
 
 		expect(mockFs.utimes).toHaveBeenCalledWith(lockPath, expect.any(Date), expect.any(Date), expect.any(Function))
+	})
+
+	test("a streaming zip (save:false) also gets its lock refreshed by the interval", () => {
+		createZip({ body: { camera: "1", start: START, end: END, save: false } }, {
+			attachment: () => {},
+			on: () => {},
+			send: () => {}
+		})
+
+		const lockPath = zipLockPath()
+		expect(lockPath).toBeDefined()
+		expect(mockFs.utimes).not.toHaveBeenCalled()
+
+		jest.advanceTimersByTime(EXPORT_LOCK_REFRESH_MS)
+
+		expect(mockFs.utimes).toHaveBeenCalledWith(lockPath, expect.any(Date), expect.any(Date), expect.any(Function))
+	})
+
+	test("video progress events no longer touch the lock file directly", (done) => {
+		createVideo({ body: { camera: "1", start: START, end: END } }, {
+			send: () => {
+				mockFfmpegHandlers.progress({ frames: 1 })
+				expect(mockFs.utimes).not.toHaveBeenCalled()
+				done()
+			}
+		})
+	})
+
+	test("zip no longer registers a progress handler for lock refresh", () => {
+		createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+		expect(mockArchiveHandlers.progress).toBeUndefined()
 	})
 
 	test("the refreshed mtime is newer than the orphan-sweep threshold", () => {
 		const ORPHAN_AGE_MS = 24 * 60 * 60 * 1000
 		createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
 
-		mockArchiveHandlers.progress({ entries: { processed: 1, total: 2 } })
+		jest.advanceTimersByTime(EXPORT_LOCK_REFRESH_MS)
 
 		const [, , mtime] = mockFs.utimes.mock.calls[0]
 		expect(Date.now() - mtime.getTime()).toBeLessThan(ORPHAN_AGE_MS)
@@ -116,9 +172,116 @@ describe("convert lock refresh", () => {
 
 		expect(sent).toBeUndefined()
 		expect(lockWrites().filter(p => /zip_.+\.txt$/.test(p))).toHaveLength(1)
+	})
 
-		mockArchiveHandlers.progress({ entries: { processed: 1, total: 2 } })
+	describe("interval cleared on terminal paths, so a finished export cannot keep its lock alive", () => {
+		test("stops refreshing the video lock once ffmpeg ends", (done) => {
+			createVideo({ body: { camera: "1", start: START, end: END } }, {
+				send: () => {
+					mockFfmpegHandlers.end()
+					mockFs.utimes.mockClear()
 
-		expect(mockFs.utimes).toHaveBeenCalledWith(lockWrites()[0], expect.any(Date), expect.any(Date), expect.any(Function))
+					jest.advanceTimersByTime(EXPORT_LOCK_ACTIVE_MS * 2)
+
+					expect(mockFs.utimes).not.toHaveBeenCalled()
+					done()
+				}
+			})
+		})
+
+		test("stops refreshing the video lock once ffmpeg errors", (done) => {
+			createVideo({ body: { camera: "1", start: START, end: END } }, {
+				send: () => {
+					mockFfmpegHandlers.error(new Error("ffmpeg exited with code 1"))
+					mockFs.utimes.mockClear()
+
+					jest.advanceTimersByTime(EXPORT_LOCK_ACTIVE_MS * 2)
+
+					expect(mockFs.utimes).not.toHaveBeenCalled()
+					done()
+				}
+			})
+		})
+
+		test("stops refreshing the video lock once the export is cancelled", (done) => {
+			createVideo({ body: { camera: "1", start: START, end: END } }, {
+				send: () => {
+					cancelEnder()
+					mockFs.utimes.mockClear()
+
+					jest.advanceTimersByTime(EXPORT_LOCK_ACTIVE_MS * 2)
+
+					expect(mockFs.utimes).not.toHaveBeenCalled()
+					done()
+				}
+			})
+		})
+
+		test("stops refreshing the zip (save) lock once the output stream closes", () => {
+			createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+
+			mockOutputHandlers.close()
+			mockFs.utimes.mockClear()
+
+			jest.advanceTimersByTime(EXPORT_LOCK_ACTIVE_MS * 2)
+
+			expect(mockFs.utimes).not.toHaveBeenCalled()
+		})
+
+		test("stops refreshing the zip (save) lock once the archive errors", () => {
+			createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+
+			mockArchiveHandlers.error(new Error("archive error"))
+			mockFs.utimes.mockClear()
+
+			jest.advanceTimersByTime(EXPORT_LOCK_ACTIVE_MS * 2)
+
+			expect(mockFs.utimes).not.toHaveBeenCalled()
+		})
+
+		test("stops refreshing the zip (save) lock once the export is cancelled", () => {
+			createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+
+			cancelEnder()
+			mockFs.utimes.mockClear()
+
+			jest.advanceTimersByTime(EXPORT_LOCK_ACTIVE_MS * 2)
+
+			expect(mockFs.utimes).not.toHaveBeenCalled()
+		})
+
+		test("stops refreshing the streaming zip lock once the archive errors", () => {
+			let resHandlers = {}
+			createZip({ body: { camera: "1", start: START, end: END, save: false } }, {
+				attachment: () => {},
+				on: (event, cb) => { resHandlers[event] = cb },
+				send: () => {},
+				headersSent: false,
+				status: () => ({ end: () => {} })
+			})
+
+			mockArchiveHandlers.error(new Error("archive error"))
+			mockFs.utimes.mockClear()
+
+			jest.advanceTimersByTime(EXPORT_LOCK_ACTIVE_MS * 2)
+
+			expect(mockFs.utimes).not.toHaveBeenCalled()
+		})
+
+		test("stops refreshing the streaming zip lock once the response closes", () => {
+			let resHandlers = {}
+			createZip({ body: { camera: "1", start: START, end: END, save: false } }, {
+				attachment: () => {},
+				on: (event, cb) => { resHandlers[event] = cb },
+				send: () => {}
+			})
+
+			resHandlers.close()
+			mockFs.utimes.mockClear()
+
+			jest.advanceTimersByTime(EXPORT_LOCK_ACTIVE_MS * 2)
+
+			expect(mockFs.utimes).not.toHaveBeenCalled()
+		})
 	})
 })


### PR DESCRIPTION
Fixes #417

The export lock's `fs.utimes` refresh was tied to `progress` events, which conflates liveness with throughput. A stalled-but-alive export (client backpressure, or an ffmpeg child orphaned by a node crash) stops emitting progress, loses its lock after `EXPORT_LOCK_ACTIVE_MS`, and a concurrent prune can delete its source frames mid-export.

## Change

- Replaced the `progress`-driven `fs.utimes` refresh in `video.js` and `zip.js` with a `setInterval` that starts when the job starts and is cleared on every terminal path (end, error, cancel).
- `video.js`'s progress handler keeps `bar.update(...)`; only the `fs.utimes` call moved.
- `zip.js`'s progress handler did nothing but refresh the lock, so it's removed entirely.
- Added `EXPORT_LOCK_REFRESH_MS = EXPORT_LOCK_ACTIVE_MS / 3` (100s) in `file.js`, exported alongside `EXPORT_LOCK_ACTIVE_MS` so the relationship is asserted in tests rather than hardcoded. A third of the 5-minute active threshold means two missed ticks still can't cross it.
- The interval is `.unref()`'d so a leaked one can't hold the process open.
- No interval is created on the zero-frame early-return paths, since the job never starts there.

## Tests

Rewrote `storage/test/convertLockRefresh.test.js` (fake timers) to cover:
- A job that emits no progress events still gets its lock refreshed (the actual regression).
- `EXPORT_LOCK_REFRESH_MS` is strictly less than `EXPORT_LOCK_ACTIVE_MS`, asserted against the imported constants.
- The interval is cleared on end/error/cancel for both the video path and both zip paths (save and streaming), so a finished job cannot keep refreshing a dead lock.

## Test plan

- [x] `npx jest --selectProjects storage` — 157/158 pass; the one failure (`file.test.js` › `pathDelete` › "reports deleted:false...") reproduces identically on `develop` with these changes stashed out, so it's a pre-existing, unrelated flake.