### PR TITLE
Fix oversized detection boxes in mini grid thumbnails (#440)

### DIFF
--- a/command/frontend/app/ObjectDetections.jsx
+++ b/command/frontend/app/ObjectDetections.jsx
@@ -50,7 +50,7 @@ const DetectionImage = ({ image, boxes, cover = false, height }) => {
 					className="absolute inset-0 w-full h-full object-cover object-top"
 					onLoad={handleLoad}
 				/>
-				<DetectionOverlay boxes={boxes} dims={dims} pad={pad} fit="xMidYMin slice" />
+				<DetectionOverlay boxes={boxes} dims={dims} fit="xMidYMin slice" />
 			</div>
 		)
 	}

--- a/command/test/detectionOverlay.test.js
+++ b/command/test/detectionOverlay.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
-const FRAME = { w: 416, h: 416 }
-const PAD = { top: 0, bot: 182, left: 0, right: 0 }
+const FRAME = { w: 640, h: 640 }
+const PAD = { top: 0, bot: 280, left: 0, right: 0 }
 
 jest.mock("../frontend/js/letterbox.js", () => ({
 	__esModule: true,
@@ -70,6 +70,8 @@ describe("mini thumbnail overlay", () => {
 
 		expect(detectGrayPad).toHaveBeenCalled()
 		expect(img.className).toContain("object-cover")
+		expect(img.className).toContain("object-top")
+		expect(svg.getAttribute("preserveAspectRatio")).toBe("xMidYMin slice")
 
 		expect(coverScale(cell, { w: vbW, h: vbH }))
 			.toBeCloseTo(coverScale(cell, { w: img.naturalWidth, h: img.naturalHeight }), 6)

--- a/command/test/detectionOverlay.test.js
+++ b/command/test/detectionOverlay.test.js
@@ -1,4 +1,30 @@
+/** @jest-environment jsdom */
+
+const FRAME = { w: 416, h: 416 }
+const PAD = { top: 0, bot: 182, left: 0, right: 0 }
+
+jest.mock("../frontend/js/letterbox.js", () => ({
+	__esModule: true,
+	detectGrayPad: jest.fn(() => PAD)
+}))
+
+jest.mock("../frontend/hooks/useObjectDetections.js", () => ({
+	__esModule: true,
+	default: () => ({
+		status: { cameraNames: { 1: "front" } },
+		detections: [{ image: "a.jpg", camera: 1, timestamp: "2024-01-01T00:00:00Z", box: [10, 10, 50, 50], type: "person", confidence: 0.9 }],
+		loadStatus: () => {},
+		loadDetections: () => {},
+		scan: () => {}
+	})
+}))
+
+const React = require("react")
+const { render, fireEvent } = require("@testing-library/react")
+const { MemoryRouter } = require("react-router-dom")
 const { contentViewBox } = require("../frontend/js/detections.js")
+const { detectGrayPad } = require("../frontend/js/letterbox.js")
+const ObjectDetections = require("../frontend/app/ObjectDetections.jsx").default
 
 describe("contentViewBox", () => {
 	test("crops all four padded sides", () => {
@@ -18,5 +44,34 @@ describe("contentViewBox", () => {
 
 	test("treats undefined pad as no crop", () => {
 		expect(contentViewBox({ w: 100, h: 100 })).toBe("0 0 100 100")
+	})
+})
+
+describe("mini thumbnail overlay", () => {
+	const coverScale = (cell, src) => Math.max(cell.w / src.w, cell.h / src.h)
+
+	const renderMini = () => {
+		const future = { v7_startTransition: true, v7_relativeSplatPath: true }
+		const { container } = render(React.createElement(MemoryRouter, { future },
+			React.createElement(ObjectDetections, { mini: true })))
+		const img = container.querySelector("img")
+		Object.defineProperty(img, "naturalWidth", { value: FRAME.w })
+		Object.defineProperty(img, "naturalHeight", { value: FRAME.h })
+		fireEvent.load(img)
+		return { img, svg: img.parentElement.querySelector("svg") }
+	}
+
+	test.each([
+		["square", { w: 200, h: 200 }],
+		["1.65 aspect", { w: 264, h: 160 }]
+	])("image and overlay cover a %s cell from the same source rect", (_label, cell) => {
+		const { img, svg } = renderMini()
+		const [, , vbW, vbH] = svg.getAttribute("viewBox").split(" ").map(Number)
+
+		expect(detectGrayPad).toHaveBeenCalled()
+		expect(img.className).toContain("object-cover")
+
+		expect(coverScale(cell, { w: vbW, h: vbH }))
+			.toBeCloseTo(coverScale(cell, { w: img.naturalWidth, h: img.naturalHeight }), 6)
 	})
 })


### PR DESCRIPTION
The mini thumbnail draws the `<img>` with `object-cover` from the full 416x416 letterboxed capture, but handed `DetectionOverlay` the letterbox `pad`, so its viewBox was cropped to the 416x234 content region. Two different source rectangles scaled to cover the same cell give two different scales, so the boxes were drawn up to 1.78x too large (square cell); ~1.08x on a 264x160 desktop cell. Only exact at 16:9, which is why it looked fine on a wide window.

Fix: drop `pad` in the cover branch so the overlay viewBox is the full frame, matching the image. `contentViewBox` already defaults an absent pad to no crop. The non-mini branch offsets and upscales the image by the same pad and is unchanged.

Test: `command/test/detectionOverlay.test.js` now renders the mini path and asserts the image and overlay resolve the same cover scale for a square and a 1.65-aspect cell against a 416x416 frame with pad `{top:0,bot:182,left:0,right:0}`. Both cases fail on the old behaviour (0.855 vs 0.481, 0.684 vs 0.635).

Fixes #440