### PR TITLE
Associate form labels with their inputs and announce auth errors

### DIFF
--- a/command/frontend/app/AccountSettings.jsx
+++ b/command/frontend/app/AccountSettings.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useId, useState } from "react"
 import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card"
 import { Input } from "../components/ui/input"
 import { Label } from "../components/ui/label"
@@ -11,6 +11,7 @@ const emptyForm = { currentPassword: "", password: "", confirm: "" }
 
 const AccountSettings = () => {
 	const changePassword = useChangePassword()
+	const uid = useId()
 	const [form, setForm] = useState(emptyForm)
 	const [pending, setPending] = useState(false)
 
@@ -32,8 +33,9 @@ const AccountSettings = () => {
 
 	const field = (key, label, placeholder, autoComplete) => (
 		<div className="flex flex-col gap-1">
-			<Label className="text-primary">{label}</Label>
+			<Label htmlFor={`${uid}-${key}`} className="text-primary">{label}</Label>
 			<Input
+				id={`${uid}-${key}`}
 				type="password"
 				value={form[key]}
 				onChange={e => setForm(f => ({ ...f, [key]: e.target.value }))}

--- a/command/frontend/app/AddUserDialog.jsx
+++ b/command/frontend/app/AddUserDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useId, useState } from "react"
 import { Button } from "../components/ui/button"
 import { Input } from "../components/ui/input"
 import { Label } from "../components/ui/label"
@@ -10,6 +10,7 @@ import toast from "../js/toast.js"
 const ROLES = ["user", "admin"]
 
 const AddUserDialog = ({ onAdded }) => {
+	const uid = useId()
 	const [open, setOpen] = useState(false)
 	const [form, setForm] = useState({ username: "", role: "user" })
 	const [tempPassword, setTempPassword] = useState(null)
@@ -82,13 +83,13 @@ const AddUserDialog = ({ onAdded }) => {
 				) : (
 					<form onSubmit={addUser} className="flex flex-col gap-4 pt-2">
 						<div className="flex flex-col gap-1">
-							<Label className="text-primary">Username</Label>
-							<Input required value={form.username} onChange={e => setForm(f => ({ ...f, username: e.target.value }))} className="bg-surface-raised border-border text-primary placeholder:text-muted" placeholder="username" />
+							<Label htmlFor={`${uid}-username`} className="text-primary">Username</Label>
+							<Input id={`${uid}-username`} required value={form.username} onChange={e => setForm(f => ({ ...f, username: e.target.value }))} className="bg-surface-raised border-border text-primary placeholder:text-muted" placeholder="username" />
 						</div>
 						<div className="flex flex-col gap-1">
-							<Label className="text-primary">Role</Label>
+							<Label id={`${uid}-role-label`} htmlFor={`${uid}-role`} className="text-primary">Role</Label>
 							<Select value={form.role} onValueChange={v => setForm(f => ({ ...f, role: v }))}>
-								<SelectTrigger className="bg-surface-raised border-border text-primary">
+								<SelectTrigger id={`${uid}-role`} aria-labelledby={`${uid}-role-label ${uid}-role`} className="bg-surface-raised border-border text-primary">
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent className="bg-surface-raised border-border text-primary">

--- a/command/frontend/app/ChangePasswordForm.jsx
+++ b/command/frontend/app/ChangePasswordForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useId, useState } from "react"
 import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card"
 import { Input } from "../components/ui/input"
 import { Label } from "../components/ui/label"
@@ -6,14 +6,21 @@ import { Button } from "../components/ui/button"
 import { validatePassword } from "../js/password.js"
 
 const ChangePasswordForm = ({ changePassword }) => {
+	const uid = useId()
 	const [password, setPassword] = useState("")
 	const [confirm, setConfirm] = useState("")
 	const [status, setStatus] = useState(null)
 	const [message, setMessage] = useState(null)
 
 	const onSubmit = () => {
-		if (!password || password !== confirm) {
-			setStatus("mismatch")
+		if (!password || !confirm) {
+			setStatus("failed")
+			setMessage("Enter and confirm your new password.")
+			return
+		}
+		if (password !== confirm) {
+			setStatus("failed")
+			setMessage("Passwords do not match.")
 			return
 		}
 		const invalid = validatePassword(password)
@@ -42,8 +49,9 @@ const ChangePasswordForm = ({ changePassword }) => {
 				</CardHeader>
 				<CardContent className="flex flex-col gap-4">
 					<div className="flex flex-col gap-1">
-						<Label className="text-muted">New Password</Label>
+						<Label htmlFor={`${uid}-password`} className="text-muted">New Password</Label>
 						<Input
+							id={`${uid}-password`}
 							className="bg-surface-raised border-border text-primary placeholder:text-muted"
 							type="password"
 							placeholder="new password"
@@ -54,8 +62,9 @@ const ChangePasswordForm = ({ changePassword }) => {
 						/>
 					</div>
 					<div className="flex flex-col gap-1">
-						<Label className="text-muted">Confirm Password</Label>
+						<Label htmlFor={`${uid}-confirm`} className="text-muted">Confirm Password</Label>
 						<Input
+							id={`${uid}-confirm`}
 							className="bg-surface-raised border-border text-primary placeholder:text-muted"
 							type="password"
 							placeholder="confirm password"
@@ -65,11 +74,8 @@ const ChangePasswordForm = ({ changePassword }) => {
 							autoComplete="new-password"
 						/>
 					</div>
-					{status === "mismatch" && (
-						<p className="text-danger text-sm">Passwords do not match.</p>
-					)}
 					{status === "failed" && (
-						<p className="text-danger text-sm">{message || "Failed to change password."}</p>
+						<p role="alert" className="text-danger text-sm">{message || "Failed to change password."}</p>
 					)}
 					<Button
 						className="bg-accent text-accent-foreground hover:opacity-90 w-full"

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, useEffect } from "react"
+import React, { useId, useState, useMemo, useRef, useEffect } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { useRole } from "./AuthContext"
 import { ImageOff, Square, Minus, Plus, ZoomIn, Check, X, Rewind, LayoutGrid, RectangleHorizontal, Save, SkipBack, ScanEye } from "lucide-react"
@@ -281,6 +281,7 @@ const ClipMakerMini = () => {
 }
 
 const ClipMakerFull = () => {
+	const uid = useId()
 	const isDesktop = useMediaQuery({ query: "(min-width: 601px)" })
 	const role = useRole()
 	const isAdmin = role === "admin"
@@ -805,10 +806,10 @@ const ClipMakerFull = () => {
 			<div className="flex flex-col gap-4 px-2 pt-1 pb-3">
 				<div className="grid grid-cols-2 gap-3">
 					<div className="flex flex-col gap-1.5">
-						<Label>Camera{multiCam ? "s" : ""}</Label>
+						<Label id={`${uid}-camera-label`} htmlFor={multiCam && isDesktop ? undefined : `${uid}-camera`}>Camera{multiCam ? "s" : ""}</Label>
 						{multiCam && isDesktop ? (
 							<div className="flex flex-col gap-1">
-								<div className="flex flex-wrap gap-1">
+								<div role="group" aria-labelledby={`${uid}-camera-label`} className="flex flex-wrap gap-1">
 									{cameras.map((cam, i) => {
 										const selected = selectedCams.includes(i)
 										const atMax = !selected && selectedCams.length >= 4
@@ -833,7 +834,7 @@ const ClipMakerFull = () => {
 						) : (
 							<div className="flex gap-1">
 								<Select value={camera == null ? "" : String(camera)} onValueChange={v => setCamera(parseInt(v))}>
-									<SelectTrigger><SelectValue placeholder="Select camera" /></SelectTrigger>
+									<SelectTrigger id={`${uid}-camera`} aria-labelledby={`${uid}-camera-label ${uid}-camera`}><SelectValue placeholder="Select camera" /></SelectTrigger>
 									<SelectContent>
 										{cameras.map((cam, i) => (
 											<SelectItem key={cam.id} value={String(i)}>{cam.name}</SelectItem>
@@ -849,12 +850,13 @@ const ClipMakerFull = () => {
 						)}
 					</div>
 					<div className="flex flex-col gap-1.5">
-						<Label>Frames</Label>
+						<Label htmlFor={`${uid}-frames`}>Frames</Label>
 						<div className="flex items-center gap-2">
 							<Button variant="outline" size="icon" className="size-9 pointer-coarse:size-11 shrink-0" onClick={() => setNumber(n => Math.max(frameLimits.min, n - 10))}>
 								<Minus className="size-4" />
 							</Button>
 							<Input
+								id={`${uid}-frames`}
 								type="number"
 								min={frameLimits.min}
 								max={frameLimits.max}
@@ -871,8 +873,8 @@ const ClipMakerFull = () => {
 
 				<div className="flex flex-col gap-3 p-2 bg-muted/5 border border-border/50 rounded-lg">
 					<div className="flex flex-col gap-1">
-						<Label>Time Range</Label>
-						<div className="flex items-center gap-2 justify-end flex-wrap">
+						<Label id={`${uid}-range-label`}>Time Range</Label>
+						<div role="group" aria-labelledby={`${uid}-range-label`} className="flex items-center gap-2 justify-end flex-wrap">
 							<span className="text-xs text-muted/50">preset</span>
 							<Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={cancelPreset} disabled={!pendingPreset}>
 								<X className="size-3" />
@@ -892,15 +894,15 @@ const ClipMakerFull = () => {
 						</div>
 					</div>
 					<div className="grid grid-cols-2 gap-x-3 gap-y-2">
-						<Label className="text-xs">Start</Label>
-						<Label className="text-xs">End</Label>
-						<Input type="date" value={startDate.format("YYYY-MM-DD")}
+						<Label htmlFor={`${uid}-start-date`} className="text-xs">Start</Label>
+						<Label htmlFor={`${uid}-end-date`} className="text-xs">End</Label>
+						<Input id={`${uid}-start-date`} type="date" value={startDate.format("YYYY-MM-DD")}
 							onChange={e => setDatePart(setStartDate, "date", e.target.value)} />
-						<Input type="date" value={endDate.format("YYYY-MM-DD")}
+						<Input id={`${uid}-end-date`} type="date" value={endDate.format("YYYY-MM-DD")}
 							onChange={e => setDatePart(setEndDate, "date", e.target.value)} />
-						<Input type="time" step="1" value={startDate.format("HH:mm:ss")}
+						<Input aria-label="Start time" type="time" step="1" value={startDate.format("HH:mm:ss")}
 							onChange={e => setDatePart(setStartDate, "time", e.target.value)} />
-						<Input type="time" step="1" value={endDate.format("HH:mm:ss")}
+						<Input aria-label="End time" type="time" step="1" value={endDate.format("HH:mm:ss")}
 							onChange={e => setDatePart(setEndDate, "time", e.target.value)} />
 					</div>
 				</div>
@@ -925,12 +927,13 @@ const ClipMakerFull = () => {
 								<div className="flex flex-col gap-4">
 									<div className="flex flex-col gap-3">
 										<div className="flex items-center justify-between gap-4">
-											<Label>FPS</Label>
+											<Label htmlFor={`${uid}-fps`}>FPS</Label>
 											<div className="flex items-center gap-2">
 												<Button variant="outline" size="icon" className="size-8 pointer-coarse:size-11 shrink-0" onClick={() => setFps(f => Math.max(1, f - 5))}>
 													<Minus className="size-4" />
 												</Button>
 												<Input
+													id={`${uid}-fps`}
 													type="number"
 													min="1"
 													value={fps}
@@ -943,12 +946,13 @@ const ClipMakerFull = () => {
 											</div>
 										</div>
 										<div className="flex items-center justify-between gap-4">
-											<Label>Skip</Label>
+											<Label htmlFor={`${uid}-skip`}>Skip</Label>
 											<div className="flex items-center gap-2">
 												<Button variant="outline" size="icon" className="size-8 pointer-coarse:size-11 shrink-0" onClick={() => setSkip(s => Math.max(1, s - 1))}>
 													<Minus className="size-4" />
 												</Button>
 												<Input
+													id={`${uid}-skip`}
 													type="number"
 													min="1"
 													value={skip}

--- a/command/frontend/app/EditUserDialog.jsx
+++ b/command/frontend/app/EditUserDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useId, useState, useEffect } from "react"
 import { Button } from "../components/ui/button"
 import { Input } from "../components/ui/input"
 import { Label } from "../components/ui/label"
@@ -11,6 +11,7 @@ import { validatePassword } from "../js/password.js"
 const ROLES = ["user", "admin"]
 
 const EditUserDialog = ({ user, open, onOpenChange, onUpdated }) => {
+	const uid = useId()
 	const [form, setForm] = useState({ role: "", password: "", confirm: "" })
 
 	useEffect(() => {
@@ -56,9 +57,9 @@ const EditUserDialog = ({ user, open, onOpenChange, onUpdated }) => {
 				</DialogHeader>
 				<form onSubmit={updateUser} className="flex flex-col gap-4 pt-2">
 					<div className="flex flex-col gap-1">
-						<Label className="text-primary">Role</Label>
+						<Label id={`${uid}-role-label`} htmlFor={`${uid}-role`} className="text-primary">Role</Label>
 						<Select value={form.role} onValueChange={v => setForm(f => ({ ...f, role: v }))}>
-							<SelectTrigger className="bg-surface-raised border-border text-primary">
+							<SelectTrigger id={`${uid}-role`} aria-labelledby={`${uid}-role-label ${uid}-role`} className="bg-surface-raised border-border text-primary">
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent className="bg-surface-raised border-border text-primary">
@@ -67,12 +68,12 @@ const EditUserDialog = ({ user, open, onOpenChange, onUpdated }) => {
 						</Select>
 					</div>
 					<div className="flex flex-col gap-1">
-						<Label className="text-primary">New Password</Label>
-						<Input type="password" value={form.password} onChange={e => setForm(f => ({ ...f, password: e.target.value }))} className="bg-surface-raised border-border text-primary placeholder:text-muted" placeholder="leave blank to keep current" />
+						<Label htmlFor={`${uid}-password`} className="text-primary">New Password</Label>
+						<Input id={`${uid}-password`} type="password" value={form.password} onChange={e => setForm(f => ({ ...f, password: e.target.value }))} className="bg-surface-raised border-border text-primary placeholder:text-muted" placeholder="leave blank to keep current" />
 					</div>
 					<div className="flex flex-col gap-1">
-						<Label className="text-primary">Confirm Password</Label>
-						<Input type="password" value={form.confirm} onChange={e => setForm(f => ({ ...f, confirm: e.target.value }))} className="bg-surface-raised border-border text-primary placeholder:text-muted" placeholder="re-enter new password" />
+						<Label htmlFor={`${uid}-confirm`} className="text-primary">Confirm Password</Label>
+						<Input id={`${uid}-confirm`} type="password" value={form.confirm} onChange={e => setForm(f => ({ ...f, confirm: e.target.value }))} className="bg-surface-raised border-border text-primary placeholder:text-muted" placeholder="re-enter new password" />
 					</div>
 					<DialogFooter>
 						<DialogClose asChild>

--- a/command/frontend/app/LoginForm.jsx
+++ b/command/frontend/app/LoginForm.jsx
@@ -7,6 +7,7 @@ import { Button } from "../components/ui/button"
 
 const LoginForm = (props) => {
 	const [loginStatus, , , inputValues, onLoginEnter, updateUsername, updatePassword, loginError] = useLoginSchema(props)
+	const uid = React.useId()
 
 	const handleSubmit = (e) => {
 		e.preventDefault()
@@ -22,8 +23,9 @@ const LoginForm = (props) => {
 			<CardContent>
 				<form onSubmit={handleSubmit} className="flex flex-col gap-4">
 					<div className="flex flex-col gap-1">
-						<Label className="text-muted">Username</Label>
+						<Label htmlFor={`${uid}-username`} className="text-muted">Username</Label>
 						<Input
+							id={`${uid}-username`}
 							className="bg-surface-raised border-border text-primary placeholder:text-muted"
 							placeholder="username"
 							value={inputValues.username}
@@ -32,8 +34,9 @@ const LoginForm = (props) => {
 						/>
 					</div>
 					<div className="flex flex-col gap-1">
-						<Label className="text-muted">Password</Label>
+						<Label htmlFor={`${uid}-password`} className="text-muted">Password</Label>
 						<Input
+							id={`${uid}-password`}
 							className="bg-surface-raised border-border text-primary placeholder:text-muted"
 							type="password"
 							placeholder="password"
@@ -43,10 +46,10 @@ const LoginForm = (props) => {
 						/>
 					</div>
 					{loginStatus === "wrong" && (
-						<p className="text-danger text-sm">{loginError || "Invalid username or password."}</p>
+						<p role="alert" className="text-danger text-sm">{loginError || "Invalid username or password."}</p>
 					)}
 					{loginStatus === "right" && (
-						<p className="text-accent text-sm">Signed in.</p>
+						<p role="status" className="text-accent text-sm">Signed in.</p>
 					)}
 					<Button
 						type="submit"

--- a/command/frontend/app/ScheduleDashboard.jsx
+++ b/command/frontend/app/ScheduleDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useId, useState, useEffect } from "react"
 import { useRole } from "./AuthContext"
 import moment from "moment"
 import cronstrue from "cronstrue"
@@ -156,6 +156,7 @@ const ScheduleDashboardMini = ({ withButton }) => {
 const ScheduleDashboardFull = ({ mobile = false }) => {
 	const role = useRole()
 	const isAdmin = role === "admin"
+	const uid = useId()
 	const [{ processList, loading }, restartTask, stopTask, deleteTask, reloadTasks] = useTasks()
 	const [scheduleTask] = useScheduler()
 	const [cameras] = useCameras()
@@ -292,9 +293,9 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 						</CardHeader>
 						<CardContent className="flex flex-col gap-4">
 							<div className="flex flex-col gap-1.5">
-								<Label className="text-xs text-muted">Camera</Label>
+								<Label id={`${uid}-camera-label`} htmlFor={`${uid}-camera`} className="text-xs text-muted">Camera</Label>
 								<Select value={schedCamera == null ? "" : String(schedCamera)} onValueChange={v => setSchedCamera(parseInt(v))}>
-									<SelectTrigger><SelectValue placeholder="Select camera" /></SelectTrigger>
+									<SelectTrigger id={`${uid}-camera`} aria-labelledby={`${uid}-camera-label ${uid}-camera`}><SelectValue placeholder="Select camera" /></SelectTrigger>
 									<SelectContent>
 										{cameras.map((cam, i) => (
 											<SelectItem key={cam.id} value={String(i)}>{cam.name}</SelectItem>
@@ -304,8 +305,8 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 							</div>
 
 							<div className="flex flex-col gap-1.5">
-								<Label className="text-xs text-muted">Window</Label>
-								<div className="flex gap-1">
+								<Label id={`${uid}-window-label`} className="text-xs text-muted">Window</Label>
+								<div role="group" aria-labelledby={`${uid}-window-label`} className="flex gap-1">
 									{SCHEDULE_PRESETS.map(p => (
 										<Button
 											key={p.label}
@@ -321,12 +322,13 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 							</div>
 
 							<div className="flex items-center justify-between">
-								<Label className="text-xs text-muted">Skip</Label>
+								<Label htmlFor={`${uid}-skip`} className="text-xs text-muted">Skip</Label>
 								<div className="flex items-center gap-1">
 									<Button variant="ghost" size="icon" className="size-7 pointer-coarse:size-11" onClick={() => setSchedSkip(s => Math.max(1, s - 1))}>
 										<Minus className="size-3" />
 									</Button>
 									<Input
+										id={`${uid}-skip`}
 										type="number"
 										min={1}
 										value={schedSkip}
@@ -354,8 +356,8 @@ const ScheduleDashboardFull = ({ mobile = false }) => {
 
 							{outputType === "video" && (
 								<div className="flex items-center justify-between">
-									<Label className="text-xs text-muted">FPS</Label>
-									<div className="flex items-center gap-1">
+									<Label id={`${uid}-fps-label`} className="text-xs text-muted">FPS</Label>
+									<div role="group" aria-labelledby={`${uid}-fps-label`} className="flex items-center gap-1">
 										<Button variant="ghost" size="icon" className="size-7 pointer-coarse:size-11" onClick={() => setFps(f => Math.max(1, f - 5))}>
 											<Minus className="size-3" />
 										</Button>

--- a/command/frontend/app/Scheduler.jsx
+++ b/command/frontend/app/Scheduler.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useId, useState } from "react"
 
 import cronstrue from "cronstrue"
 
@@ -25,13 +25,15 @@ const cronIsInvalid = (cronString) => {
 }
 
 const Scheduler = ({ cronString: initial = "", url, onEnter, disabled = false }) => {
+	const cronId = useId()
 	const [cronString, setCronString] = useState(initial)
 
 	return (
 		<div className="flex flex-col gap-1.5">
-			<Label className="text-xs text-muted">CRON expression</Label>
+			<Label htmlFor={cronId} className="text-xs text-muted">CRON expression</Label>
 			<div className="flex items-center gap-2">
 				<Input
+					id={cronId}
 					value={cronString}
 					onChange={(e) => setCronString(e.target.value)}
 					placeholder="* * * * *"

--- a/command/frontend/app/SetupForm.jsx
+++ b/command/frontend/app/SetupForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useId, useState } from "react"
 import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card"
 import { Input } from "../components/ui/input"
 import { Label } from "../components/ui/label"
@@ -6,6 +6,7 @@ import { Button } from "../components/ui/button"
 import { validatePassword } from "../js/password.js"
 
 const SetupForm = ({ trySetup, tokenRequired }) => {
+	const uid = useId()
 	const [status, setStatus] = useState(null)
 	const [message, setMessage] = useState(null)
 	const [username, setUsername] = useState("")
@@ -60,8 +61,9 @@ const SetupForm = ({ trySetup, tokenRequired }) => {
 				<CardContent>
 					<form onSubmit={onSubmit} className="flex flex-col gap-4">
 						<div className="flex flex-col gap-1">
-							<Label className="text-muted">Username</Label>
+							<Label htmlFor={`${uid}-username`} className="text-muted">Username</Label>
 							<Input
+								id={`${uid}-username`}
 								className="bg-surface-raised border-border text-primary placeholder:text-muted"
 								placeholder="username"
 								value={username}
@@ -70,8 +72,9 @@ const SetupForm = ({ trySetup, tokenRequired }) => {
 							/>
 						</div>
 						<div className="flex flex-col gap-1">
-							<Label className="text-muted">Password</Label>
+							<Label htmlFor={`${uid}-password`} className="text-muted">Password</Label>
 							<Input
+								id={`${uid}-password`}
 								className="bg-surface-raised border-border text-primary placeholder:text-muted"
 								type="password"
 								placeholder="password"
@@ -81,8 +84,9 @@ const SetupForm = ({ trySetup, tokenRequired }) => {
 							/>
 						</div>
 						<div className="flex flex-col gap-1">
-							<Label className="text-muted">Confirm Password</Label>
+							<Label htmlFor={`${uid}-confirm`} className="text-muted">Confirm Password</Label>
 							<Input
+								id={`${uid}-confirm`}
 								className="bg-surface-raised border-border text-primary placeholder:text-muted"
 								type="password"
 								placeholder="confirm password"
@@ -93,8 +97,9 @@ const SetupForm = ({ trySetup, tokenRequired }) => {
 						</div>
 						{tokenRequired && (
 							<div className="flex flex-col gap-1">
-								<Label className="text-muted">Setup Token</Label>
+								<Label htmlFor={`${uid}-token`} className="text-muted">Setup Token</Label>
 								<Input
+									id={`${uid}-token`}
 									className="bg-surface-raised border-border text-primary placeholder:text-muted"
 									type="password"
 									placeholder="setup token"
@@ -104,10 +109,10 @@ const SetupForm = ({ trySetup, tokenRequired }) => {
 							</div>
 						)}
 						{status === "failed" && (
-							<p className="text-danger text-sm">{message || "Setup failed. Check your credentials."}</p>
+							<p role="alert" className="text-danger text-sm">{message || "Setup failed. Check your credentials."}</p>
 						)}
 						{status === "done" && (
-							<p className="text-accent text-sm">Account created — redirecting to login…</p>
+							<p role="status" className="text-accent text-sm">Account created — redirecting to login…</p>
 						)}
 						<Button
 							type="submit"

--- a/command/frontend/components/ToastContainer.jsx
+++ b/command/frontend/components/ToastContainer.jsx
@@ -25,10 +25,8 @@ export default function ToastContainer() {
 		}
 	}, [])
 
-	if (toasts.length === 0) return null
-
 	return (
-		<div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] flex flex-col gap-2 pointer-events-none">
+		<div role="status" aria-live="polite" className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] flex flex-col gap-2 pointer-events-none">
 			{toasts.map(t => (
 				<div key={t.id} className="bg-surface-raised text-primary border border-border px-4 py-2.5 rounded-lg font-sans text-sm shadow-[0_4px_16px_rgba(0,0,0,0.4)] whitespace-nowrap pointer-events-auto">
 					{t.message}

--- a/command/test/accountSettings.test.jsx
+++ b/command/test/accountSettings.test.jsx
@@ -12,9 +12,9 @@ const renderForm = (changePassword) =>
 		React.createElement(AccountSettings)))
 
 const fill = ({ current = "oldpassword", password = "newpassword", confirm = "newpassword" } = {}) => {
-	fireEvent.change(screen.getByPlaceholderText("current password"), { target: { value: current } })
-	fireEvent.change(screen.getByPlaceholderText("new password"), { target: { value: password } })
-	fireEvent.change(screen.getByPlaceholderText("re-enter new password"), { target: { value: confirm } })
+	fireEvent.change(screen.getByLabelText("Current Password"), { target: { value: current } })
+	fireEvent.change(screen.getByLabelText("New Password"), { target: { value: password } })
+	fireEvent.change(screen.getByLabelText("Confirm Password"), { target: { value: confirm } })
 }
 
 test("submits the current password alongside the new one", () => {

--- a/command/test/changePasswordForm.test.jsx
+++ b/command/test/changePasswordForm.test.jsx
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+
+const React = require("react")
+const { render, screen, fireEvent } = require("@testing-library/react")
+const ChangePasswordForm = require("../frontend/app/ChangePasswordForm.jsx").default
+
+const fill = ({ password = "longenough1", confirm = "longenough1" } = {}) => {
+	fireEvent.change(screen.getByLabelText("New Password"), { target: { value: password } })
+	fireEvent.change(screen.getByLabelText("Confirm Password"), { target: { value: confirm } })
+}
+
+test("both fields are reachable by their visible labels", () => {
+	const changePassword = jest.fn()
+	render(React.createElement(ChangePasswordForm, { changePassword }))
+
+	fill()
+	fireEvent.click(screen.getByText("Set Password"))
+
+	expect(changePassword).toHaveBeenCalledWith({ password: "longenough1" }, expect.any(Function))
+})
+
+test("submitting two empty fields asks for a password instead of reporting a mismatch", () => {
+	const changePassword = jest.fn()
+	render(React.createElement(ChangePasswordForm, { changePassword }))
+
+	fireEvent.click(screen.getByText("Set Password"))
+
+	expect(changePassword).not.toHaveBeenCalled()
+	expect(screen.getByRole("alert").textContent).toBe("Enter and confirm your new password.")
+})
+
+test("leaving only the confirm field blank does not claim a mismatch", () => {
+	const changePassword = jest.fn()
+	render(React.createElement(ChangePasswordForm, { changePassword }))
+
+	fill({ confirm: "" })
+	fireEvent.click(screen.getByText("Set Password"))
+
+	expect(changePassword).not.toHaveBeenCalled()
+	expect(screen.getByRole("alert").textContent).toBe("Enter and confirm your new password.")
+})
+
+test("two different non-empty passwords still report a mismatch", () => {
+	const changePassword = jest.fn()
+	render(React.createElement(ChangePasswordForm, { changePassword }))
+
+	fill({ confirm: "different1" })
+	fireEvent.click(screen.getByText("Set Password"))
+
+	expect(changePassword).not.toHaveBeenCalled()
+	expect(screen.getByRole("alert").textContent).toBe("Passwords do not match.")
+})
+
+test("a rejected change is announced", () => {
+	const changePassword = jest.fn((body, cb) => cb(false, "Server said no"))
+	render(React.createElement(ChangePasswordForm, { changePassword }))
+
+	fill()
+	fireEvent.click(screen.getByText("Set Password"))
+
+	expect(screen.getByRole("alert").textContent).toBe("Server said no")
+})

--- a/command/test/loginForm.test.jsx
+++ b/command/test/loginForm.test.jsx
@@ -26,6 +26,26 @@ test("clicking Sign In submits the form via type=submit", () => {
 	expect(tryLogin).toHaveBeenCalledWith("bob", "hunter2", expect.any(Function))
 })
 
+test("each field is reachable by its visible label", () => {
+	const tryLogin = jest.fn()
+	render(React.createElement(LoginForm, { tryLogin }))
+
+	fireEvent.change(screen.getByLabelText("Username"), { target: { value: "alice" } })
+	fireEvent.change(screen.getByLabelText("Password"), { target: { value: "secret" } })
+	fireEvent.click(screen.getByText("Sign In"))
+
+	expect(tryLogin).toHaveBeenCalledWith("alice", "secret", expect.any(Function))
+})
+
+test("a rejected login is announced rather than only shown", () => {
+	const tryLogin = jest.fn((username, password, cb) => cb(false, null))
+	render(React.createElement(LoginForm, { tryLogin }))
+
+	fireEvent.click(screen.getByText("Sign In"))
+
+	expect(screen.getByRole("alert").textContent).toBe("Invalid username or password.")
+})
+
 test("submit does not trigger native page navigation", () => {
 	const tryLogin = jest.fn()
 	render(React.createElement(LoginForm, { tryLogin }))

--- a/command/test/setupForm.test.jsx
+++ b/command/test/setupForm.test.jsx
@@ -31,7 +31,7 @@ test("clicking Create Account submits the form via type=submit", () => {
 	expect(trySetup).toHaveBeenCalledWith("bob", "hunter22", "tok", expect.any(Function))
 })
 
-test("a password/confirm mismatch blocks submission and shows an error", () => {
+test("a password/confirm mismatch blocks submission and announces the error", () => {
 	const trySetup = jest.fn()
 	render(React.createElement(SetupForm, { trySetup, tokenRequired: true }))
 
@@ -39,7 +39,20 @@ test("a password/confirm mismatch blocks submission and shows an error", () => {
 	fireEvent.click(screen.getByText("Create Account"))
 
 	expect(trySetup).not.toHaveBeenCalled()
-	expect(screen.getByText("Passwords do not match.")).toBeTruthy()
+	expect(screen.getByRole("alert").textContent).toBe("Passwords do not match.")
+})
+
+test("every field is reachable by its visible label", () => {
+	const trySetup = jest.fn()
+	render(React.createElement(SetupForm, { trySetup, tokenRequired: true }))
+
+	fireEvent.change(screen.getByLabelText("Username"), { target: { value: "alice" } })
+	fireEvent.change(screen.getByLabelText("Password"), { target: { value: "longenough1" } })
+	fireEvent.change(screen.getByLabelText("Confirm Password"), { target: { value: "longenough1" } })
+	fireEvent.change(screen.getByLabelText("Setup Token"), { target: { value: "topsecret" } })
+	fireEvent.click(screen.getByText("Create Account"))
+
+	expect(trySetup).toHaveBeenCalledWith("alice", "longenough1", "topsecret", expect.any(Function))
 })
 
 test("submit does not trigger native page navigation", () => {


### PR DESCRIPTION
## What changed

**1. Labels are now associated with their controls.** Every `<Label>` in the frontend was a bare `<label>` with no `htmlFor`, sitting as a *sibling* of its `<Input>` — so no explicit and no implicit association. Screen readers announced unnamed edit fields, and clicking a label didn't focus anything.

Wired across the whole app, not just the auth screens:

- `LoginForm`, `SetupForm`, `ChangePasswordForm`, `AccountSettings`, `AddUserDialog`, `EditUserDialog` — `htmlFor`/`id` per field.
- `Scheduler`, `ScheduleDashboard`, `ClipMaker` — same, plus the cases a plain `htmlFor` can't express:
  - **Select triggers** (`AddUserDialog`/`EditUserDialog` Role, `ScheduleDashboard`/`ClipMaker` Camera) get `aria-labelledby="<label-id> <trigger-id>"`. A `<label for>` does not name a `<button>` under HTML-AAM, so `htmlFor` alone would have left the trigger named only by its selected value. The two-id form keeps both the field name and the current value in the accessible name.
  - **Button groups** with a heading-style label (`ScheduleDashboard` Window and FPS, `ClipMaker` multi-camera picker and Time Range presets) become `role="group" aria-labelledby=…`.
  - `ClipMaker`'s Start/End grid has two labels over four inputs; the labels are wired to the date inputs and the time inputs carry `aria-label="Start time"` / `"End time"`.

`grep -rn "<Label" command/frontend` now returns zero labels without an `htmlFor` or an `id`.

**2. Errors are announced.** The frontend had zero `aria-live`/`role="alert"`. Added `role="alert"` to the error paragraphs in `LoginForm`, `SetupForm` and `ChangePasswordForm`, and `role="status"` to the two success messages ("Signed in.", "Account created…"), which were equally silent. For the `AccountSettings` path the errors are toasts, so `ToastContainer` is now a persistent `role="status" aria-live="polite"` region — it previously returned `null` when empty, and a live region has to exist *before* content lands in it to be reliably announced.

**3. Wrong copy on the forced-password-change screen.** `ChangePasswordForm` folded emptiness and mismatch into one branch, so submitting two empty fields said "Passwords do not match." — on the first screen every new account sees. Split into an empty check ("Enter and confirm your new password.") and a real mismatch check, both routed through the existing `message` state so there's a single error node. This also drops the now-redundant `"mismatch"` status and matches how `SetupForm` already reports the same condition.

## Approach for the id wiring

**Explicit `htmlFor`/`id` per call site**, with the id namespaced by a `React.useId()` prefix in each component, rather than making `ui/label.jsx` and `ui/input.jsx` auto-cooperate.

The primitives are rendered as siblings, so they cannot share a generated id without a common parent — the auto-generated version means adding a `<Field>` context provider and converting every `<div className="flex flex-col gap-1">` into `<Field>`. That's the same number of touched lines as wiring the attributes directly, but it buys two failure modes: a `Field` containing two `<Input>`s silently emits duplicate ids, and a `Field` whose label sits over a button group or a Select emits an `htmlFor` pointing at nothing. Both are invisible at the call site. It also wouldn't have covered the Select and `role="group"` cases at all, which needed hand-wiring regardless — so the "magic" would have handled only the easy half.

The explicit form needs no new file, no context, no changes to `label.jsx` or `input.jsx` (Radix's `Label` already spreads `htmlFor` onto the `<label>`), and uses one mechanism for every case. `useId()` keeps ids unique for components that can mount more than once (`ClipMaker`, `Scheduler`, the dialogs).

## Tests

Added tests that only pass if the association is real (`getByLabelText` fails on an unassociated label) and that assert the error node's role:

- `loginForm.test.jsx` — fields reachable by label; rejected login exposes `role="alert"`.
- `setupForm.test.jsx` — all four fields reachable by label; the mismatch test now asserts `getByRole("alert")` instead of `getByText`.
- `accountSettings.test.jsx` — the shared `fill` helper switched from `getByPlaceholderText` to `getByLabelText`, so all four existing tests now cover the association.
- `changePasswordForm.test.jsx` (new) — fields reachable by label, both-empty and confirm-only-empty produce the new copy, a genuine mismatch still says "Passwords do not match.", and a server rejection is announced.

## Results

- `npx jest --selectProjects command` — **25 suites, 226 tests passed**.
- `npm run build:command` — **passed**, built in 2.16s.
- `npm run lint:ci` — **cannot run in this worktree**, and this is pre-existing, not caused by this change. The worktree lives at `.claude/worktrees/…` inside the parent checkout, so ESLint's config cascade loads both the worktree's `.eslintrc.js` and the parent's, and fails with `ESLint couldn't determine the plugin "react" uniquely` before reading a single source file. Verified by stashing this branch's changes and re-running: identical failure. Linting the same rules with the cascade pinned to the worktree (`eslint --no-eslintrc -c .eslintrc.js --resolve-plugins-relative-to .`) over every source directory gives **0 errors, 122 warnings** — under the 150 cap, exit 0. CI checks out the repo standalone and won't hit the cascade collision.

Closes #454

https://claude.ai/code/session_01Ko8njbHXNyeWBvTCQaiJV6
