### PR TITLE
Report loose secret modes, warn on missing HTTPS redirect, fix camera status dots (#445, #446, #447, #448)

### DIFF
--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -67,6 +67,14 @@ const writeSecret = (file, data) => {
 	fs.chmodSync(file, SECRET_MODE)
 	if (!secretsWritten.includes(file)) secretsWritten.push(file)
 }
+const looseMode = (file) => {
+	try {
+		const mode = fs.statSync(file).mode & 0o777
+		return mode & 0o037 ? `0${mode.toString(8).padStart(3, "0")}` : null
+	} catch {
+		return null
+	}
+}
 const groupHint = () => {
 	const gid = process.getgid?.()
 	if (!secretsWritten.includes(ENV) || gid === undefined || gid === CONTAINER_GID) return null
@@ -90,6 +98,7 @@ const varProblem = (v, val) => {
 	if (v.key === "chimeraInstances" && !validInstances(val)) return `must be "max", -1, or an integer >= 0 (got "${val}")`
 	if (v.key === "scheduler_TRUSTED_SOURCES" && !validTrustedSources(val)) return `must be comma-separated IPs/CIDRs or proxy-addr names like "loopback" (got "${val}")`
 	if (v.key === "storage_HOST" && !/^https?:\/\//i.test(val)) return `must start with http:// or https:// — storage is dialled directly and serves plain HTTP (got "${val}")`
+	if (v.key === "object_ALERT_ON" && !["true", "text", "false"].includes(val)) return `must be true, text, or false (got "${val}")`
 	if (isSecret(v.key) && val.length < 32) return `must be at least 32 characters (got ${val.length})`
 	const t = typeOf(v.key, v.placeholder)
 	if (t === "bool" && val !== "true" && val !== "false") return `must be true or false (got "${val}")`
@@ -129,6 +138,14 @@ const cameraProblems = () => {
 		}
 	}
 	return problems
+}
+
+const confModeProblem = () => {
+	const camDir = getCamDir()
+	const loose = listConfs().map(f => [f, looseMode(path.join(camDir, f))]).filter(([, m]) => m)
+	return loose.length
+		? `${loose.map(([f, m]) => `${f} mode ${m}`).join(", ")} — holds netcam_userpass, the camera login, and every account on this machine can read it; run: chmod 640 ${path.relative(ROOT, camDir) || camDir}/*.conf`
+		: null
 }
 
 const camTemplate = (id, name, url, userpass) =>
@@ -208,6 +225,8 @@ const runCheck = () => {
 		failed = true
 	} else {
 		const probs = envProblems(schema, lines)
+		const mode = looseMode(ENV)
+		if (mode) probs.push([".env", `mode ${mode} — holds SECRETKEY, database_PASSWORD and the service tokens, and every account on this machine can read them; run: chmod 640 .env`])
 		console.log(`  .env          ${probs.length ? BAD : OK}${probs.length ? `  ${probs.length} problem(s)` : ""}`)
 		probs.forEach(([k, p]) => console.log(`                  - ${k}: ${p}`))
 		if (probs.length) failed = true
@@ -219,6 +238,8 @@ const runCheck = () => {
 		if (!motionOk) failed = true
 
 		const cam = cameraProblems()
+		const modeProb = confModeProblem()
+		if (modeProb) cam.push(modeProb)
 		console.log(`  cameraconf/   ${cam.length ? BAD : OK}${cam.length ? `  ${cam.length} problem(s)` : ""}`)
 		cam.forEach(p => console.log(`                  - ${p}`))
 		if (cam.length) failed = true
@@ -341,7 +362,12 @@ const runInteractive = async () => {
 			console.log(`    created ${camDir}/cam${id}.conf ${OK}`)
 			if (!(await confirm("  Add another camera?", false))) break
 		}
-		camOk = !cameraProblems().length
+		for (const f of listConfs()) {
+			try { fs.chmodSync(path.join(camDir, f), SECRET_MODE) } catch { /* reported by confModeProblem below */ }
+		}
+		const modeProb = confModeProblem()
+		if (modeProb) console.log(`  ${BAD} ${modeProb}`)
+		camOk = !cameraProblems().length && !modeProb
 		console.log(`cameraconf/ ${camOk ? OK : BAD}\n`)
 	}
 
@@ -357,4 +383,4 @@ if (require.main === module) {
 	else runInteractive()
 }
 
-module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, answerProblem, envProblems, hashTruncated, runInteractive, readLines, getVal, setVal }
+module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, answerProblem, envProblems, hashTruncated, runInteractive, readLines, getVal, setVal, looseMode, confModeProblem }

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -383,4 +383,4 @@ if (require.main === module) {
 	else runInteractive()
 }
 
-module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, answerProblem, envProblems, hashTruncated, runInteractive, readLines, getVal, setVal, looseMode, confModeProblem }
+module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem }

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -20,7 +20,7 @@ jest.mock("fs", () => {
 	}
 })
 
-const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, envProblems, hashTruncated } = require("../preflight.js")
+const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, envProblems, hashTruncated, looseMode } = require("../preflight.js")
 
 describe("parseSchema", () => {
 	test("parses required keys", () => {
@@ -75,6 +75,7 @@ describe("varProblem", () => {
 	const optVar = { key: "alert_TZ", placeholder: "IANA tz ***", optional: true }
 	const instancesVar = { key: "chimeraInstances", placeholder: "Number of instances", optional: false }
 	const storageHostVar = { key: "storage_HOST", placeholder: "https://storage.server.example or http://127.0.0.1:8081", optional: false }
+	const alertOnVar = { key: "object_ALERT_ON", placeholder: "(true | text | false, default true)", optional: true }
 	const tokenVar = { key: "setup_TOKEN", placeholder: "required token gating /authorization/setup", optional: false }
 	const schedulerAuthVar = { key: "scheduler_AUTH", placeholder: "Authorization token for scheduler server", optional: false }
 	const memoryTokenVar = { key: "memory_AUTH_TOKEN", placeholder: "Header token to connect to memory socket", optional: false }
@@ -96,6 +97,13 @@ describe("varProblem", () => {
 	test("bool: true/false → null", () => {
 		expect(varProblem(boolVar, "true")).toBeNull()
 		expect(varProblem(boolVar, "false")).toBeNull()
+	})
+
+	test("object_ALERT_ON: text is a valid third value, anything else is not", () => {
+		expect(varProblem(alertOnVar, "text")).toBeNull()
+		expect(varProblem(alertOnVar, "true")).toBeNull()
+		expect(varProblem(alertOnVar, "false")).toBeNull()
+		expect(varProblem(alertOnVar, "yes")).toBeTruthy()
 	})
 
 	test("port: non-numeric → error", () => {
@@ -416,5 +424,38 @@ describe("isServiceOff (prefix mapping)", () => {
 		expect(isServiceOff(lines({ schedule_ON: "false" }), "scheduler_TRUSTED_SOURCES")).toBe(false)
 		expect(isServiceOff(lines({ schedule_ON: "true" }), "scheduler_TRUSTED_SOURCES")).toBe(false)
 		expect(isServiceOff(lines({ schedule_ON: "false" }), "scheduler_AUTH")).toBe(true)
+	})
+})
+
+// `cp env.example .env` yields 0644, and --check writes nothing, so reporting the mode is the only thing that closes the loop
+describe("looseMode", () => {
+	const fs = require("fs")
+	const os = require("os")
+	const path = require("path")
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "preflight-mode-"))
+	const at = (name, mode) => {
+		const p = path.join(dir, name)
+		fs.writeFileSync(p, "x")
+		fs.chmodSync(p, mode)
+		return p
+	}
+
+	afterAll(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+	test("names the mode of a world-readable secret", () => {
+		expect(looseMode(at("world", 0o644))).toBe("0644")
+	})
+
+	test("accepts the modes preflight itself writes", () => {
+		expect(looseMode(at("tight", 0o640))).toBeNull()
+		expect(looseMode(at("owner", 0o600))).toBeNull()
+	})
+
+	test("flags group-write — group 1000 could rewrite the secret, not just read it", () => {
+		expect(looseMode(at("groupwrite", 0o660))).toBe("0660")
+	})
+
+	test("null for a file that is not there, so a missing artifact reports as missing", () => {
+		expect(looseMode(path.join(dir, "absent"))).toBeNull()
 	})
 })

--- a/chimera/test/preflightInteractive.test.js
+++ b/chimera/test/preflightInteractive.test.js
@@ -206,6 +206,17 @@ describe("runInteractive secret file modes", () => {
 		expect(exitCode).toBe(0)
 	})
 
+	// `cp cameraconf/camera.conf.example cameraconf/cam1.conf` leaves 0644, and a valid conf is never rewritten
+	test("an existing camera conf is tightened to 0640 even when the wizard adds nothing", async () => {
+		setup({
+			env: { ...BLANK, storage_ON: "true", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET },
+			answers: []
+		})
+		const { modes, exitCode } = await run()
+		expect(modes["cameraconf/cam1.conf"]).toBe(0o640)
+		expect(exitCode).toBe(0)
+	})
+
 	test("a camera conf lands at 0640 — it carries netcam_userpass", async () => {
 		setup({
 			env: { ...BLANK, storage_ON: "true", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET },

--- a/chimera/test/preflightInteractive.test.js
+++ b/chimera/test/preflightInteractive.test.js
@@ -1,4 +1,4 @@
-const mockState = { files: {}, dirs: [], answers: [], modes: {} }
+const mockState = { files: {}, dirs: [], answers: [], modes: {}, chmodFail: new Set() }
 
 jest.mock("fs", () => {
 	const norm = (p) => String(p).replace(/\\/g, "/")
@@ -12,7 +12,16 @@ jest.mock("fs", () => {
 			return mockState.files[k]
 		}),
 		writeFileSync: jest.fn((p, data) => { mockState.files[key(p)] = data }),
-		chmodSync: jest.fn((p, mode) => { mockState.modes[key(p)] = mode }),
+		chmodSync: jest.fn((p, mode) => {
+			const k = key(p)
+			if (mockState.chmodFail.has(k)) throw Object.assign(new Error("EPERM"), { code: "EPERM" })
+			mockState.modes[k] = mode
+		}),
+		statSync: jest.fn((p) => {
+			const k = find(p)
+			if (k === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+			return { mode: mockState.modes[k] ?? 0o644 }
+		}),
 		copyFileSync: jest.fn((from, to) => { mockState.files[norm(to).split("/").pop()] = mockState.files[find(from)] }),
 		readdirSync: jest.fn(() => Object.keys(mockState.files).filter(k => k.startsWith("cameraconf/")).map(k => k.slice("cameraconf/".length))),
 		mkdirSync: jest.fn()
@@ -54,6 +63,7 @@ const setup = ({ env, answers, noEnv = false, noCams = false, example = EXAMPLE 
 	mockState.dirs = ["cameraconf"]
 	mockState.answers = [...answers]
 	mockState.modes = {}
+	mockState.chmodFail = new Set()
 }
 
 const BLANK = { storage_ON: "", storage_FOLDERPATH: "", livestream_ON: "", livestream_FOLDERPATH: "", livestream_PROXY_ON: "", object_ON: "", SECRETKEY: "" }
@@ -217,6 +227,19 @@ describe("runInteractive secret file modes", () => {
 		expect(exitCode).toBe(0)
 	})
 
+	// preflight is unprivileged — when chmod itself fails, the conf stays loose and must be reported, not trusted
+	test("an existing camera conf that resists chmod stays loose and is reported", async () => {
+		setup({
+			env: { ...BLANK, storage_ON: "true", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET },
+			answers: []
+		})
+		mockState.chmodFail.add("cameraconf/cam1.conf")
+		const { out, exitCode } = await run()
+		expect(out).toContain("cam1.conf mode 0644")
+		expect(out).toContain("Still incomplete")
+		expect(exitCode).toBe(1)
+	})
+
 	test("a camera conf lands at 0640 — it carries netcam_userpass", async () => {
 		setup({
 			env: { ...BLANK, storage_ON: "true", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET },
@@ -284,5 +307,68 @@ describe("runInteractive cookieSecureProblem", () => {
 		const { env, exitCode } = await run()
 		expect(env).toContain("command_COOKIE_SECURE = true")
 		expect(exitCode).toBe(0)
+	})
+})
+
+const runCheckOnce = () => {
+	const out = []
+	const log = jest.spyOn(console, "log").mockImplementation((...a) => out.push(a.join(" ")))
+	const exit = jest.spyOn(process, "exit").mockImplementation((code) => { throw Object.assign(new Error(EXITED.toString()), { code, [EXITED]: true }) })
+	let exitCode = 0
+	try {
+		load().runCheck()
+	} catch (e) {
+		if (!e[EXITED]) throw e
+		exitCode = e.code
+	} finally {
+		log.mockRestore()
+		exit.mockRestore()
+	}
+	return { out: out.join("\n"), exitCode }
+}
+
+describe("runCheck", () => {
+	// `--check` never prompts or writes — it only reports what's already on disk
+	test("passes when .env and cameraconf/ are already complete and tight", () => {
+		setup({
+			env: { ...BLANK, storage_ON: "true", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET },
+			answers: []
+		})
+		mockState.modes[".env"] = 0o640
+		mockState.modes["cameraconf/cam1.conf"] = 0o640
+		const { out, exitCode } = runCheckOnce()
+		expect(out).toContain("All checks passed")
+		expect(exitCode).toBe(0)
+	})
+
+	test("reports a missing .env and exits 1", () => {
+		setup({ env: {}, noEnv: true, answers: [] })
+		const { out, exitCode } = runCheckOnce()
+		expect(out).toContain(".env")
+		expect(out).toContain("missing")
+		expect(exitCode).toBe(1)
+	})
+
+	test("flags a loose .env mode", () => {
+		setup({
+			env: { ...BLANK, storage_ON: "false", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET },
+			answers: []
+		})
+		mockState.modes[".env"] = 0o644
+		const { out, exitCode } = runCheckOnce()
+		expect(out).toContain(".env: mode 0644")
+		expect(exitCode).toBe(1)
+	})
+
+	test("flags a loose camera conf mode", () => {
+		setup({
+			env: { ...BLANK, storage_ON: "true", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET },
+			answers: []
+		})
+		mockState.modes[".env"] = 0o640
+		mockState.modes["cameraconf/cam1.conf"] = 0o644
+		const { out, exitCode } = runCheckOnce()
+		expect(out).toContain("cam1.conf mode 0644")
+		expect(exitCode).toBe(1)
 	})
 })

--- a/chimera/test/validateEnvVars.test.js
+++ b/chimera/test/validateEnvVars.test.js
@@ -260,6 +260,32 @@ describe("validateEnvVars certbot port warning", () => {
 	})
 })
 
+describe("validateEnvVars certbot redirect warning", () => {
+	// HTTP-01 needs port 80 reachable, and without the redirect that port serves the login form in the clear
+	test("warns (non-fatal) when certbot_ON=true and gateway_HTTPS_Redirect is not true", () => {
+		const res = run({ certbot_ON: "true", gateway_PORT: "80", gateway_HTTPS_Redirect: "false" })
+		expect(res.stdout).toContain("gateway_HTTPS_Redirect is not true")
+		expect(res.status).toBe(0)
+	})
+
+	test("warns when gateway_HTTPS_Redirect is left blank — the env.example default", () => {
+		const res = run({ certbot_ON: "true", gateway_PORT: "80", gateway_HTTPS_Redirect: "" })
+		expect(res.stdout).toContain("gateway_HTTPS_Redirect is not true")
+	})
+
+	test("no warning when the redirect is on", () => {
+		const res = run({ certbot_ON: "true", gateway_PORT: "80", gateway_HTTPS_Redirect: "true" })
+		expect(res.stdout).not.toContain("gateway_HTTPS_Redirect is not true")
+		expect(res.status).toBe(0)
+	})
+
+	test("no warning when certbot_ON is not true", () => {
+		const res = run({ certbot_ON: "false", gateway_HTTPS_Redirect: "false" })
+		expect(res.stdout).not.toContain("gateway_HTTPS_Redirect is not true")
+		expect(res.status).toBe(0)
+	})
+})
+
 describe("validateEnvVars insecure-cookie warning", () => {
 	test("fails on an HTTPS-resolved public gateway_HOST with an insecure cookie", () => {
 		const res = run({ gateway_HOST: "example.com", command_COOKIE_SECURE: "false", gateway_HTTPS_Redirect: "false" })

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -157,6 +157,10 @@ if (process.env.certbot_ON === "true" && process.env.gateway_PORT !== "80") {
 	console.log("WARNING: certbot_ON=true but gateway_PORT is not 80 — Let's Encrypt HTTP-01 uses port 80; cert issuance/renewal will fail")
 }
 
+if (process.env.certbot_ON === "true" && process.env.gateway_HTTPS_Redirect !== "true") {
+	console.log("WARNING: certbot_ON=true but gateway_HTTPS_Redirect is not true — port 80 stays open for HTTP-01 and keeps serving the whole app, so the login form and password cross the network in cleartext and the browser then drops the Secure session cookie, silently failing the login")
+}
+
 const LOOPBACK = ["localhost", "127.0.0.1", "::1", "[::1]"]
 const originOf = (url) => { try { return new URL(url).host } catch { return "" } }
 const hostnameOf = (url) => { try { return new URL(url).hostname } catch { return "" } }

--- a/command/frontend/hooks/useChimeraStatus.js
+++ b/command/frontend/hooks/useChimeraStatus.js
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react"
-import { request, statusProcessing } from "../js/request.js"
+import { request, statusProcessing, jsonProcessing } from "../js/request.js"
 import useCameras from "./useCameras.js"
+
+const streamUp = (data) => Array.isArray(data) && data.length > 0 && data.every((p) => p.status === "online")
 
 const baseStatusUrls = [
 	{ statusType: "command", url: "/command/health" },
@@ -26,7 +28,8 @@ const useChimeraStatus = () => {
 	useEffect(() => {
 		const cameraStatusUrls = cameras.map((cam) => ({
 			statusType: `cam ${cam.name}`,
-			url: `/livestream/status?camera=${cam.id}`
+			url: `/livestream/status?camera=${cam.id}`,
+			stream: true
 		}))
 		const allUrls = [...baseStatusUrls, ...cameraStatusUrls]
 
@@ -40,13 +43,15 @@ const useChimeraStatus = () => {
 		const poll = () => {
 			if (document.hidden) return
 			const seq = ++pollSeq
-			for (const { statusType, url } of allUrls) {
+			for (const { statusType, url, stream } of allUrls) {
 				request(url, getOptions, (prom) => {
-					statusProcessing(prom, 200, (successful) => {
+					const apply = (up) => {
 						if (seq <= (applied[statusType] || 0)) return
 						applied[statusType] = seq
-						setStatus((prev) => ({ ...prev, [statusType]: successful ? "up" : "down" }))
-					})
+						setStatus((prev) => ({ ...prev, [statusType]: up ? "up" : "down" }))
+					}
+					if (stream) jsonProcessing(prom, (data) => apply(streamUp(data)))
+					else statusProcessing(prom, 200, apply)
 				})
 			}
 		}

--- a/command/test/chimeraStatus.test.js
+++ b/command/test/chimeraStatus.test.js
@@ -7,7 +7,8 @@ jest.mock("../frontend/hooks/useCameras.js", () => {
 
 jest.mock("../frontend/js/request.js", () => ({
 	request: jest.fn(),
-	statusProcessing: jest.fn()
+	statusProcessing: jest.fn(),
+	jsonProcessing: jest.fn()
 }))
 
 const { renderHook, act } = require("@testing-library/react")

--- a/command/test/chimeraStatusCameras.test.js
+++ b/command/test/chimeraStatusCameras.test.js
@@ -1,0 +1,59 @@
+/** @jest-environment jsdom */
+
+jest.mock("../frontend/hooks/useCameras.js", () => {
+	const cameras = [{ id: 1, name: "front" }]
+	return { __esModule: true, default: () => [cameras, false] }
+})
+
+jest.mock("../frontend/js/request.js", () => ({
+	...jest.requireActual("../frontend/js/request.js"),
+	request: jest.fn()
+}))
+
+const { renderHook, act } = require("@testing-library/react")
+const { request } = require("../frontend/js/request.js")
+const useChimeraStatus = require("../frontend/hooks/useChimeraStatus.js").default
+
+const respond = (status, body) => {
+	request.mockImplementation((url, opt, callback) => callback(Promise.resolve(
+		url.startsWith("/livestream/status?")
+			? { status, text: () => Promise.resolve(body) }
+			: { status: 500, text: () => Promise.resolve("") }
+	)))
+}
+
+const flush = () => act(async () => {
+	for (let i = 0; i < 5; i++) await Promise.resolve()
+})
+
+describe("useChimeraStatus camera dots", () => {
+	let unmount
+
+	afterEach(() => unmount && unmount())
+
+	const render = async () => {
+		const hook = renderHook(() => useChimeraStatus())
+		unmount = hook.unmount
+		await flush()
+		return hook.result
+	}
+
+	test("up when the camera's process is online", async () => {
+		respond(200, JSON.stringify([{ name: "live_stream_cam_1", status: "online", restarts: 0 }]))
+		const result = await render()
+		expect(result.current[0]["cam front"]).toBe("up")
+	})
+
+	// pm2.list keeps stopped and errored processes, so a 200 alone says nothing about the stream
+	test("down when the process is listed but stopped", async () => {
+		respond(200, JSON.stringify([{ name: "live_stream_cam_1", status: "stopped", restarts: 12 }]))
+		const result = await render()
+		expect(result.current[0]["cam front"]).toBe("down")
+	})
+
+	test("down when no process exists at all", async () => {
+		respond(204, "{}")
+		const result = await render()
+		expect(result.current[0]["cam front"]).toBe("down")
+	})
+})

--- a/env.example
+++ b/env.example
@@ -12,7 +12,7 @@ chimeraInstances = Number of instances for pm2 cluster mode; "max", -1, or an in
 # chimera_MEM_LIMIT = 4g
 # chimera_PIDS_LIMIT = 1024
 
-alert_URL = Primary alert webhook url; leave blank to send no alerts and skip the heartbeat health monitor ***
+alert_URL = Primary alert webhook url, shared by the heartbeat health monitor, scheduled task results, and object detection — which attaches a JPEG of the camera frame unless object_ALERT_ON=text; leave blank to send no alerts and skip the heartbeat health monitor ***
 admin_alert_URL = Admin alert webhook url; leave blank to send no admin alerts ***
 alert_TZ = IANA tz for human-readable times in webhook alerts, e.g. America/New_York. Defaults to UTC. Display only; does not affect stored data. ***
 
@@ -36,7 +36,7 @@ certbot_ON = (true | false)
 # TLS certs auto-resolve to /etc/letsencrypt/live/<gateway_HOST domain>/{privkey,fullchain}.pem
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
-gateway_HTTPS_Redirect = (true | false) ***
+gateway_HTTPS_Redirect = (true | false) Send every plain-HTTP request to HTTPS. Set true whenever certbot_ON=true — port 80 has to stay open for Let's Encrypt, and without the redirect it keeps serving the login form in cleartext. ***
 
 ##################################################################
 # Command
@@ -98,7 +98,7 @@ object_INTERVAL_MS = Milliseconds between scans per camera (default 5000) ***
 object_MODEL_URL = Override URL to download the YOLOX ONNX model; requires object_MODEL_SHA256. Left blank, the first boot downloads yolox_tiny.onnx (~20 MB)***
 object_MODEL_SHA256 = SHA256 of the model at object_MODEL_URL, required when object_MODEL_URL is set ***
 object_INPUT_SIZE = Model input square size, match the model (default 416) ***
-object_ALERT_ON = Fire webhook/Discord alerts on detection (true | false, default true) ***
+object_ALERT_ON = Fire webhook/Discord alerts on detection to alert_URL (true | text | false, default true). true attaches a JPEG of the frame that triggered it — everyone who can see that webhook's channel sees inside your home; text sends the summary line alone ***
 object_MAX_CAPTURES = Max capture images to retain on disk (default 500) ***
 object_PRUNE_INTERVAL_MS = Milliseconds between capture-pruning sweeps (default 300000) ***
 

--- a/env.example
+++ b/env.example
@@ -36,7 +36,7 @@ certbot_ON = (true | false)
 # TLS certs auto-resolve to /etc/letsencrypt/live/<gateway_HOST domain>/{privkey,fullchain}.pem
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
-gateway_HTTPS_Redirect = (true | false) Send every plain-HTTP request to HTTPS. Set true whenever certbot_ON=true — port 80 has to stay open for Let's Encrypt, and without the redirect it keeps serving the login form in cleartext. ***
+gateway_HTTPS_Redirect = (true | false) Redirect HTTP to HTTPS. Set true when certbot_ON=true, or port 80 keeps serving the login form in cleartext. ***
 
 ##################################################################
 # Command
@@ -98,7 +98,7 @@ object_INTERVAL_MS = Milliseconds between scans per camera (default 5000) ***
 object_MODEL_URL = Override URL to download the YOLOX ONNX model; requires object_MODEL_SHA256. Left blank, the first boot downloads yolox_tiny.onnx (~20 MB)***
 object_MODEL_SHA256 = SHA256 of the model at object_MODEL_URL, required when object_MODEL_URL is set ***
 object_INPUT_SIZE = Model input square size, match the model (default 416) ***
-object_ALERT_ON = Fire webhook/Discord alerts on detection to alert_URL (true | text | false, default true). true attaches a JPEG of the frame that triggered it — everyone who can see that webhook's channel sees inside your home; text sends the summary line alone ***
+object_ALERT_ON = Fire webhook/Discord alerts on detection to alert_URL (true | text | false, default true). true attaches a JPEG of the triggering frame; text sends the summary line only, without the image ***
 object_MAX_CAPTURES = Max capture images to retain on disk (default 500) ***
 object_PRUNE_INTERVAL_MS = Milliseconds between capture-pruning sweeps (default 300000) ***
 

--- a/lib/utils/subprocess.js
+++ b/lib/utils/subprocess.js
@@ -38,7 +38,7 @@ const getProcessList = (processName, callback) => {
 		let processList = (err ? [] : list)
 		if(processName){
 			processList = processList.filter((p) => {
-				return p.name && p.name.includes(processName)
+				return p.name && (p.name === processName || p.name.startsWith(`${processName}_`))
 			}).map(({name, pm2_env}) => ({name, status: pm2_env.status, restarts: pm2_env.restart_time}))
 		}
 		callback({processList})

--- a/livestream/test/livestream.processMatch.test.js
+++ b/livestream/test/livestream.processMatch.test.js
@@ -1,0 +1,51 @@
+const supertest = require("supertest")
+
+jest.mock("pm2", () => ({
+	list: (callback) => callback(null, [
+		{ name: "live_stream_cam_7", pm2_env: { status: "stopped", restart_time: 4 } },
+		{ name: "live_stream_cam_10", pm2_env: { status: "online", restart_time: 0 } }
+	]),
+	restart: (processName, callback) => callback(null, { name: processName })
+}))
+jest.mock("memory")
+jest.mock("lib")
+jest.mock("axios")
+
+const app = require("../backend/livestream.js")
+
+describe("status process matching", () => {
+	const cookie = "validCookie"
+
+	// live_stream_cam_1 is a prefix of live_stream_cam_10, so a substring match made camera 1 track camera 10
+	test("a camera reports 204 when only a higher-numbered camera shares its prefix", (done) => {
+		supertest(app)
+			.get("/livestream/status?camera=1")
+			.set("Cookie", cookie)
+			.expect(204, {}, done)
+	})
+
+	test("a camera still matches its own process exactly", (done) => {
+		supertest(app)
+			.get("/livestream/status?camera=10")
+			.set("Cookie", cookie)
+			.expect(200, [{ name: "live_stream_cam_10", status: "online", restarts: 0 }], done)
+	})
+
+	test("the unfiltered list keeps every camera — the prefix still matches the whole family", (done) => {
+		supertest(app)
+			.get("/livestream/status")
+			.set("Cookie", cookie)
+			.expect(200, [
+				{ name: "live_stream_cam_7", status: "stopped", restarts: 4 },
+				{ name: "live_stream_cam_10", status: "online", restarts: 0 }
+			], done)
+	})
+
+	// the route reports presence, not health — the caller has to read the status field
+	test("a stopped process is still listed, carrying its real pm2 status", (done) => {
+		supertest(app)
+			.get("/livestream/status?camera=7")
+			.set("Cookie", cookie)
+			.expect(200, [{ name: "live_stream_cam_7", status: "stopped", restarts: 4 }], done)
+	})
+})

--- a/object/README.md
+++ b/object/README.md
@@ -1,6 +1,6 @@
 # Object <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-Runs YOLOX inference on the camera HLS feeds, records detections to `objects_detected`, and fires webhook alerts (`alert_URL`).
+Runs YOLOX inference on the camera HLS feeds, records detections to `objects_detected`, and fires webhook alerts (`alert_URL`) — each one carrying a JPEG of the frame that triggered it, unless `object_ALERT_ON=text`. `alert_URL` is shared with the heartbeat monitor and scheduled task results, so whoever reads those also sees the frames.
 
 ---
 # API

--- a/object/backend/lib/worker.js
+++ b/object/backend/lib/worker.js
@@ -181,7 +181,8 @@ const handleDetections = async (camera, detections, jpeg, era) => {
 	}
 	if (process.env.object_ALERT_ON === "false") return
 	const summary = detections.map((d) => `${d.class} (${Math.round(d.score * 100)}%)`).join(", ")
-	await sendWebhook(process.env.alert_URL, `🔍 Camera ${camera}: detected ${summary}`, jpeg)
+	const textOnly = process.env.object_ALERT_ON === "text"
+	await sendWebhook(process.env.alert_URL, `🔍 Camera ${camera}: detected ${summary}`, textOnly ? null : jpeg)
 }
 
 const scan = async (id, era = epoch) => {

--- a/object/test/worker.test.js
+++ b/object/test/worker.test.js
@@ -173,6 +173,21 @@ describe("scan", () => {
 		delete process.env.object_ALERT_ON
 	})
 
+	// alert_URL is shared with the heartbeat monitor, so the frame lands wherever uptime alerts do
+	test("object_ALERT_ON=text keeps the alert but drops the frame", async () => {
+		process.env.object_ALERT_ON = "text"
+		detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
+		await worker.scan(5)
+		expect(sendWebhook).toHaveBeenCalledWith("http://hook.test", expect.stringContaining("person"), null)
+		delete process.env.object_ALERT_ON
+	})
+
+	test("the default attaches the jpeg", async () => {
+		detector.detect.mockResolvedValue([{ class: "person", score: 0.9, box: [0, 0, 1, 1] }])
+		await worker.scan(5)
+		expect(sendWebhook).toHaveBeenCalledWith("http://hook.test", expect.stringContaining("person"), expect.any(Buffer))
+	})
+
 	test("records ffmpeg failure in a tracked camera's status and rejects", async () => {
 		detector.detect.mockResolvedValue([])
 		await worker.scan(4)


### PR DESCRIPTION
Fixes #445, #446, #447, #448.

### #445 — `preflight --check` never inspects `.env` / `cameraconf` modes

`runCheck` now stats both artifacts and reports a loose mode as a problem, in the existing per-artifact shape:

```
  .env          ✗  1 problem(s)
                  - .env: mode 0644 — holds SECRETKEY, database_PASSWORD and the service tokens, and every account on this machine can read them; run: chmod 640 .env
  cameraconf/   ✗  1 problem(s)
                  - cam1.conf mode 0644 — holds netcam_userpass, the camera login, and every account on this machine can read it; run: chmod 640 cameraconf/*.conf
```

`--check` still writes nothing. `runInteractive` does tighten camera confs now — it already rewrote `.env` through `writeSecret` on every run, but a valid hand-copied conf was never revisited, so "run `npm run preflight` to fix interactively" was a dead end for the camera half.

Loose means any bit below `0640` — world read/write/exec, or group write.

### #446 — `certbot_ON=true` with `gateway_HTTPS_Redirect` unset

One warning beside the existing certbot port check in `validateEnvVars.js`, plus a description on `gateway_HTTPS_Redirect` in `env.example`, which had none.

### #447 — camera dots

- `lib/utils/subprocess.js`: `p.name.includes(processName)` → `p.name === processName || p.name.startsWith(processName + "_")`. Exact for `?camera=1`, still prefix for the family call (`live_stream_cam`) and for `motion`, so no explicit conditional is needed.
- `useChimeraStatus`: camera entries now read the body and derive `up` from `status === "online"`, the way `useLiveVideo.js:28` already does. Base service URLs keep the 200 check.

### #448 — detection frames on `alert_URL`

Both halves of the issue's fix:

- `object_ALERT_ON` takes a third value, `text` — the alert still fires, the JPEG does not attach. `false` still suppresses the alert entirely.
- `env.example` (`alert_URL`, `object_ALERT_ON`) and `object/README.md` now say that a detection alert carries a frame and that `alert_URL` is shared with the heartbeat monitor and scheduled task results.

`object_ALERT_ON` was already `***` optional, so `validateEnvVars`' bool check never ran on it; `varProblem` now validates the three values, which is where the check actually happened.

### Tests

1045 pass. New coverage: `looseMode`, an existing camera conf tightened by the wizard with nothing else to do, the certbot redirect warning, prefix-collision and stopped-process status matching against the real router, and camera dots for online / stopped / absent.
