### PR TITLE
Scope certbot group-read grant to Chimera's own lineage (#438)

### DIFF
--- a/certbot-entry.sh
+++ b/certbot-entry.sh
@@ -5,9 +5,14 @@
 DOMAIN=$(echo "$gateway_HOST" | sed -e 's|^http://||' -e 's|^https://||' | awk -F/ '{print $1}' | awk -F: '{print $1}')
 mkdir -p /webroot/.well-known/acme-challenge
 
+LE_DIR="${LE_DIR:-/etc/letsencrypt}"
+
 grant_gateway_read() {
-	chgrp -R 1000 /etc/letsencrypt/live /etc/letsencrypt/archive 2>/dev/null || true
-	chmod -R g+rX /etc/letsencrypt/live /etc/letsencrypt/archive 2>/dev/null || true
+	[ -n "$DOMAIN" ] || return 0
+	chgrp 1000 "$LE_DIR/live" "$LE_DIR/archive" 2>/dev/null || true
+	chmod g+X "$LE_DIR/live" "$LE_DIR/archive" 2>/dev/null || true
+	chgrp -R 1000 "$LE_DIR/live/$DOMAIN" "$LE_DIR/archive/$DOMAIN" 2>/dev/null || true
+	chmod -R g+rX "$LE_DIR/live/$DOMAIN" "$LE_DIR/archive/$DOMAIN" 2>/dev/null || true
 }
 
 if [ -n "$DOMAIN" ]; then
@@ -22,7 +27,7 @@ fi
 
 fails=0
 while true; do
-	if [ -n "$DOMAIN" ] && [ ! -d "/etc/letsencrypt/live/$DOMAIN" ]; then
+	if [ -n "$DOMAIN" ] && [ ! -d "$LE_DIR/live/$DOMAIN" ]; then
 		if certbot certonly --webroot -w /webroot -d "$DOMAIN" --register-unsafely-without-email --agree-tos --non-interactive; then
 			grant_gateway_read
 			fails=0

--- a/chimera/test/certbotEntry.test.js
+++ b/chimera/test/certbotEntry.test.js
@@ -1,0 +1,68 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { spawnSync } = require("child_process")
+
+const SCRIPT = path.join(__dirname, "..", "..", "certbot-entry.sh")
+
+const grantGatewayRead = (dir, domain) => {
+	const fn = fs.readFileSync(SCRIPT, "utf8").match(/grant_gateway_read\(\) \{[\s\S]*?\n\}/)
+	expect(fn).not.toBeNull()
+	const res = spawnSync("sh", ["-c", `${fn[0]}\ngrant_gateway_read`], {
+		env: { LE_DIR: dir, DOMAIN: domain },
+		encoding: "utf8"
+	})
+	expect(res.status).toBe(0)
+}
+
+const mode = (...parts) => fs.statSync(path.join(...parts)).mode & 0o777
+
+const store = () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "letsencrypt-"))
+	for (const parent of ["live", "archive"]) {
+		fs.mkdirSync(path.join(dir, parent), { mode: 0o700 })
+		for (const lineage of ["mine.com", "other.com"]) {
+			fs.mkdirSync(path.join(dir, parent, lineage), { mode: 0o700 })
+			fs.writeFileSync(path.join(dir, parent, lineage, "privkey.pem"), "key", { mode: 0o600 })
+		}
+	}
+	return dir
+}
+
+describe("grant_gateway_read", () => {
+	test("opens up only the configured domain's lineage, leaving other certs in the shared store untouched", () => {
+		const dir = store()
+
+		grantGatewayRead(dir, "mine.com")
+
+		expect(mode(dir, "live", "mine.com", "privkey.pem") & 0o040).toBe(0o040)
+		expect(mode(dir, "archive", "mine.com", "privkey.pem") & 0o040).toBe(0o040)
+		expect(mode(dir, "live", "mine.com") & 0o050).toBe(0o050)
+		expect(mode(dir, "archive", "mine.com") & 0o050).toBe(0o050)
+
+		expect(mode(dir, "live", "other.com", "privkey.pem")).toBe(0o600)
+		expect(mode(dir, "archive", "other.com", "privkey.pem")).toBe(0o600)
+		expect(mode(dir, "live", "other.com")).toBe(0o700)
+		expect(mode(dir, "archive", "other.com")).toBe(0o700)
+	})
+
+	test("grants the store parents traverse but not read, so the gateway cannot list what other certs exist", () => {
+		const dir = store()
+
+		grantGatewayRead(dir, "mine.com")
+
+		expect(mode(dir, "live")).toBe(0o710)
+		expect(mode(dir, "archive")).toBe(0o710)
+	})
+
+	test("is a no-op without a domain — an install that owns no cert relaxes nothing", () => {
+		const dir = store()
+
+		grantGatewayRead(dir, "")
+
+		expect(mode(dir, "live")).toBe(0o700)
+		expect(mode(dir, "archive")).toBe(0o700)
+		expect(mode(dir, "live", "mine.com", "privkey.pem")).toBe(0o600)
+		expect(mode(dir, "live", "other.com", "privkey.pem")).toBe(0o600)
+	})
+})

--- a/chimera/test/certbotEntry.test.js
+++ b/chimera/test/certbotEntry.test.js
@@ -5,20 +5,28 @@ const { spawnSync } = require("child_process")
 
 const SCRIPT = path.join(__dirname, "..", "..", "certbot-entry.sh")
 
+const tmp = []
+
 const grantGatewayRead = (dir, domain) => {
 	const fn = fs.readFileSync(SCRIPT, "utf8").match(/grant_gateway_read\(\) \{[\s\S]*?\n\}/)
 	expect(fn).not.toBeNull()
+	const bin = fs.mkdtempSync(path.join(os.tmpdir(), "stubbin-"))
+	const log = path.join(bin, "calls")
+	fs.writeFileSync(path.join(bin, "chgrp"), `#!/bin/sh\necho "$@" >> "${log}"\n`, { mode: 0o755 })
+	tmp.push(bin)
 	const res = spawnSync("sh", ["-c", `${fn[0]}\ngrant_gateway_read`], {
-		env: { LE_DIR: dir, DOMAIN: domain },
+		env: { PATH: `${bin}:${process.env.PATH}`, LE_DIR: dir, DOMAIN: domain },
 		encoding: "utf8"
 	})
 	expect(res.status).toBe(0)
+	return fs.existsSync(log) ? fs.readFileSync(log, "utf8").trim().split("\n") : []
 }
 
 const mode = (...parts) => fs.statSync(path.join(...parts)).mode & 0o777
 
 const store = () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "letsencrypt-"))
+	tmp.push(dir)
 	for (const parent of ["live", "archive"]) {
 		fs.mkdirSync(path.join(dir, parent), { mode: 0o700 })
 		for (const lineage of ["mine.com", "other.com"]) {
@@ -28,6 +36,10 @@ const store = () => {
 	}
 	return dir
 }
+
+afterEach(() => {
+	while (tmp.length) fs.rmSync(tmp.pop(), { recursive: true, force: true })
+})
 
 describe("grant_gateway_read", () => {
 	test("opens up only the configured domain's lineage, leaving other certs in the shared store untouched", () => {
@@ -55,10 +67,19 @@ describe("grant_gateway_read", () => {
 		expect(mode(dir, "archive")).toBe(0o710)
 	})
 
+	test("recurses group ownership only inside the configured lineage, never over the store root", () => {
+		const dir = store()
+
+		expect(grantGatewayRead(dir, "mine.com")).toEqual([
+			`1000 ${dir}/live ${dir}/archive`,
+			`-R 1000 ${dir}/live/mine.com ${dir}/archive/mine.com`
+		])
+	})
+
 	test("is a no-op without a domain — an install that owns no cert relaxes nothing", () => {
 		const dir = store()
 
-		grantGatewayRead(dir, "")
+		expect(grantGatewayRead(dir, "")).toEqual([])
 
 		expect(mode(dir, "live")).toBe(0o700)
 		expect(mode(dir, "archive")).toBe(0o700)


### PR DESCRIPTION
Closes #438.

`grant_gateway_read` handed gid 1000 read on every lineage in `/etc/letsencrypt`, which is a host bind mount (`docker-compose.yml:66`) and the machine's system-wide certbot store. On a host that also runs certbot for nginx or a mail server, starting Chimera dropped those unrelated private keys from `0600 root` to group-1000-readable — gid 1000 being the first human user on a default Debian/Ubuntu install. The call after `certbot renew` also ran unconditionally, so an install with `certbot_ON=true` and no domain configured walked the whole store every 12 hours while owning zero certs.

Now the grant is scoped to `$DOMAIN`:

- returns early when `$DOMAIN` is empty
- `live/` and `archive/` get `chgrp 1000` + `chmod g+X` — traverse only, no read, no listing
- the recursive `chgrp -R` / `chmod -R g+rX` is limited to `live/$DOMAIN` and `archive/$DOMAIN`

That is exactly what the gateway needs to follow `live/$DOMAIN/privkey.pem` into `archive/`, and nothing else.

`LE_DIR` defaults to `/etc/letsencrypt`, so container behaviour is unchanged and no compose edit is needed. It exists so the function can be pointed at a fixture under test. The issuance guard now uses it too, leaving one definition of the store path instead of two.

**This does not retroactively re-lock certs already loosened by earlier runs.** Hosts that ran the old script need a manual `chmod`/`chgrp` to restore `0600 root` on unrelated lineages — this change only stops the loosening from happening again.

### Testing

`chimera/test/certbotEntry.test.js` builds a fake store in a tmpdir with `mine.com` and `other.com` lineages, runs the function with `DOMAIN=mine.com`, and asserts on the resulting file modes: `other.com`'s key stays `0600` and its directory `0700`, `mine.com`'s key becomes group-readable, and the two parents land at `0710`. A third case asserts an empty `$DOMAIN` changes nothing.

The function is extracted from the script by regex and eval'd in `sh` — the script cannot be sourced, since it `exec tail -f /dev/null`s when `certbot_ON != true` and falls into the ACME probe loop when it is. Asserting on modes rather than script text means a rewrite that looks correct but produces the wrong permissions still fails. Both scoping tests fail against the pre-fix script; all 225 chimera tests pass.

There was no shell-test precedent in this repo, so this establishes the pattern.
