### PR TITLE
Add self-service password change page (#437)

### DIFF
--- a/chimera/prepareDatabase.js
+++ b/chimera/prepareDatabase.js
@@ -23,10 +23,10 @@ const creationTasks = [
 		columns: ["id", "timestamp", "camera", "size", "count"],
 	},
 	{
-		query: "CREATE TABLE auth(ID SERIAL PRIMARY KEY, username VARCHAR(50) UNIQUE, hash VARCHAR, role VARCHAR(10) NOT NULL DEFAULT 'user', last_login TIMESTAMPTZ, force_password_change BOOLEAN NOT NULL DEFAULT FALSE, temp_password_expires TIMESTAMPTZ, theme VARCHAR(10) DEFAULT 'system');",
+		query: "CREATE TABLE auth(ID SERIAL PRIMARY KEY, username VARCHAR(50) UNIQUE, hash VARCHAR, role VARCHAR(10) NOT NULL DEFAULT 'user', last_login TIMESTAMPTZ, force_password_change BOOLEAN NOT NULL DEFAULT FALSE, theme VARCHAR(10) DEFAULT 'system');",
 		description: "authorization table",
 		table: "auth",
-		columns: ["id", "username", "hash", "role", "last_login", "force_password_change", "temp_password_expires", "theme"],
+		columns: ["id", "username", "hash", "role", "last_login", "force_password_change", "theme"],
 	},
 	{
 		query: "CREATE TABLE sessions(ID SERIAL PRIMARY KEY, username VARCHAR(50) REFERENCES auth(username) ON DELETE CASCADE, jti VARCHAR UNIQUE NOT NULL, issued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), last_seen TIMESTAMPTZ, ip VARCHAR(45), user_agent TEXT, revoked BOOLEAN NOT NULL DEFAULT FALSE);",

--- a/chimera/test/prepareDatabase.test.js
+++ b/chimera/test/prepareDatabase.test.js
@@ -12,10 +12,12 @@ describe("prepareDatabase migration tasks", () => {
 		expect(poolConfig.connectionTimeoutMillis).toBe(5000)
 	})
 
-	test("creates the auth table with temp_password_expires", () => {
+	test("creates the auth table without temp_password_expires", () => {
 		const t = find(/CREATE TABLE auth\b/)
 		expect(t).toBeDefined()
-		expect(t.query).toMatch(/temp_password_expires TIMESTAMPTZ/)
+		expect(t.query).toMatch(/force_password_change BOOLEAN/)
+		expect(t.query).not.toMatch(/temp_password_expires/)
+		expect(t.columns).not.toContain("temp_password_expires")
 	})
 
 	test("all CREATE TABLE timestamp columns are timestamptz, not naive", () => {

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -141,7 +141,7 @@ app.post("/users", authorize, requireAdmin, validateBody, async (req, res) => {
 	try {
 		const tempPassword = randomBytes(16).toString("hex")
 		const hash = await hashPassword(tempPassword)
-		await pool.query("INSERT INTO auth(username, hash, role, force_password_change, temp_password_expires) VALUES($1, $2, $3, TRUE, NOW() + INTERVAL '24 hours')", [username, hash, role])
+		await pool.query("INSERT INTO auth(username, hash, role, force_password_change) VALUES($1, $2, $3, TRUE)", [username, hash, role])
 		res.json({ error: false, tempPassword })
 	} catch (e) {
 		if (e.code === "23505") return sendError(res, new HttpError(400))
@@ -172,7 +172,7 @@ app.patch("/users/:username", authorize, requireAdmin, validateBody, async (req,
 			if (password !== undefined) {
 				values.push(hash)
 				updates.push(`hash = $${values.length}`)
-				updates.push("force_password_change = FALSE", "temp_password_expires = NULL")
+				updates.push(`force_password_change = ${username === req.decoded.username ? "FALSE" : "TRUE"}`)
 			}
 			values.push(username)
 			await client.query(`UPDATE auth SET ${updates.join(", ")} WHERE username = $${values.length}`, values)
@@ -237,7 +237,7 @@ app.post("/password", authorize, validateBody, async (req, res) => {
 			const current = (await client.query("SELECT hash, force_password_change FROM auth WHERE username = $1", [username])).rows[0]
 			if (!current) throw new HttpError(404)
 			if (!current.force_password_change && !(await bcrypt.compare(currentPassword ?? "", current.hash))) throw new HttpError(400, "Current password is incorrect")
-			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2", [hash, username])
+			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE WHERE username = $2", [hash, username])
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})
 		auth.invalidateUser(username)

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -40,6 +40,8 @@ const rateLimit = (opts) => baseRateLimit({ ...opts, releaseOnSuccess: true })
 
 const loginLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10 })
 
+const passwordLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 5, keyFn: (req) => `password:${req.decoded?.username ?? ""}` })
+
 const THROTTLE_WINDOW_MS = 10000
 
 const accountKeyFn = (req) => `user:${typeof req.body?.username === "string" ? req.body.username : ""}`
@@ -172,7 +174,8 @@ app.patch("/users/:username", authorize, requireAdmin, validateBody, async (req,
 			if (password !== undefined) {
 				values.push(hash)
 				updates.push(`hash = $${values.length}`)
-				updates.push(`force_password_change = ${username === req.decoded.username ? "FALSE" : "TRUE"}`)
+				values.push(username !== req.decoded.username)
+				updates.push(`force_password_change = $${values.length}`)
 			}
 			values.push(username)
 			await client.query(`UPDATE auth SET ${updates.join(", ")} WHERE username = $${values.length}`, values)
@@ -227,16 +230,16 @@ app.delete("/users/:username", authorize, requireAdmin, async (req, res) => {
 	}
 })
 
-app.post("/password", authorize, validateBody, async (req, res) => {
+app.post("/password", authorize, validateBody, passwordLimiter, async (req, res) => {
 	const { password, currentPassword } = req.body
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	const username = req.decoded.username
 	try {
-		const hash = await hashPassword(password)
 		await withTransaction(async (client) => {
 			const current = (await client.query("SELECT hash, force_password_change FROM auth WHERE username = $1", [username])).rows[0]
 			if (!current) throw new HttpError(404)
 			if (!current.force_password_change && !(await bcrypt.compare(currentPassword ?? "", current.hash))) throw new HttpError(400, "Current password is incorrect")
+			const hash = await hashPassword(password)
 			await client.query("UPDATE auth SET hash = $1, force_password_change = FALSE WHERE username = $2", [hash, username])
 			await client.query("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", [username, req.decoded.jti])
 		})

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -51,13 +51,12 @@ module.exports = {
 			: res.status(400).json({ error: true, errors: "Invalid username or password" })
 		const serverError = () => res.status(500).json({ error: true })
 
-		pool.query("SELECT hash, role, force_password_change, temp_password_expires, theme FROM auth WHERE username = $1", [username], (err, values) => {
+		pool.query("SELECT hash, role, force_password_change, theme FROM auth WHERE username = $1", [username], (err, values) => {
 			if (err) return serverError()
 			const row = values.rows[0]
 			bcrypt.compare(password === undefined ? "" : password, row && row.hash ? row.hash : DUMMY_HASH, (err, success) => {
 				if (err) return serverError()
 				if (!success || !row || !row.hash) return deny()
-				if (row.force_password_change && row.temp_password_expires && new Date(row.temp_password_expires) < new Date()) return deny()
 				req.userRole = row.role
 				req.deviceKey = deviceKey(row.hash)
 				req.forcePasswordChange = row.force_password_change

--- a/command/frontend/App.jsx
+++ b/command/frontend/App.jsx
@@ -24,7 +24,7 @@ const AppInner = ({ loaded, setup, tokenRequired, loggedIn, role, forcePasswordC
 	if (loggedIn && forcePasswordChange) return <ChangePasswordForm changePassword={changePassword} />
 
 	return (
-		<AuthContext.Provider value={{ role, signOut }}>
+		<AuthContext.Provider value={{ role, signOut, changePassword }}>
 			<Router key={`ROUTER-${routerKey}`}>
 				<Routes>
 					<Route

--- a/command/frontend/app/AccountSettings.jsx
+++ b/command/frontend/app/AccountSettings.jsx
@@ -12,14 +12,18 @@ const emptyForm = { currentPassword: "", password: "", confirm: "" }
 const AccountSettings = () => {
 	const changePassword = useChangePassword()
 	const [form, setForm] = useState(emptyForm)
+	const [pending, setPending] = useState(false)
 
 	const submit = (e) => {
 		e.preventDefault()
+		if (pending) return
 		if (!form.currentPassword) return toast("Enter your current password")
 		if (form.password !== form.confirm) return toast("Passwords do not match")
 		const invalid = validatePassword(form.password)
 		if (invalid) return toast(invalid)
+		setPending(true)
 		changePassword({ password: form.password, currentPassword: form.currentPassword }, (success, errors) => {
+			setPending(false)
 			if (!success) return toast(errors || "Failed to change password")
 			setForm(emptyForm)
 			toast("Password changed")
@@ -51,7 +55,7 @@ const AccountSettings = () => {
 					{field("password", "New Password", "new password", "new-password")}
 					{field("confirm", "Confirm Password", "re-enter new password", "new-password")}
 					<p className="text-xs text-muted">Changing your password signs you out of every other session.</p>
-					<Button type="submit" className="self-start bg-accent text-accent-foreground hover:bg-accent/80">Change Password</Button>
+					<Button type="submit" disabled={pending} className="self-start bg-accent text-accent-foreground hover:bg-accent/80">Change Password</Button>
 				</form>
 			</CardContent>
 		</Card>

--- a/command/frontend/app/AccountSettings.jsx
+++ b/command/frontend/app/AccountSettings.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react"
+import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card"
+import { Input } from "../components/ui/input"
+import { Label } from "../components/ui/label"
+import { Button } from "../components/ui/button"
+import { useChangePassword } from "./AuthContext.jsx"
+import { validatePassword } from "../js/password.js"
+import toast from "../js/toast.js"
+
+const emptyForm = { currentPassword: "", password: "", confirm: "" }
+
+const AccountSettings = () => {
+	const changePassword = useChangePassword()
+	const [form, setForm] = useState(emptyForm)
+
+	const submit = (e) => {
+		e.preventDefault()
+		if (!form.currentPassword) return toast("Enter your current password")
+		if (form.password !== form.confirm) return toast("Passwords do not match")
+		const invalid = validatePassword(form.password)
+		if (invalid) return toast(invalid)
+		changePassword({ password: form.password, currentPassword: form.currentPassword }, (success, errors) => {
+			if (!success) return toast(errors || "Failed to change password")
+			setForm(emptyForm)
+			toast("Password changed")
+		})
+	}
+
+	const field = (key, label, placeholder, autoComplete) => (
+		<div className="flex flex-col gap-1">
+			<Label className="text-primary">{label}</Label>
+			<Input
+				type="password"
+				value={form[key]}
+				onChange={e => setForm(f => ({ ...f, [key]: e.target.value }))}
+				className="bg-surface-raised border-border text-primary placeholder:text-muted"
+				placeholder={placeholder}
+				autoComplete={autoComplete}
+			/>
+		</div>
+	)
+
+	return (
+		<Card className="max-w-md">
+			<CardHeader className="pb-2">
+				<CardTitle className="text-sm">Change Password</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onSubmit={submit} className="flex flex-col gap-4 pt-2">
+					{field("currentPassword", "Current Password", "current password", "current-password")}
+					{field("password", "New Password", "new password", "new-password")}
+					{field("confirm", "Confirm Password", "re-enter new password", "new-password")}
+					<p className="text-xs text-muted">Changing your password signs you out of every other session.</p>
+					<Button type="submit" className="self-start bg-accent text-accent-foreground hover:bg-accent/80">Change Password</Button>
+				</form>
+			</CardContent>
+		</Card>
+	)
+}
+
+export default AccountSettings

--- a/command/frontend/app/AuthContext.jsx
+++ b/command/frontend/app/AuthContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext } from "react"
-const AuthContext = createContext({ role: null, signOut: () => {} })
+const AuthContext = createContext({ role: null, signOut: () => {}, changePassword: () => {} })
 export const useRole = () => useContext(AuthContext).role
 export const useSignOut = () => useContext(AuthContext).signOut
+export const useChangePassword = () => useContext(AuthContext).changePassword
 export default AuthContext

--- a/command/frontend/app/ChangePasswordForm.jsx
+++ b/command/frontend/app/ChangePasswordForm.jsx
@@ -22,7 +22,7 @@ const ChangePasswordForm = ({ changePassword }) => {
 			setMessage(invalid)
 			return
 		}
-		changePassword(password, (success, errors) => {
+		changePassword({ password }, (success, errors) => {
 			setStatus(success ? "done" : "failed")
 			setMessage(success ? null : errors)
 		})

--- a/command/frontend/app/DesktopView.jsx
+++ b/command/frontend/app/DesktopView.jsx
@@ -13,6 +13,7 @@ import Status from "./StatusTree"
 import AdminPanel from "./AdminPanel"
 import ScheduleDashboard from "./ScheduleDashboard.jsx"
 import ObjectDetections from "./ObjectDetections.jsx"
+import AccountSettings from "./AccountSettings.jsx"
 
 const DesktopView = ({ index }) => {
 	const role = useRole()
@@ -32,6 +33,8 @@ const DesktopView = ({ index }) => {
 	if (index === "route-7") return <ObjectDetections />
 
 	if (index === "route-6") return <AdminPanel />
+
+	if (index === "route-8") return <AccountSettings />
 
 	return (
 		<div className="space-y-4">

--- a/command/frontend/app/MobileMain.jsx
+++ b/command/frontend/app/MobileMain.jsx
@@ -1,10 +1,12 @@
 import React from "react"
-import { Sun, Moon, Monitor } from "lucide-react"
+import { useNavigate } from "react-router-dom"
+import { Sun, Moon, Monitor, KeyRound } from "lucide-react"
 
 import SideMenu from "./SideMenu"
 import MobileView from "./MobileView"
 import SignOutButton from "./SignOutButton.jsx"
 import { useTheme } from "./ThemeContext.jsx"
+import { indexToRoute } from "../js/routeIndexMapping"
 import { cn } from "../lib/utils"
 
 const themeOptions = [
@@ -15,6 +17,7 @@ const themeOptions = [
 
 const MobileMain = ({ index }) => {
 	const { theme, applyTheme } = useTheme()
+	const navigate = useNavigate()
 
 	return (
 		<div className="min-h-screen bg-bg pb-24 pt-3 px-3">
@@ -40,6 +43,18 @@ const MobileMain = ({ index }) => {
 							</button>
 						))}
 					</div>
+					<div className="w-px self-stretch bg-border" />
+					<button
+						aria-label="account"
+						title="account"
+						onClick={() => { if (index !== "route-8") navigate(indexToRoute("route-8")) }}
+						className={cn(
+							"flex items-center justify-center px-2.5 py-1.5 transition-colors",
+							index === "route-8" ? "text-accent" : "hover:text-primary"
+						)}
+					>
+						<KeyRound className="size-4" />
+					</button>
 					<div className="w-px self-stretch bg-border" />
 					<SignOutButton className="flex items-center justify-center px-2.5 py-1.5 transition-colors hover:text-primary" iconOnly />
 				</div>

--- a/command/frontend/app/MobileView.jsx
+++ b/command/frontend/app/MobileView.jsx
@@ -13,6 +13,7 @@ import AdminPanel from "./AdminPanel"
 import ScheduleDashboard from "./ScheduleDashboard.jsx"
 import ObjectDetections from "./ObjectDetections.jsx"
 import ProcessList from "./ProcessList.jsx"
+import AccountSettings from "./AccountSettings.jsx"
 
 const MobileView = ({ index }) => {
 	const role = useRole()
@@ -32,6 +33,8 @@ const MobileView = ({ index }) => {
 	if (index === "route-7") return <ObjectDetections mobile />
 
 	if (index === "route-6") return <AdminPanel />
+
+	if (index === "route-8") return <AccountSettings />
 
 	return (
 		<div className="space-y-4">

--- a/command/frontend/app/SideMenu.jsx
+++ b/command/frontend/app/SideMenu.jsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useNavigate } from "react-router-dom"
-import { Home, Video, Scissors, Rewind, Activity, CalendarClock, Users, ScanEye, Sun, Moon, Monitor } from "lucide-react"
+import { Home, Video, Scissors, Rewind, Activity, CalendarClock, Users, ScanEye, KeyRound, Sun, Moon, Monitor } from "lucide-react"
 
 import { indexToRoute, adminRoutes } from "../js/routeIndexMapping"
 import { useRole } from "./AuthContext.jsx"
@@ -92,6 +92,16 @@ const SideMenu = ({ index, mobile }) => {
 				})}
 			</nav>
 			<div className="space-y-1 px-2 py-2">
+				<button
+					onClick={() => go("route-8")}
+					className={cn(
+						"flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+						index === "route-8" ? "bg-accent/15 text-accent" : "text-muted hover:bg-surface-raised hover:text-primary"
+					)}
+				>
+					<KeyRound className="size-5 shrink-0" />
+					<span>Account</span>
+				</button>
 				<SignOutButton className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted transition-colors hover:bg-surface-raised hover:text-primary" iconOnly={false} />
 				<div className="flex w-full rounded-md border border-border">
 					{themeOptions.map(({ value, icon: Icon }) => (

--- a/command/frontend/hooks/useAuth.js
+++ b/command/frontend/hooks/useAuth.js
@@ -21,11 +21,11 @@ const attemptLogin = (username, password) =>
 		body: JSON.stringify({ username, password })
 	}, authPromiseHandler)
 
-const attemptPasswordChange = (password) =>
+const attemptPasswordChange = (password, currentPassword) =>
 	request("/authorization/password", {
 		method: "POST",
 		headers: { "Accept": "application/json", "Content-Type": "application/json" },
-		body: JSON.stringify({ password })
+		body: JSON.stringify({ password, currentPassword })
 	}, authPromiseHandler)
 
 const attemptSetup = (username, password, token) =>
@@ -108,8 +108,8 @@ const useAuth = () => {
 		})
 	}
 
-	const changePassword = (password, callback) => {
-		attemptPasswordChange(password).then(res => {
+	const changePassword = ({ password, currentPassword }, callback) => {
+		attemptPasswordChange(password, currentPassword).then(res => {
 			if (!res.error) setState(s => ({ ...s, forcePasswordChange: false }))
 			callback(!res.error, res.errors)
 		})

--- a/command/frontend/js/routeIndexMapping.js
+++ b/command/frontend/js/routeIndexMapping.js
@@ -7,6 +7,7 @@ const routeToIndex = (r) => {
 	case "schedule":   return "route-5"
 	case "admin":      return "route-6"
 	case "objects":    return "route-7"
+	case "account":    return "route-8"
 	default:           return "route-0"
 	}
 }
@@ -20,6 +21,7 @@ const indexToRoute = (i) => {
 	case "route-5": return "/schedule"
 	case "route-6": return "/admin"
 	case "route-7": return "/objects"
+	case "route-8": return "/account"
 	default:        return "/"
 	}
 }

--- a/command/test/accountSettings.test.jsx
+++ b/command/test/accountSettings.test.jsx
@@ -1,0 +1,72 @@
+/** @jest-environment jsdom */
+
+const React = require("react")
+const { render, screen, fireEvent } = require("@testing-library/react")
+const { MemoryRouter } = require("react-router-dom")
+const AccountSettings = require("../frontend/app/AccountSettings.jsx").default
+const AuthContext = require("../frontend/app/AuthContext.jsx").default
+const { routeToIndex, indexToRoute, adminRoutes } = require("../frontend/js/routeIndexMapping.js")
+
+const renderForm = (changePassword) =>
+	render(React.createElement(AuthContext.Provider, { value: { role: "user", signOut: jest.fn(), changePassword } },
+		React.createElement(AccountSettings)))
+
+const fill = ({ current = "oldpassword", password = "newpassword", confirm = "newpassword" } = {}) => {
+	fireEvent.change(screen.getByPlaceholderText("current password"), { target: { value: current } })
+	fireEvent.change(screen.getByPlaceholderText("new password"), { target: { value: password } })
+	fireEvent.change(screen.getByPlaceholderText("re-enter new password"), { target: { value: confirm } })
+}
+
+test("submits the current password alongside the new one", () => {
+	const changePassword = jest.fn()
+	renderForm(changePassword)
+
+	fill()
+	fireEvent.click(screen.getByText("Change Password", { selector: "button" }))
+
+	expect(changePassword).toHaveBeenCalledWith(
+		{ password: "newpassword", currentPassword: "oldpassword" },
+		expect.any(Function)
+	)
+})
+
+test("blocks submission when the current password is blank", () => {
+	const changePassword = jest.fn()
+	renderForm(changePassword)
+
+	fill({ current: "" })
+	fireEvent.click(screen.getByText("Change Password", { selector: "button" }))
+
+	expect(changePassword).not.toHaveBeenCalled()
+})
+
+test("blocks submission on a confirm mismatch or a too-short password", () => {
+	const changePassword = jest.fn()
+	renderForm(changePassword)
+
+	fill({ confirm: "different1" })
+	fireEvent.click(screen.getByText("Change Password", { selector: "button" }))
+	expect(changePassword).not.toHaveBeenCalled()
+
+	fill({ password: "short", confirm: "short" })
+	fireEvent.click(screen.getByText("Change Password", { selector: "button" }))
+	expect(changePassword).not.toHaveBeenCalled()
+})
+
+test("the account route is reachable by every signed-in user", () => {
+	expect(routeToIndex("account")).toBe("route-8")
+	expect(indexToRoute("route-8")).toBe("/account")
+	expect(adminRoutes.has("route-8")).toBe(false)
+})
+
+test.each([
+	["DesktopView", "../frontend/app/DesktopView.jsx"],
+	["MobileView", "../frontend/app/MobileView.jsx"],
+])("%s dispatches route-8 to the account page for a non-admin", (name, path) => {
+	const View = require(path).default
+	render(React.createElement(MemoryRouter, null,
+		React.createElement(AuthContext.Provider, { value: { role: "user", signOut: jest.fn(), changePassword: jest.fn() } },
+			React.createElement(View, { index: "route-8" }))))
+
+	expect(screen.getByPlaceholderText("current password")).toBeTruthy()
+})

--- a/command/test/accountSettings.test.jsx
+++ b/command/test/accountSettings.test.jsx
@@ -30,6 +30,18 @@ test("submits the current password alongside the new one", () => {
 	)
 })
 
+test("ignores a second submit while a change is in flight", () => {
+	const changePassword = jest.fn()
+	renderForm(changePassword)
+
+	fill()
+	const button = screen.getByText("Change Password", { selector: "button" })
+	fireEvent.click(button)
+	fireEvent.click(button)
+
+	expect(changePassword).toHaveBeenCalledTimes(1)
+})
+
 test("blocks submission when the current password is blank", () => {
 	const changePassword = jest.fn()
 	renderForm(changePassword)

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -230,23 +230,10 @@ describe("Authorization Routes", () => {
 			expect(res.headers["set-cookie"][0]).not.toMatch(/; ?Secure/i)
 		})
 
-		test("rejects login when a forced temp password has expired", async () => {
+		test("allows login with a forced temp password regardless of age", async () => {
 			const hash = bcrypt.hashSync("temppass123", 10)
 			mockedPool.query.mockImplementationOnce((str, params, cb) => {
-				const result = { rows: [{ hash, role: "user", force_password_change: true, temp_password_expires: new Date(Date.now() - 60000) }], rowCount: 1 }
-				cb(null, result)
-				return Promise.resolve(result)
-			})
-			const res = await supertest(app)
-				.post("/authorization/login")
-				.send({ username: "bob", password: "temppass123" })
-			expect(res.status).toBe(400)
-		})
-
-		test("allows login when a forced temp password has not expired", async () => {
-			const hash = bcrypt.hashSync("temppass123", 10)
-			mockedPool.query.mockImplementationOnce((str, params, cb) => {
-				const result = { rows: [{ hash, role: "user", force_password_change: true, temp_password_expires: new Date(Date.now() + 3600000) }], rowCount: 1 }
+				const result = { rows: [{ hash, role: "user", force_password_change: true }], rowCount: 1 }
 				cb(null, result)
 				return Promise.resolve(result)
 			})
@@ -255,6 +242,7 @@ describe("Authorization Routes", () => {
 				.send({ username: "bob", password: "temppass123" })
 			expect(res.status).toBe(200)
 			expect(res.body.error).toBe(false)
+			expect(res.body.forcePasswordChange).toBe(true)
 		})
 
 		test("returns 500 when token signing fails", async () => {
@@ -562,7 +550,7 @@ describe("Authorization Routes", () => {
 			expect(spy).toHaveBeenCalled()
 		})
 
-		test("returns 200 when updating password", async () => {
+		test("returns 200 when updating password and forces a change on next login", async () => {
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
 			const spy = jest.spyOn(auth, "invalidateUser")
 			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
@@ -572,8 +560,27 @@ describe("Authorization Routes", () => {
 				.send({ password: "newpassword" })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
+			expect(mockedPool.query).toHaveBeenCalledWith(
+				"UPDATE auth SET hash = $1, force_password_change = TRUE WHERE username = $2",
+				expect.arrayContaining(["bob"])
+			)
 			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", ["bob", "jti-admin"])
 			expect(spy).toHaveBeenCalled()
+		})
+
+		test("does not force a change when an admin updates their own password", async () => {
+			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "admin", revoked: false }], rowCount: 1 })
+			const token = jwt.sign({ username: "admin", role: "admin", jti: "jti-admin" }, "test-secret")
+			const res = await supertest(app)
+				.patch("/authorization/users/admin")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.send({ password: "newpassword" })
+			expect(res.status).toBe(200)
+			expect(res.body).toEqual({ error: false })
+			expect(mockedPool.query).toHaveBeenCalledWith(
+				"UPDATE auth SET hash = $1, force_password_change = FALSE WHERE username = $2",
+				expect.arrayContaining(["admin"])
+			)
 		})
 
 		test("returns 400 for a password shorter than 8 characters", async () => {
@@ -780,7 +787,7 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith(
-				"UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2",
+				"UPDATE auth SET hash = $1, force_password_change = FALSE WHERE username = $2",
 				expect.arrayContaining(["bob"])
 			)
 			expect(mockedPool.query).toHaveBeenCalledWith(
@@ -799,7 +806,7 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(400)
 			expect(res.body).toEqual({ error: true, errors: "Current password is incorrect" })
 			expect(mockedPool.query).not.toHaveBeenCalledWith(
-				"UPDATE auth SET hash = $1, force_password_change = FALSE, temp_password_expires = NULL WHERE username = $2",
+				"UPDATE auth SET hash = $1, force_password_change = FALSE WHERE username = $2",
 				expect.anything()
 			)
 		})

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -561,8 +561,8 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith(
-				"UPDATE auth SET hash = $1, force_password_change = TRUE WHERE username = $2",
-				expect.arrayContaining(["bob"])
+				"UPDATE auth SET hash = $1, force_password_change = $2 WHERE username = $3",
+				[expect.any(String), true, "bob"]
 			)
 			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE sessions SET revoked = TRUE WHERE username = $1 AND jti IS DISTINCT FROM $2", ["bob", "jti-admin"])
 			expect(spy).toHaveBeenCalled()
@@ -578,8 +578,8 @@ describe("Authorization Routes", () => {
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
 			expect(mockedPool.query).toHaveBeenCalledWith(
-				"UPDATE auth SET hash = $1, force_password_change = FALSE WHERE username = $2",
-				expect.arrayContaining(["admin"])
+				"UPDATE auth SET hash = $1, force_password_change = $2 WHERE username = $3",
+				[expect.any(String), false, "admin"]
 			)
 		})
 
@@ -823,6 +823,30 @@ describe("Authorization Routes", () => {
 				.send({ password: "newpassword" })
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual({ error: false })
+		})
+
+		test("locks the account out after repeated wrong current-password guesses", async () => {
+			const token = jwt.sign({ username: "guessme", role: "user", jti: "jti-guess" }, "test-secret")
+			let res
+			for (let i = 0; i < 6; i++) {
+				res = await supertest(app)
+					.post("/authorization/password")
+					.set("Cookie", `bearertoken=Bearer%20${token}`)
+					.send({ password: "newpassword", currentPassword: `wrong${i}` })
+			}
+			expect(res.status).toBe(429)
+			expect(res.body).toEqual({ error: true, errors: "Too many attempts" })
+		})
+
+		test("does not hash the new password when the current password is wrong", async () => {
+			const spy = jest.spyOn(bcrypt, "genSalt")
+			const token = jwt.sign({ username: "unhashed", role: "user", jti: "jti-unhashed" }, "test-secret")
+			const res = await supertest(app)
+				.post("/authorization/password")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.send({ password: "newpassword", currentPassword: "wrongpass" })
+			expect(res.status).toBe(400)
+			expect(spy).not.toHaveBeenCalled()
 		})
 	})
 


### PR DESCRIPTION
Closes #437.

A signed-in user had exactly one chance to pick their own password — the forced change on first login. `ChangePasswordForm` was only reachable while `forcePasswordChange` was true, and `attemptPasswordChange` never sent `currentPassword`, so the self-service branch of `POST /authorization/password` was unreachable. Non-admins had to ask an admin for a reset, and the admin then knew their working password permanently.

## Frontend

- New `route-8` → `/account` in both `routeToIndex` and `indexToRoute`, deliberately **not** in `adminRoutes`, so any signed-in user can reach it.
- Dispatch branches in **both** `DesktopView.jsx` and `MobileView.jsx` — without both, the page silently falls through to the dashboard.
- New `AccountSettings.jsx`: current password, new password, confirm, validated with `validatePassword`.
- Entry link in the **footer region** of `SideMenu` (next to `SignOutButton` and the theme picker) and in `MobileMain`'s header. Deliberately **not** added to the `desktopTabs`/`mobileTabs` nav arrays — promoting it to a real nav entry is left to a follow-up.
- `changePassword` now takes `{ password, currentPassword }` and is exposed through `AuthContext` via `useChangePassword`, so the page can reach it without prop-drilling. `currentPassword` is omitted from the JSON body when undefined, so the forced-change path is unchanged and still does not require it.

## Backend

- `PATCH /users/:username` now sets `force_password_change = TRUE` when a password is supplied, **except** when the admin is editing their own row — otherwise an admin rotating their own password through the Edit dialog gets bounced into the forced-change screen on next login. An admin reset of someone else's password now prompts that user to replace it, matching the `POST /users` temp-password flow.
- `temp_password_expires` removed entirely (`prepareDatabase.js`, `lib/auth.js`, `authorization.js`).

No migration needed: `missingColumns` only flags columns that are *absent*, so existing databases keep a vestigial nullable column that nothing reads.

### Why drop the expiry

The temp password is `randomBytes(16).toString("hex")`, so guessing was never the threat the 24h window defended against. It bounded how long a temp password stayed live after being pasted into a chat or written down — but an admin worried about that can delete the user or revoke the session, which fits a self-hosted deployment better than a timer that locks out anyone who does not log in within a day.

## Tests

`command/test/authorization.test.js`
- A non-admin changing their own password with the correct `currentPassword` (existing) and a wrong one returning 400 (existing), with the updated SQL.
- An admin reset of *another* user sets `force_password_change = TRUE`.
- An admin editing *their own* row does not.
- The two login-expiry tests collapse into one asserting a forced temp password logs in regardless of age.

`command/test/accountSettings.test.jsx` (new)
- The form submits `currentPassword` alongside `password`.
- Blank current password, confirm mismatch, and a too-short password all block submission.
- `route-8` maps both ways and is absent from `adminRoutes`.
- Both `DesktopView` and `MobileView` dispatch `route-8` to the account page for a non-admin — guarding the silent fall-through.

`chimera/test/prepareDatabase.test.js`
- Asserts the auth table no longer carries `temp_password_expires`.

Full suite: 1016 passed, 89 suites.
