### PR TITLE
List frames from frame_files instead of scanning the capture directory

### DIFF
--- a/storage/__mocks__/pg.js
+++ b/storage/__mocks__/pg.js
@@ -1,6 +1,32 @@
 const { EventEmitter } = require("events")
+const moment = require("moment")
 
-const queryFn = jest.fn(() => Promise.resolve({ rows: [], rowCount: 0 }))
+const frameFiles = [
+	"20210101-000000-00.jpg",
+	"20210101-030000-00.jpg",
+	"20210101-060000-00.jpg",
+	"20210101-090000-00.jpg",
+	"20210101-120000-00.jpg",
+	"20210101-150000-00.jpg",
+	"20210101-180000-00.jpg",
+	"20210101-210000-00.jpg",
+	"20210102-000000-00.jpg",
+]
+
+const framesInWindow = (camera, from, to) => String(camera) !== "1" ? [] : frameFiles.filter((name) => {
+	const at = moment.utc(name.slice(0, 15), "YYYYMMDD-HHmmss")
+	return !at.isBefore(moment.utc(from, "YYYY-MM-DD HH:mm:ss")) && at.isBefore(moment.utc(to, "YYYY-MM-DD HH:mm:ss").add(1, "second"))
+})
+
+const frameListRows = (sql, [camera, from, to, step, limit]) => {
+	const window = framesInWindow(camera, from, to)
+	const every = /COUNT\(\*\) OVER/.test(sql) ? Math.max(Math.ceil(window.length / Number(step)), 1) : Number(step)
+	return window.filter((name, index) => index % every === 0).slice(0, Number(limit)).map((name) => ({ name }))
+}
+
+const queryFn = jest.fn((sql, params) =>
+	Promise.resolve(/AS idx/.test(sql) ? { rows: frameListRows(sql, params) } : { rows: [], rowCount: 0 })
+)
 
 const mockedPool = {
 	query: queryFn,
@@ -11,5 +37,6 @@ const mockedPool = {
 
 module.exports = {
 	Pool: jest.fn(() => mockedPool),
-	mockedPool
+	mockedPool,
+	frameFiles
 }

--- a/storage/backend/routes/lib/converter.js
+++ b/storage/backend/routes/lib/converter.js
@@ -4,8 +4,24 @@ var moment     = require("moment")
 var dateFormat = require("./dateFormat.js")
 var {randomID, gatewayHost}    = require("lib")
 var memory     = require("memory")
+var {pool}     = require("../../lib/pool.js")
 
 const imgDir = path.join(process.env.storage_FOLDERPATH, "shared/captures")
+
+const FRAME_LIST_MAX = 250000
+
+const FRAME_WINDOW = "FROM frame_files WHERE camera = $1 AND timestamp >= ($2::timestamp AT TIME ZONE 'UTC') AND timestamp < (($3::timestamp AT TIME ZONE 'UTC') + INTERVAL '1 second')"
+
+const windowBound = (value) => moment.utc(value, dateFormat).format("YYYY-MM-DD HH:mm:ss")
+
+const positiveInt = (value) => Math.max(parseInt(value) || 1, 1)
+
+const frameNames = (query, params, callback) => pool.query(query, params)
+	.then(({rows}) => callback(rows.map(row => row.name)))
+	.catch((err) => {
+		console.log("STORAGE FRAME LIST ERROR", err.message)
+		callback([])
+	})
 
 module.exports = {
 	generateID: () => {
@@ -18,21 +34,19 @@ module.exports = {
 		return (event, ...args) => { if(process.env.memory_ON == "true" && client.connected) client.emit(event, ...args) }
 	},
     
-	filterList: (camera, start, end, skipEvery=1, callback) => {
-		fs.readdir(path.join(imgDir, camera), (err, files) => {
-			if(err){
-				callback([])
-			}
-			else{
-				let list = files.filter( file => file.includes(".jpg") && 
-					`${file.split("-")[0]}-${file.split("-")[1]}` >= start && 
-					`${file.split("-")[0]}-${file.split("-")[1]}` <= end )
-				callback(skipEvery == 1 ? list : list.filter( (file, index) => {
-					return (index % skipEvery === 0 )
-				}))
-			}
-		})
-	},
+	/** Every `skipEvery`-th frame of the window, oldest first, for the ffmpeg concat manifest and zip archives. */
+	filterList: (camera, start, end, skipEvery=1, callback) => frameNames(
+		`SELECT name FROM (SELECT name, row_number() OVER (ORDER BY timestamp ASC, name ASC) - 1 AS idx ${FRAME_WINDOW}) frames WHERE idx % $4 = 0 ORDER BY idx ASC LIMIT $5`,
+		[camera, windowBound(start), windowBound(end), positiveInt(skipEvery), FRAME_LIST_MAX],
+		callback
+	),
+
+	/** At most `limit` frames of the window, evenly spaced across it, oldest first. */
+	sampleList: (camera, start, end, limit, callback) => frameNames(
+		`SELECT name FROM (SELECT name, row_number() OVER (ORDER BY timestamp ASC, name ASC) - 1 AS idx, COUNT(*) OVER () AS total ${FRAME_WINDOW}) frames WHERE idx % GREATEST(CEIL(total::numeric / $4), 1) = 0 ORDER BY idx ASC LIMIT $5`,
+		[camera, windowBound(start), windowBound(end), positiveInt(limit), positiveInt(limit)],
+		callback
+	),
 
 	filterType: (type, callback) => {
 		fs.readdir(path.join(imgDir), (err, files) => {

--- a/storage/backend/routes/lib/video.js
+++ b/storage/backend/routes/lib/video.js
@@ -6,6 +6,7 @@ const cliProgress = require("cli-progress")
 const {
 	generateID,
 	filterList,
+	sampleList,
 	fileName,
 	memoryEmitter,
 }              = require("./converter.js")
@@ -20,16 +21,8 @@ const emitToMemory = memoryEmitter("VIDEO PROCESS")
 const imgDir = path.join(process.env.storage_FOLDERPATH, "shared/captures")
 
 const createFrameList = (camera, start, end, limit, callback) => {
-	filterList(camera, start, end, undefined, (filteredList) => {
-		const limitIteration = Math.ceil(filteredList.length/limit)
-
-		const limitedList = filteredList.filter((item, index) => {
-			return (index % limitIteration === 0)
-		}).map((item) => {
-			return `/shared/captures/${camera}/${item}`
-		})
-	
-		callback(limitedList)
+	sampleList(camera, start, end, limit, (sampledList) => {
+		callback(sampledList.map((item) => `/shared/captures/${camera}/${item}`))
 	})
 }
 

--- a/storage/test/convert.test.js
+++ b/storage/test/convert.test.js
@@ -1,21 +1,36 @@
 const supertest = require("supertest")
+
+jest.mock("lib")
+jest.mock("fs")
+jest.mock("memory")
+jest.mock("pm2")
+jest.mock("pg")
+jest.mock("cli-progress")
+jest.mock("fluent-ffmpeg", () => {
+	const { EventEmitter } = require("events")
+	const chainable = ["inputFormat", "outputFPS", "videoBitrate", "videoCodec", "toFormat", "mergeToFile", "outputOptions", "pipe"]
+	const factory = jest.fn(() => {
+		const command = new EventEmitter()
+		chainable.forEach((method) => { command[method] = jest.fn(() => command) })
+		command.kill = jest.fn()
+		return command
+	})
+	factory.setFfmpegPath = jest.fn()
+	factory.setFfprobePath = jest.fn()
+	return factory
+})
+
 const app = require("../backend/storage.js")
 
 const moment = require("moment")
 var {parseFileName, validateDays, validateRequest}    = require("../backend/routes/lib/converter.js")
 const dateFormat = require("../backend/routes/lib/dateFormat.js")
+const { frameFiles } = require("pg")
+
+const flush = async () => { for(let i = 0; i < 3; i++) await Promise.resolve() }
 
 const fileList = [
-	"20210101-000000-00.jpg",
-	"20210101-030000-00.jpg",
-	"20210101-060000-00.jpg",
-	"20210101-090000-00.jpg",
-	"20210101-120000-00.jpg",
-	"20210101-150000-00.jpg",
-	"20210101-180000-00.jpg",
-	"20210101-210000-00.jpg",
-	"20210102-000000-00.jpg",
-	"output_1_20210101-235959_20210201-235959_video1-20210301-235959.mp4", 
+	"output_1_20210101-235959_20210201-235959_video1-20210301-235959.mp4",
 	"output_1_20210101-235959_20210201-235959_video2-20210301-235959.mp4",
 	"output_1_20210101-235959_20210201-235959_video3-20210301-235959.mp4",
 	"mp4_1_video3-20210301-235959.txt",
@@ -33,26 +48,7 @@ const listOfProcesses = fileList.filter(file => file.includes(".mp4") || file.in
 	}
 }).filter(Boolean)
 
-const listOfImages = fileList.filter(file => file.includes(".jpg")).map(file => `/shared/captures/1/${file}`)
-
-jest.mock("lib")
-jest.mock("fs")
-jest.mock("memory")
-jest.mock("pm2")
-jest.mock("cli-progress")
-jest.mock("fluent-ffmpeg", () => {
-	const { EventEmitter } = require("events")
-	const chainable = ["inputFormat", "outputFPS", "videoBitrate", "videoCodec", "toFormat", "mergeToFile", "outputOptions", "pipe"]
-	const factory = jest.fn(() => {
-		const command = new EventEmitter()
-		chainable.forEach((method) => { command[method] = jest.fn(() => command) })
-		command.kill = jest.fn()
-		return command
-	})
-	factory.setFfmpegPath = jest.fn()
-	factory.setFfprobePath = jest.fn()
-	return factory
-})
+const listOfImages = frameFiles.map(file => `/shared/captures/1/${file}`)
 
 describe("Convert Routes", () => {
 	let cookieWithBearerToken = "validCookie"
@@ -532,20 +528,21 @@ describe("Convert Routes", () => {
 		beforeEach(() => { process.env.memory_ON = "true" })
 		afterEach(() => { memory.__client.connected = true })
 
-		const runVideo = () => {
+		const runVideo = async () => {
 			memory.__emitted.length = 0
 			const writeFileSpy = jest.spyOn(fs, "writeFile").mockImplementation((p, d, cb) => cb && cb())
 			const req = { body: { camera: "1", start: "20210101-000000", end: "20210102-000000" } }
 			const res = { send: jest.fn() }
 
 			createVideo(req, res)
+			await flush()
 
 			writeFileSpy.mockRestore()
 			return ffmpeg.mock.results[ffmpeg.mock.results.length - 1].value
 		}
 
-		const startVideo = () => {
-			const command = runVideo()
+		const startVideo = async () => {
+			const command = await runVideo()
 			const saved = memory.__emitted.find(e => e.event === "saveProcessEnder")
 			expect(saved).toBeDefined()
 			return { command, id: saved.args[0], ender: saved.args[1] }
@@ -553,20 +550,20 @@ describe("Convert Routes", () => {
 
 		const deletedIds = () => memory.__emitted.filter(e => e.event === "deleteProcessEnder").map(e => e.args[0])
 
-		test("deletes the ender when ffmpeg finishes", () => {
-			const { command, id } = startVideo()
+		test("deletes the ender when ffmpeg finishes", async () => {
+			const { command, id } = await startVideo()
 			command.emit("end")
 			expect(deletedIds()).toContain(id)
 		})
 
-		test("deletes the ender when ffmpeg errors", () => {
-			const { command, id } = startVideo()
+		test("deletes the ender when ffmpeg errors", async () => {
+			const { command, id } = await startVideo()
 			command.emit("error", new Error("ffmpeg exited with code 1"))
 			expect(deletedIds()).toContain(id)
 		})
 
-		test("alerts about storage cleanup when ffmpeg reports a missing concat input", () => {
-			const { command, id } = startVideo()
+		test("alerts about storage cleanup when ffmpeg reports a missing concat input", async () => {
+			const { command, id } = await startVideo()
 
 			lib.webhookAlert.mockClear()
 			command.emit("error", new Error("1/frame2.jpg: No such file or directory"))
@@ -576,8 +573,8 @@ describe("Convert Routes", () => {
 			)
 		})
 
-		test("alerts a generic failure for any other ffmpeg error", () => {
-			const { command, id } = startVideo()
+		test("alerts a generic failure for any other ffmpeg error", async () => {
+			const { command, id } = await startVideo()
 
 			lib.webhookAlert.mockClear()
 			command.emit("error", new Error("ffmpeg exited with code 1"))
@@ -587,17 +584,17 @@ describe("Convert Routes", () => {
 			)
 		})
 
-		test("releasing the ender does not kill ffmpeg, cancelling does", () => {
-			const { command, ender } = startVideo()
+		test("releasing the ender does not kill ffmpeg, cancelling does", async () => {
+			const { command, ender } = await startVideo()
 			ender(false)
 			expect(command.kill).not.toHaveBeenCalled()
 			ender(true)
 			expect(command.kill).toHaveBeenCalledTimes(1)
 		})
 
-		test("drops enders while disconnected instead of buffering them", () => {
+		test("drops enders while disconnected instead of buffering them", async () => {
 			memory.__client.connected = false
-			const command = runVideo()
+			const command = await runVideo()
 			command.emit("end")
 
 			memory.__client.connected = true
@@ -606,9 +603,9 @@ describe("Convert Routes", () => {
 			expect(events).not.toContain("deleteProcessEnder")
 		})
 
-		test("registers no ender while memory is off", () => {
+		test("registers no ender while memory is off", async () => {
 			process.env.memory_ON = "false"
-			runVideo().emit("end")
+			;(await runVideo()).emit("end")
 			const events = memory.__emitted.map(e => e.event)
 			expect(events).not.toContain("saveProcessEnder")
 			expect(events).not.toContain("deleteProcessEnder")
@@ -619,15 +616,62 @@ describe("Convert Routes", () => {
 		const fs = require("fs")
 		const { createVideo } = require("../backend/routes/lib/video.js")
 
-		test("returns {error:true} instead of throwing when the frame-list write fails", () => {
+		test("returns {error:true} instead of throwing when the frame-list write fails", async () => {
 			const writeFileSpy = jest.spyOn(fs, "writeFile").mockImplementation((p, d, cb) => cb(new Error("ENOSPC")))
 			const req = { body: { camera: "1", start: "20210101-000000", end: "20210102-000000" } }
 			const res = { send: jest.fn() }
 
 			expect(() => createVideo(req, res)).not.toThrow()
+			await flush()
 			expect(res.send).toHaveBeenCalledWith({ error: true })
 
 			writeFileSpy.mockRestore()
+		})
+	})
+
+	describe("frame listing comes from the database, not the capture directory", () => {
+		const fs = require("fs")
+		const { mockedPool } = require("pg")
+
+		test("a frame list is an indexed, window-bounded, limited query and never reads the camera directory", async () => {
+			fs.readdir.mockClear()
+			mockedPool.query.mockClear()
+
+			await supertest(app)
+				.post("/convert/listFramesVideo")
+				.send({ start: "20210101-000000", end: "20210102-000000", camera: 1, frames: 3 })
+				.set("Cookie", cookieWithBearerToken)
+				.expect(200)
+
+			const [sql, params] = mockedPool.query.mock.calls.find(([q]) => /AS idx/.test(q))
+			expect(sql).toMatch(/FROM frame_files WHERE camera = \$1 AND timestamp >= .+ AND timestamp < /)
+			expect(sql).toMatch(/ORDER BY idx ASC LIMIT \$5/)
+			expect(params.slice(0, 4)).toEqual(["1", "2021-01-01 00:00:00", "2021-01-02 00:00:00", 3])
+			expect(fs.readdir).not.toHaveBeenCalledWith(expect.stringContaining("captures/1"), expect.anything())
+		})
+
+		test("the concat manifest is ordered oldest first and skips every Nth frame in one query", async () => {
+			mockedPool.query.mockClear()
+
+			await new Promise((resolve) => {
+				const { createVideo } = require("../backend/routes/lib/video.js")
+				createVideo({ body: { camera: "1", start: "20210101-000000", end: "20210102-000000", skip: 4 } }, { send: resolve })
+			})
+
+			const [sql, params] = mockedPool.query.mock.calls.find(([q]) => /AS idx/.test(q))
+			expect(sql).toMatch(/ORDER BY timestamp ASC, name ASC/)
+			expect(sql).toMatch(/WHERE idx % \$4 = 0/)
+			expect(params[3]).toBe(4)
+		})
+
+		test("an unreadable database yields an empty list instead of a crash", async () => {
+			mockedPool.query.mockImplementationOnce(() => Promise.reject(new Error("connection terminated")))
+
+			await supertest(app)
+				.post("/convert/listFramesVideo")
+				.send({ start: "20210101-000000", end: "20210102-000000", camera: 1 })
+				.set("Cookie", cookieWithBearerToken)
+				.expect(200, { list: [] })
 		})
 	})
 })

--- a/storage/test/convertLockRefresh.test.js
+++ b/storage/test/convertLockRefresh.test.js
@@ -54,6 +54,9 @@ jest.mock("fluent-ffmpeg", () => {
 
 jest.mock("lib")
 jest.mock("memory")
+jest.mock("pg")
+
+const flush = async () => { for(let i = 0; i < 3; i++) await Promise.resolve() }
 
 const { createVideo } = require("../backend/routes/lib/video.js")
 const { createZip } = require("../backend/routes/lib/zip.js")
@@ -108,9 +111,10 @@ describe("convert lock refresh", () => {
 		})
 	})
 
-	test("a zip job with no progress events still gets its lock refreshed by the interval", () => {
+	test("a zip job with no progress events still gets its lock refreshed by the interval", async () => {
 		let sent
 		createZip({ body: { camera: "1", start: START, end: END } }, { send: (body) => { sent = body } })
+		await flush()
 
 		const lockPath = path.join(process.env.storage_FOLDERPATH, "shared/captures", exportLockName("zip", "1", sent.id))
 		expect(lockWrites()).toContain(lockPath)
@@ -121,12 +125,13 @@ describe("convert lock refresh", () => {
 		expect(mockFs.utimes).toHaveBeenCalledWith(lockPath, expect.any(Date), expect.any(Date), expect.any(Function))
 	})
 
-	test("a streaming zip (save:false) also gets its lock refreshed by the interval", () => {
+	test("a streaming zip (save:false) also gets its lock refreshed by the interval", async () => {
 		createZip({ body: { camera: "1", start: START, end: END, save: false } }, {
 			attachment: () => {},
 			on: () => {},
 			send: () => {}
 		})
+		await flush()
 
 		const lockPath = zipLockPath()
 		expect(lockPath).toBeDefined()
@@ -147,14 +152,16 @@ describe("convert lock refresh", () => {
 		})
 	})
 
-	test("zip no longer registers a progress handler for lock refresh", () => {
+	test("zip no longer registers a progress handler for lock refresh", async () => {
 		createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+		await flush()
 		expect(mockArchiveHandlers.progress).toBeUndefined()
 	})
 
-	test("the refreshed mtime is newer than the orphan-sweep threshold", () => {
+	test("the refreshed mtime is newer than the orphan-sweep threshold", async () => {
 		const ORPHAN_AGE_MS = 24 * 60 * 60 * 1000
 		createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+		await flush()
 
 		jest.advanceTimersByTime(EXPORT_LOCK_REFRESH_MS)
 
@@ -217,8 +224,9 @@ describe("convert lock refresh", () => {
 			})
 		})
 
-		test("stops refreshing the zip (save) lock once the output stream closes", () => {
+		test("stops refreshing the zip (save) lock once the output stream closes", async () => {
 			createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+			await flush()
 
 			mockOutputHandlers.close()
 			mockFs.utimes.mockClear()
@@ -228,8 +236,9 @@ describe("convert lock refresh", () => {
 			expect(mockFs.utimes).not.toHaveBeenCalled()
 		})
 
-		test("stops refreshing the zip (save) lock once the archive errors", () => {
+		test("stops refreshing the zip (save) lock once the archive errors", async () => {
 			createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+			await flush()
 
 			mockArchiveHandlers.error(new Error("archive error"))
 			mockFs.utimes.mockClear()
@@ -239,8 +248,9 @@ describe("convert lock refresh", () => {
 			expect(mockFs.utimes).not.toHaveBeenCalled()
 		})
 
-		test("stops refreshing the zip (save) lock once the export is cancelled", () => {
+		test("stops refreshing the zip (save) lock once the export is cancelled", async () => {
 			createZip({ body: { camera: "1", start: START, end: END } }, { send: () => {} })
+			await flush()
 
 			cancelEnder()
 			mockFs.utimes.mockClear()
@@ -250,7 +260,7 @@ describe("convert lock refresh", () => {
 			expect(mockFs.utimes).not.toHaveBeenCalled()
 		})
 
-		test("stops refreshing the streaming zip lock once the archive errors", () => {
+		test("stops refreshing the streaming zip lock once the archive errors", async () => {
 			let resHandlers = {}
 			createZip({ body: { camera: "1", start: START, end: END, save: false } }, {
 				attachment: () => {},
@@ -259,6 +269,7 @@ describe("convert lock refresh", () => {
 				headersSent: false,
 				status: () => ({ end: () => {} })
 			})
+			await flush()
 
 			mockArchiveHandlers.error(new Error("archive error"))
 			mockFs.utimes.mockClear()
@@ -268,13 +279,14 @@ describe("convert lock refresh", () => {
 			expect(mockFs.utimes).not.toHaveBeenCalled()
 		})
 
-		test("stops refreshing the streaming zip lock once the response closes", () => {
+		test("stops refreshing the streaming zip lock once the response closes", async () => {
 			let resHandlers = {}
 			createZip({ body: { camera: "1", start: START, end: END, save: false } }, {
 				attachment: () => {},
 				on: (event, cb) => { resHandlers[event] = cb },
 				send: () => {}
 			})
+			await flush()
 
 			resHandlers.close()
 			mockFs.utimes.mockClear()


### PR DESCRIPTION
`POST /convert/listFramesVideo` did a full `readdir` of a camera's capture directory and only then filtered by time window, so narrowing the range removed no work and `clampFrames` bounded the returned array rather than the scan. `ClipMakerMini` fires one of these per camera on every dashboard mount to fetch a single thumbnail, and `fs.readdir` runs on the 4-thread libuv pool, so concurrent calls also stalled the `/shared` static mount and the sweep jobs.

## What changed

`storage/backend/routes/lib/converter.js` now reads the frame list out of `frame_files` instead of the filesystem, via two entry points over one shared query helper on the request pool (`storage/backend/lib/pool.js`):

- `filterList(camera, start, end, skipEvery, callback)` — every `skipEvery`-th frame in the window, ordered oldest first.
- `sampleList(camera, start, end, limit, callback)` — at most `limit` frames, evenly spaced across the window.

Both are single indexed queries against `idx_frame_files_camera_timestamp`, fully parameterized (`$1`..`$5`), bounded by the time window and a `LIMIT`. Sampling and skipping happen in SQL via `row_number()`/`COUNT(*) OVER ()` inside a subquery, so only the rows actually wanted come back — `sampleList` reproduces the old `Math.ceil(total/limit)` stride exactly, and `filterList` reproduces the old `index % skipEvery === 0`. A query failure logs and yields `[]`, matching the old `readdir` error path.

## How each caller was handled

- `createFrameList` (`video.js`, behind `listOfFrames`) — switched to `sampleList`. The post-hoc `Math.ceil(length/limit)` stride is gone; the SQL does it. Result shape is unchanged (`/shared/captures/<camera>/<name>` strings).
- `createVideoList` (`video.js`) — still `filterList`, unchanged signature. It needs the full ordered window for the ffmpeg concat manifest, and `ORDER BY timestamp ASC, name ASC` now guarantees chronological order, which `readdir` never did.
- `createZipList` (`zip.js`) — still `filterList`, unchanged signature. `zip.js` needed no edit.
- `filterType`/`findFile` still use `readdir`; they enumerate export artifacts in the captures root, not a camera's frame directory, and are not part of this issue.

## Boundaries

`start`/`end` arrive from `validateDays`/`validateRequest` as `YYYYMMDD-HHmmss` UTC strings and were compared lexicographically against the filename prefix, inclusive on both ends. They are now converted to real timestamps and compared as `timestamp >= start AND timestamp < end + INTERVAL '1 second'`, which keeps the old inclusive-to-the-second semantics for sub-second frames landing in the `end` second.

## No fallback

There is deliberately **no filesystem fallback and no migration**. `frame_files` is assumed populated — `motion.conf.example`'s `on_picture_save` inserts every frame, `chimera/prepareDatabase.js` already creates the table and the `(camera, timestamp)` index, and the hourly `sweepOrphanFrames` in `storage/backend/routes/lib/file.js` backfills anything motion missed. A camera with no rows lists no frames.

## Tests

`storage/__mocks__/pg.js` now emulates the frame-listing query (window filter, stride, limit) and exports its `frameFiles` fixture, which `convert.test.js` uses to build its expectations. `convert.test.js` and `convertLockRefresh.test.js` mock `pg` and await the now-async frame listing where they previously relied on the synchronous `readdir` mock. Three new tests cover: the query being window-bounded, limited and never touching the camera directory; the concat manifest being ordered oldest-first with the skip applied in one query; and a database error yielding an empty list instead of a crash.

- `npx jest --selectProjects storage` — 9 suites, 191 tests, all passing
- `npm test` — 92 suites, 1053 tests, all passing across 9 projects
- `npm run lint:ci` — 0 errors, 122 warnings (limit 150)

Closes #452

https://claude.ai/code/session_01Ko8njbHXNyeWBvTCQaiJV6
