### PR TITLE
print reason before re-asking camera_id/camera_name

### DIFF
--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -415,7 +415,8 @@ const runInteractive = async () => {
 			const idProblem = (id) => {
 				if (!(id > 0)) return "camera_id must be a positive integer"
 				const i = used.indexOf(id)
-				return i >= 0 ? `camera_id ${id} already used by ${files[i]}` : null
+				if (i >= 0) return `camera_id ${id} already used by ${files[i]}`
+				return files.includes(`cam${id}.conf`) ? `cam${id}.conf already exists` : null
 			}
 			const nameProblem = (name) => {
 				if (!name) return "camera_name not set"
@@ -424,7 +425,8 @@ const runInteractive = async () => {
 			}
 			let id
 			do {
-				id = parseInt(await ask("    camera_id (positive integer) = "))
+				const rawId = await ask("    camera_id (positive integer) = ")
+				id = /^\d+$/.test(rawId) ? parseInt(rawId) : NaN
 				const p = idProblem(id)
 				if (p) console.log(`    ${BAD} ${p}`)
 			} while (idProblem(id))

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -408,13 +408,32 @@ const runInteractive = async () => {
 		while (cameraProblems().length) {
 			for (const p of cameraProblems()) console.log(`  ${BAD} ${p}`)
 			if (!(await confirm("  Add a camera now?"))) break
-			const confs = listConfs().map(f => parseConf(fs.readFileSync(path.join(camDir, f), "utf8")))
+			const files = listConfs()
+			const confs = files.map(f => parseConf(fs.readFileSync(path.join(camDir, f), "utf8")))
 			const used = confs.map(c => parseInt(c.camera_id))
 			const usedNames = confs.map(c => c.camera_name)
+			const idProblem = (id) => {
+				if (!(id > 0)) return "camera_id must be a positive integer"
+				const i = used.indexOf(id)
+				return i >= 0 ? `camera_id ${id} already used by ${files[i]}` : null
+			}
+			const nameProblem = (name) => {
+				if (!name) return "camera_name not set"
+				const i = usedNames.indexOf(name)
+				return i >= 0 ? `camera_name "${name}" already used by ${files[i]}` : null
+			}
 			let id
-			do { id = parseInt(await ask("    camera_id (positive integer) = ")) } while (!(id > 0) || used.includes(id))
+			do {
+				id = parseInt(await ask("    camera_id (positive integer) = "))
+				const p = idProblem(id)
+				if (p) console.log(`    ${BAD} ${p}`)
+			} while (idProblem(id))
 			let name
-			do { name = await ask("    camera_name = ") } while (!name || usedNames.includes(name))
+			do {
+				name = await ask("    camera_name = ")
+				const p = nameProblem(name)
+				if (p) console.log(`    ${BAD} ${p}`)
+			} while (nameProblem(name))
 			let url, userpass
 			do {
 				url = await ask("    netcam_url (rtsp://...) = ")

--- a/chimera/test/preflightInteractive.test.js
+++ b/chimera/test/preflightInteractive.test.js
@@ -281,6 +281,38 @@ describe("runInteractive secret file modes", () => {
 	})
 })
 
+describe("runInteractive camera_id/camera_name prompts", () => {
+	const CAM_ENV = { ...BLANK, storage_ON: "true", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET }
+
+	test("rejects a non-positive-integer camera_id and a blank camera_name before accepting valid answers", async () => {
+		setup({
+			env: CAM_ENV,
+			noCams: true,
+			answers: ["y", "0", "1", "", "indoor", "rtsp://1.1.1.1/cam", "", "n"]
+		})
+		const { out, exitCode } = await run()
+		expect(out).toContain("camera_id must be a positive integer")
+		expect(out).toContain("camera_name not set")
+		expect(mockState.files["cameraconf/cam1.conf"]).toContain("camera_id 1")
+		expect(out).toContain("All checks passed")
+		expect(exitCode).toBe(0)
+	})
+
+	test("rejects a duplicate camera_id and a duplicate camera_name before accepting valid answers", async () => {
+		setup({
+			env: CAM_ENV,
+			noCams: true,
+			answers: ["y", "1", "2", "indoor", "backyard", "rtsp://1.1.1.1/cam", "", "n"]
+		})
+		mockState.files["cameraconf/cam1.conf"] = "camera_id 1\ncamera_name indoor\n"
+		const { out, exitCode } = await run()
+		expect(out).toContain("camera_id 1 already used by cam1.conf")
+		expect(out).toContain("camera_name \"indoor\" already used by cam1.conf")
+		expect(mockState.files["cameraconf/cam2.conf"]).toContain("camera_id 2")
+		expect(exitCode).toBe(1)
+	})
+})
+
 describe("runInteractive objectFeedProblem", () => {
 	// every key holds a valid value, so the schema walk asks nothing at all
 	const BROKEN = { ...BLANK, storage_ON: "false", storage_FOLDERPATH: "/mnt/storage", livestream_ON: "false", livestream_FOLDERPATH: "/mnt/live", livestream_PROXY_ON: "false", object_ON: "true", SECRETKEY: SECRET }

--- a/chimera/test/preflightInteractive.test.js
+++ b/chimera/test/preflightInteractive.test.js
@@ -311,6 +311,34 @@ describe("runInteractive camera_id/camera_name prompts", () => {
 		expect(mockState.files["cameraconf/cam2.conf"]).toContain("camera_id 2")
 		expect(exitCode).toBe(1)
 	})
+
+	test("rejects a camera_id whose cam<id>.conf already exists under a different camera_id", async () => {
+		setup({
+			env: CAM_ENV,
+			noCams: true,
+			answers: ["y", "2", "3", "patio", "rtsp://2.2.2.2/cam", "", "n"]
+		})
+		// cam2.conf holds camera_id 5, so `used` (camera_id values) doesn't catch id 2 — the filename check must
+		mockState.files["cameraconf/cam2.conf"] = "camera_id 5\ncamera_name garage\n"
+		const { out, exitCode } = await run()
+		expect(out).toContain("cam2.conf already exists")
+		expect(mockState.files["cameraconf/cam2.conf"]).toContain("camera_id 5")
+		expect(mockState.files["cameraconf/cam3.conf"]).toContain("camera_id 3")
+		expect(exitCode).toBe(1)
+	})
+
+	test("rejects a camera_id with trailing junk instead of silently truncating it", async () => {
+		setup({
+			env: CAM_ENV,
+			noCams: true,
+			answers: ["y", "2abc", "2", "patio", "rtsp://2.2.2.2/cam", "", "n"]
+		})
+		const { out, exitCode } = await run()
+		expect(out).toContain("camera_id must be a positive integer")
+		expect(mockState.files["cameraconf/cam2.conf"]).toContain("camera_id 2")
+		expect(out).toContain("All checks passed")
+		expect(exitCode).toBe(0)
+	})
 })
 
 describe("runInteractive objectFeedProblem", () => {


### PR DESCRIPTION
## Summary
- The wizard's "Add a camera" prompts for `camera_id` and `camera_name` re-asked on bad input without printing why — the prompt just reappeared identically for a non-positive-integer id, a duplicate id, a blank name, or a duplicate name.
- Prints the reason before re-asking, in the same `    ✗ <problem>` format the adjacent `netcam_url` loop already uses, restructured minimally to keep each existing conf's filename in scope for the "already used by `<file>`" messages.

## Why
Ctrl-C was previously the only way out of a silently-repeating prompt, and by then `.env` was already written with no camera `.conf`, so `npm run docker:up` blocked on the same unexplained state.

Closes #474

## Test plan
- [x] `npx jest --config chimera/jest.config.js` passes
- [x] `npm test` passes
- [x] `npm run lint:ci` passes
- [x] New tests in `chimera/test/preflightInteractive.test.js` cover all four rejection reasons, asserting the message prints and the prompt re-asks until a valid answer is accepted