### PR TITLE
Serve /account, name the setup token error, drop unused rtsp_url (#451, #457, #458)

### DIFF
--- a/command/backend/command.js
+++ b/command/backend/command.js
@@ -21,12 +21,14 @@ app.use("/command/health", require("heartbeat").heart)
 app.use("/authorization", require("./routes/authorization.js"))
 app.use("/cameras", auth.createAuthorize(pool), require("./routes/cameras.js"))
 app.use("/res", express.static(path.join(__dirname, "../frontend/res")))
-for(const webpath of ["/login", "/", "/clip", "/live", "/recordings", "/stats", "/schedule", "/admin", "/objects"]){
+const webAppRoutes = ["/login", "/", "/clip", "/live", "/recordings", "/stats", "/schedule", "/admin", "/objects", "/account"]
+for(const webpath of webAppRoutes){
 	app.use(webpath, express.static(path.join(__dirname, "../dist/"), {
 		index: "index.html"
 	}))
 }
 
 app.startDbPruning = () => pruneInterval(pool, "DELETE FROM sessions WHERE revoked = TRUE OR issued_at < NOW() - INTERVAL '30 days'")
+app.webAppRoutes = webAppRoutes
 
 module.exports = app

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -77,7 +77,7 @@ app.get("/status", async (req, res) => {
 
 app.post("/setup", validateBody, loginLimiter, async (req, res) => {
 	const { username, password, token } = req.body
-	if (!process.env.setup_TOKEN || !timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true })
+	if (!process.env.setup_TOKEN || !timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true, errors: "Setup token does not match setup_TOKEN in .env" })
 	if (typeof username !== "string") return res.status(400).json({ error: true })
 	if (!isValidPassword(password)) return res.status(400).json({ error: true, errors: PASSWORD_REQUIREMENT })
 	if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(username)) return res.status(400).json({ error: true, errors: "Username must be 3-50 characters and contain only letters, numbers, dashes, dots, and underscores." })

--- a/command/backend/routes/cameras.js
+++ b/command/backend/routes/cameras.js
@@ -3,29 +3,12 @@ const { loadCameras } = require("lib")
 
 const app = express.Router()
 
-const SENSITIVE_PARAM = /user|usr|pass|pwd|pw|auth|token|secret|key|api|phrase|^[up]$/i
-
-const stripCreds = (url) => {
-	try {
-		const u = new URL(url)
-		u.username = ""
-		u.password = ""
-		for (const key of [...u.searchParams.keys()]) {
-			if (SENSITIVE_PARAM.test(key)) u.searchParams.set(key, "***")
-		}
-		return u.toString()
-	} catch {
-		return "***"
-	}
-}
-
 app.get("/", async (req, res) => {
 	try {
-		res.json((await loadCameras()).map(({ id, name, rtsp_url }) => ({ id, name, rtsp_url: stripCreds(rtsp_url) })))
+		res.json((await loadCameras()).map(({ id, name }) => ({ id, name })))
 	} catch (e) {
 		res.status(500).json({ error: true })
 	}
 })
 
-app.stripCreds = stripCreds
 module.exports = app

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -59,7 +59,7 @@ describe("Authorization Routes", () => {
 				.post("/authorization/setup")
 				.send({ username: "admin", password: "password123" })
 			expect(res.status).toBe(403)
-			expect(res.body).toEqual({ error: true })
+			expect(res.body).toEqual({ error: true, errors: "Setup token does not match setup_TOKEN in .env" })
 			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
 		})
 
@@ -136,13 +136,13 @@ describe("Authorization Routes", () => {
 			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
 		})
 
-		test("rejects setup with an invalid setup_TOKEN", async () => {
+		test("rejects setup with an invalid setup_TOKEN and names the token", async () => {
 			process.env.setup_TOKEN = "right-token"
 			const res = await supertest(app)
 				.post("/authorization/setup")
 				.send({ username: "admin", password: "password123", token: "wrong-token" })
 			expect(res.status).toBe(403)
-			expect(res.body).toEqual({ error: true })
+			expect(res.body).toEqual({ error: true, errors: "Setup token does not match setup_TOKEN in .env" })
 		})
 
 		test("returns 400 when username or password is missing", async () => {

--- a/command/test/cameras.test.js
+++ b/command/test/cameras.test.js
@@ -48,7 +48,6 @@ jest.mock("memory")
 const supertest = require("supertest")
 const jwt = require("jsonwebtoken")
 const app = require("../backend/command.js")
-const camerasRoute = require("../backend/routes/cameras.js")
 
 const { mockedPool } = require("pg")
 
@@ -59,7 +58,7 @@ describe("Cameras Route", () => {
 			expect(res.status).toBe(401)
 		})
 
-		test("excludes cameras with embedded credentials and scrubs query-param creds", async () => {
+		test("returns only id and name, never the camera url", async () => {
 			const spy = jest.spyOn(console, "error").mockImplementation(() => {})
 			mockedPool.query.mockResolvedValueOnce({ rows: [{ role: "user", revoked: false }], rowCount: 1 })
 			const token = jwt.sign({ username: "test", role: "user", jti: "jti-user" }, "test-secret")
@@ -68,11 +67,11 @@ describe("Cameras Route", () => {
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
 			expect(res.status).toBe(200)
 			expect(res.body).toEqual([
-				{ id: 1, name: "indoor", rtsp_url: "rtsp://1.1.1.1/cam" },
-				{ id: 2, name: "outdoor", rtsp_url: "rtsp://2.2.2.2/cam" },
-				{ id: 4, name: "yard", rtsp_url: "rtsp://4.4.4.4/cam?user=***&p=***" },
-				{ id: 6, name: "front", rtsp_url: "rtsp://192.168.1.5/cam@1/stream" },
-				{ id: 7, name: "lab", rtsp_url: "rtsp://7.7.7.7/cam?access_token=***&api_key=***&passphrase=***" }
+				{ id: 1, name: "indoor" },
+				{ id: 2, name: "outdoor" },
+				{ id: 4, name: "yard" },
+				{ id: 6, name: "front" },
+				{ id: 7, name: "lab" }
 			])
 			spy.mockRestore()
 		})
@@ -87,12 +86,6 @@ describe("Cameras Route", () => {
 				.set("Cookie", `bearertoken=Bearer%20${token}`)
 			expect(res.status).toBe(500)
 			expect(res.body).toEqual({ error: true })
-		})
-	})
-
-	describe("stripCreds", () => {
-		test("returns a placeholder instead of the raw url when parsing fails", () => {
-			expect(camerasRoute.stripCreds("not a valid url")).toBe("***")
 		})
 	})
 })

--- a/command/test/webapp.test.js
+++ b/command/test/webapp.test.js
@@ -22,7 +22,7 @@ afterAll(() => {
 })
 
 describe("Web App Routes", () => {
-	const webAppRoutes = ["/", "/live/", "/schedule/", "/stats/", "/login/", "/clip/", "/recordings/", "/objects/", "/admin/"]
+	const webAppRoutes = app.webAppRoutes.map(route => route.endsWith("/") ? route : `${route}/`)
 
 	test("Web app routes respond with 200", () =>
 		Promise.all(webAppRoutes.map(route => new Promise((resolve, reject) => {
@@ -31,6 +31,12 @@ describe("Web App Routes", () => {
 				.expect(200, (err) => err ? reject(new Error(`route ${route} failed`)) : resolve())
 		})))
 	)
+
+	test("/account/ responds with 200", (done) => {
+		supertest(app)
+			.get("/account/")
+			.expect(200, done)
+	})
 
 	test("Nonexistent route responds with 404", (done) => {
 		supertest(app)


### PR DESCRIPTION
Three small `command` fixes.

### `/account` 404s on direct navigation

`command/backend/command.js` served the SPA for a hardcoded list of paths that never picked up `/account` when a6ed0fa (#437/#442) added it to the client router, so any refresh, bookmark or shared link to the password-change page hit a bare Express 404.

The list is now a single `webAppRoutes` constant with `/account` added, exported as `app.webAppRoutes` and consumed by `command/test/webapp.test.js` instead of the stale duplicate that hardcoded the same nine routes — so a new page can no longer be half-registered without CI noticing.

Closes #451

### Wrong setup token said "Check your credentials"

`POST /authorization/setup` returned a bare 403 on the token branch, so `SetupForm.jsx` fell back to its generic "Setup failed. Check your credentials." message — pointing the user at the two fields that cannot be wrong yet, on the screen whose job is creating that account. The branch now returns `errors: "Setup token does not match setup_TOKEN in .env"`.

This leaks nothing: `GET /authorization/status` already advertises `tokenRequired`, and the response is identical whether or not a token was supplied.

**Deferred:** the second half of #457 — the `chimera/preflight.js` wizard hint that `setup_TOKEN` will be needed in the browser later — is not in this PR. That file is owned by another in-flight PR; the hint should land there or in a follow-up.

Closes #457

### `GET /cameras` shipped an unused `rtsp_url`

The endpoint returned a scrubbed `rtsp_url` to every authenticated account including role `user`. Nothing reads it (`grep -rni rtsp command/frontend/` is empty; `useCameras` consumers use only `.id` and `.name`), and its `stripCreds` scrubber missed query-string logins like Foscam's `?loginuse=&loginpas=`.

Dropped the field rather than patching the regex, which retires the whole class. `stripCreds` and `SENSITIVE_PARAM` are removed with it — the only other reference was its own test. Camera exclusion for embedded credentials is still covered: the expected id list in `cameras.test.js` continues to prove cam3 and cam5 are dropped.

Closes #458

### Verification

- `npx jest --selectProjects command` — 24 suites, 218 tests, all passing.
- `npm run lint:ci` — exit 0, 0 errors, 122 warnings (limit 150).

`webapp.test.js` now asserts `GET /account/` returns 200 against the real app, using the existing stub `dist/index.html` fixture.

https://claude.ai/code/session_01Ko8njbHXNyeWBvTCQaiJV6
