### PR TITLE
Write .env and camera configs at 0640 (#427)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ sudo chown "$USER":1000 .env && sudo chmod 640 .env
 
 `chmod 644 .env` also clears the error, but then every account on the machine can read your secrets. With `640` only you and group 1000 can. If your own uid is already 1000 — most single-user installs — `.env` needs nothing.
 
+Each `cameraconf/*.conf` holds `netcam_userpass`, a camera password, and `cp` leaves it at the same world-readable `644`. The container fixes its group on every start, so a hand-copied camera conf only needs the mode tightened, not the ownership:
+
+```sh
+chmod 640 cameraconf/*.conf
+```
+
 This only matters when the project folder lives on Linux — a Linux host, or a folder inside WSL such as `\\wsl$\Ubuntu\home\you\chimera`. On a Mac or Windows drive, such as `C:\Users\you\chimera` or `/mnt/c/Users/you/chimera`, Docker Desktop sets the ownership for you.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -126,7 +126,13 @@ Why the cookie can't just read the request: [command](command#config).
 
 A few checks wait until the container starts: the `*_URL` addresses and the file paths. The cookie check runs again there too, in case `.env` changed after the build. So a build can pass and still fail on startup — the container then restarts over and over, and `npm run docker:logs` shows which value it stopped on.
 
-**Or it says `CANNOT READ`.** The app reads `.env` and `motion.conf` from inside the container as a normal user, not root. Copy them with plain `cp`, which leaves them readable — no `sudo`, and no `chmod 600`. If you already used `sudo`, `sudo chmod 644 .env motion.conf` undoes it.
+**Or it says `CANNOT READ`.** The app reads `.env` and `motion.conf` from inside the container as the user `node`, which is uid 1000. Copy them with plain `cp`, not `sudo`, so they stay yours. `motion.conf` holds no secret and is fine at the default `644`. `.env` holds your passwords and tokens, so give it to group 1000 and nobody else:
+
+```sh
+sudo chown "$USER":1000 .env && sudo chmod 640 .env
+```
+
+`chmod 644 .env` also clears the error, but then every account on the machine can read your secrets. With `640` only you and group 1000 can. If your own uid is already 1000 — most single-user installs — `.env` needs nothing.
 
 This only matters when the project folder lives on Linux — a Linux host, or a folder inside WSL such as `\\wsl$\Ubuntu\home\you\chimera`. On a Mac or Windows drive, such as `C:\Users\you\chimera` or `/mnt/c/Users/you/chimera`, Docker Desktop sets the ownership for you.
 

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -59,7 +59,24 @@ const setVal = (lines, key, value) => {
 	else lines.push(`${key} = ${value}`)
 }
 
-const seedEnv = () => fs.writeFileSync(ENV,
+const SECRET_MODE = 0o640
+const CONTAINER_GID = 1000
+const secretsWritten = []
+const writeSecret = (file, data) => {
+	fs.writeFileSync(file, data)
+	fs.chmodSync(file, SECRET_MODE)
+	if (!secretsWritten.includes(file)) secretsWritten.push(file)
+}
+const groupHint = () => {
+	const gid = process.getgid?.()
+	if (!secretsWritten.length || gid === undefined || gid === CONTAINER_GID) return null
+	const files = secretsWritten.map(f => path.relative(ROOT, f)).join(" ")
+	return `Wrote ${files} mode 0640 — your account and group ${CONTAINER_GID} can read them, nobody else.\n`
+		+ `The container runs as uid ${CONTAINER_GID} and your gid is not ${CONTAINER_GID}, so hand it the group or the container will restart-loop:\n`
+		+ `  sudo chown "$USER":${CONTAINER_GID} ${files} && sudo chmod 640 ${files}\n`
+}
+
+const seedEnv = () => writeSecret(ENV,
 	fs.readFileSync(ENV_EXAMPLE, "utf8").split(/\r?\n/).map(line => {
 		const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/)
 		if (!m) return line
@@ -320,7 +337,7 @@ const runInteractive = async () => {
 				const p = urlProblem(url, buildFullUrl(url, userpass))
 				if (p) console.log(`    ${BAD} ${p}`)
 			} while (urlProblem(url, buildFullUrl(url, userpass)))
-			fs.writeFileSync(path.join(camDir, `cam${id}.conf`), camTemplate(id, name, url, userpass))
+			writeSecret(path.join(camDir, `cam${id}.conf`), camTemplate(id, name, url, userpass))
 			console.log(`    created ${camDir}/cam${id}.conf ${OK}`)
 			if (!(await confirm("  Add another camera?", false))) break
 		}
@@ -329,6 +346,8 @@ const runInteractive = async () => {
 	}
 
 	rl.close()
+	const hint = groupHint()
+	if (hint) console.log(hint)
 	if (motionOk && camOk && envOk) console.log(`All checks passed ${OK}  Safe to run docker.`)
 	else { console.log(`Still incomplete ${BAD}  Docker blocked.`); process.exit(1) }
 }

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -71,7 +71,7 @@ const groupHint = () => {
 	const gid = process.getgid?.()
 	if (!secretsWritten.includes(ENV) || gid === undefined || gid === CONTAINER_GID) return null
 	const file = path.relative(ROOT, ENV)
-	return `Wrote ${file} mode 0640 — your account and group ${CONTAINER_GID} can read it, nobody else.\n`
+	return `Wrote ${file} mode 0640 — only your account can read it right now.\n`
 		+ `The container runs as uid ${CONTAINER_GID} and your gid is not ${CONTAINER_GID}, so hand it the group or the container will restart-loop:\n`
 		+ `  sudo chown "$USER":${CONTAINER_GID} ${file} && sudo chmod 640 ${file}\n`
 }

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -63,17 +63,17 @@ const SECRET_MODE = 0o640
 const CONTAINER_GID = 1000
 const secretsWritten = []
 const writeSecret = (file, data) => {
-	fs.writeFileSync(file, data)
+	fs.writeFileSync(file, data, { mode: SECRET_MODE })
 	fs.chmodSync(file, SECRET_MODE)
 	if (!secretsWritten.includes(file)) secretsWritten.push(file)
 }
 const groupHint = () => {
 	const gid = process.getgid?.()
-	if (!secretsWritten.length || gid === undefined || gid === CONTAINER_GID) return null
-	const files = secretsWritten.map(f => path.relative(ROOT, f)).join(" ")
-	return `Wrote ${files} mode 0640 — your account and group ${CONTAINER_GID} can read them, nobody else.\n`
+	if (!secretsWritten.includes(ENV) || gid === undefined || gid === CONTAINER_GID) return null
+	const file = path.relative(ROOT, ENV)
+	return `Wrote ${file} mode 0640 — your account and group ${CONTAINER_GID} can read it, nobody else.\n`
 		+ `The container runs as uid ${CONTAINER_GID} and your gid is not ${CONTAINER_GID}, so hand it the group or the container will restart-loop:\n`
-		+ `  sudo chown "$USER":${CONTAINER_GID} ${files} && sudo chmod 640 ${files}\n`
+		+ `  sudo chown "$USER":${CONTAINER_GID} ${file} && sudo chmod 640 ${file}\n`
 }
 
 const seedEnv = () => writeSecret(ENV,

--- a/chimera/test/preflightInteractive.test.js
+++ b/chimera/test/preflightInteractive.test.js
@@ -1,8 +1,9 @@
-const mockState = { files: {}, dirs: [], answers: [] }
+const mockState = { files: {}, dirs: [], answers: [], modes: {} }
 
 jest.mock("fs", () => {
 	const norm = (p) => String(p).replace(/\\/g, "/")
 	const find = (p) => Object.keys(mockState.files).find(k => norm(p).endsWith(k))
+	const key = (p) => find(p) ?? norm(p).split("/").slice(norm(p).includes("/cameraconf/") ? -2 : -1).join("/")
 	return {
 		existsSync: jest.fn((p) => find(p) !== undefined || mockState.dirs.some(d => norm(p).endsWith(d))),
 		readFileSync: jest.fn((p) => {
@@ -10,7 +11,8 @@ jest.mock("fs", () => {
 			if (k === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
 			return mockState.files[k]
 		}),
-		writeFileSync: jest.fn((p, data) => { mockState.files[find(p) ?? norm(p).split("/").pop()] = data }),
+		writeFileSync: jest.fn((p, data) => { mockState.files[key(p)] = data }),
+		chmodSync: jest.fn((p, mode) => { mockState.modes[key(p)] = mode }),
 		copyFileSync: jest.fn((from, to) => { mockState.files[norm(to).split("/").pop()] = mockState.files[find(from)] }),
 		readdirSync: jest.fn(() => Object.keys(mockState.files).filter(k => k.startsWith("cameraconf/")).map(k => k.slice("cameraconf/".length))),
 		mkdirSync: jest.fn()
@@ -41,16 +43,17 @@ const CAM = "camera_id 1\ncamera_name indoor\nnetcam_url rtsp://1.1.1.1/cam\n"
 
 const envText = (env) => Object.entries(env).map(([k, v]) => `${k} = ${v}`).join("\n")
 
-const setup = ({ env, answers, noEnv = false, example = EXAMPLE }) => {
+const setup = ({ env, answers, noEnv = false, noCams = false, example = EXAMPLE }) => {
 	mockState.files = {
 		"env.example": example,
 		"motion.conf": "",
 		"motion.conf.example": "",
-		"cameraconf/cam1.conf": CAM,
+		...(noCams ? {} : { "cameraconf/cam1.conf": CAM }),
 		...(noEnv ? {} : { ".env": envText(env) })
 	}
 	mockState.dirs = ["cameraconf"]
 	mockState.answers = [...answers]
+	mockState.modes = {}
 }
 
 const BLANK = { storage_ON: "", storage_FOLDERPATH: "", livestream_ON: "", livestream_FOLDERPATH: "", livestream_PROXY_ON: "", object_ON: "", SECRETKEY: "" }
@@ -79,7 +82,7 @@ const run = async () => {
 		exit.mockRestore()
 	}
 	expect(mockState.answers).toHaveLength(0)
-	return { out: out.join("\n"), exitCode, env: mockState.files[".env"] ?? "" }
+	return { out: out.join("\n"), exitCode, env: mockState.files[".env"] ?? "", modes: mockState.modes }
 }
 
 describe("runInteractive re-walk", () => {
@@ -158,6 +161,50 @@ describe("runInteractive re-walk", () => {
 		})
 		const { env, exitCode } = await run()
 		expect(env).toContain(`SECRETKEY = ${SECRET}`)
+		expect(exitCode).toBe(0)
+	})
+})
+
+describe("runInteractive secret file modes", () => {
+	// 0640 keeps .env off world-read while still letting the container's uid 1000 read it through group 1000
+	test("a seeded .env lands at 0640, not the umask default", async () => {
+		setup({ env: {}, noEnv: true, answers: ["false", "false", "false", SECRET] })
+		const { modes, exitCode } = await run()
+		expect(modes[".env"]).toBe(0o640)
+		expect(exitCode).toBe(0)
+	})
+
+	// preflight is unprivileged, so it cannot chgrp — the printed command is the only thing that makes 0640 readable to the container
+	const withGid = async (gid) => {
+		const had = Object.prototype.hasOwnProperty.call(process, "getgid")
+		const original = process.getgid
+		if (gid === undefined) delete process.getgid
+		else process.getgid = () => gid
+		try { return await run() }
+		finally { if (had) process.getgid = original; else delete process.getgid }
+	}
+
+	test("tells the user to chgrp when their gid is not 1000", async () => {
+		setup({ env: {}, noEnv: true, answers: ["false", "false", "false", SECRET] })
+		const { out } = await withGid(1001)
+		expect(out).toContain("sudo chown \"$USER\":1000 .env")
+	})
+
+	test("says nothing when the gid already is 1000, or when the host has no gids at all", async () => {
+		setup({ env: {}, noEnv: true, answers: ["false", "false", "false", SECRET] })
+		expect((await withGid(1000)).out).not.toContain("sudo chown")
+		setup({ env: {}, noEnv: true, answers: ["false", "false", "false", SECRET] })
+		expect((await withGid(undefined)).out).not.toContain("sudo chown")
+	})
+
+	test("a camera conf lands at 0640 — it carries netcam_userpass", async () => {
+		setup({
+			env: { ...BLANK, storage_ON: "true", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET },
+			noCams: true,
+			answers: ["y", "2", "back", "rtsp://1.1.1.1/cam", "user:pass", "n"]
+		})
+		const { modes, exitCode } = await run()
+		expect(modes["cameraconf/cam2.conf"]).toBe(0o640)
 		expect(exitCode).toBe(0)
 	})
 })

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ mkdir -p /mnt/storage/shared/captures /app/.well-known/acme-challenge
 chmod 2775 /app/.well-known /app/.well-known/acme-challenge
 chown node:node /mnt/storage /mnt/storage/shared /mnt/storage/shared/captures \
                 /app/.well-known /app/.well-known/acme-challenge
-chown -R node:node /etc/motion/cameraconf
+chown -R :node /etc/motion/cameraconf
 
 echo "→ Validating environment variables..."
 gosu node node chimera/validateEnvVars.js


### PR DESCRIPTION
@
Closes #427.

`README.md:129` told users to run `chmod 644 .env`, and preflight wrote `.env` and `cameraconf/*.conf` at the umask default. Both leave `SECRETKEY`, `setup_TOKEN`, `database_PASSWORD`, and `netcam_userpass` readable by every account on the host.

644 was there because one file has two readers: preflight runs on the host as the invoking user, and the container reads it as `node`, uid 1000 / gid 1000. The mounts are `:ro`, so nothing in the container can chown them. 0600 breaks the container; 0644 satisfies both and exposes the secrets.

0640 with the group set to 1000 satisfies both readers without world-read.

| file | change |
|---|---|
| `chimera/preflight.js` | `writeSecret` helper — write, then `chmodSync(…, 0o640)`. Used by `seedEnv` and camera-conf creation. `chmodSync` rather than `{ mode }` so the umask cannot loosen or tighten the result. |
| `chimera/preflight.js` | `groupHint()` prints the `chown` command, gated on `process.getgid?.()` being defined and not already 1000. Preflight is unprivileged and cannot chgrp itself. |
| `entrypoint.sh:9` | `chown -R node:node` -> `chown -R :node`. Taking ownership of a host bind mount locked host users with uid != 1000 out of adding cameras. Nothing in the container writes `cameraconf/`. |
| `README.md:129` | `sudo chown "$USER":1000 .env && sudo chmod 640 .env`. `motion.conf` carries no literal secret and stays at 644. |

Tests: 0640 asserted on a seeded `.env` and a created `cam2.conf`; the hint asserted present at gid 1001 and absent at gid 1000 and where `process.getgid` does not exist. The fs mock gained `chmodSync` and now keeps the `cameraconf/` prefix on newly written files so `readdirSync` sees them.

Not changed: the `.env` rewrite in `runInteractive` leaves the existing mode alone. An install already at 644 stays there until the user runs the README command. Tightening it there would silently break the container for anyone whose gid is not 1000.
@