### PR TITLE
Add blockCrossSite to /authorization/setup

### DIFF
--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -75,7 +75,7 @@ app.get("/status", async (req, res) => {
 	}
 })
 
-app.post("/setup", validateBody, loginLimiter, async (req, res) => {
+app.post("/setup", blockCrossSite, validateBody, loginLimiter, async (req, res) => {
 	const { username, password, token } = req.body
 	if (!timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true, errors: "Setup token does not match setup_TOKEN in .env" })
 	if (typeof username !== "string") return res.status(400).json({ error: true })

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -184,6 +184,32 @@ describe("Authorization Routes", () => {
 			expect(errSpy).toHaveBeenCalled()
 			errSpy.mockRestore()
 		})
+
+		test("rejects a cross-site POST with 403", async () => {
+			process.env.setup_TOKEN = "boot-token"
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.set("Sec-Fetch-Site", "cross-site")
+				.send({ username: "admin", password: "correct-horse-battery", token: "boot-token" })
+			expect(res.status).toBe(403)
+			expect(res.body).toEqual({ error: "forbidden" })
+			expect(mockedPool.query).not.toHaveBeenCalledWith(expect.stringContaining("INSERT INTO auth"), expect.anything())
+		})
+
+		test("allows a same-origin POST", async () => {
+			process.env.setup_TOKEN = "boot-token"
+			mockedPool.query.mockResolvedValueOnce({}) // BEGIN
+			mockedPool.query.mockResolvedValueOnce({}) // pg_advisory_xact_lock
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 0 }) // no admin exists
+			mockedPool.query.mockResolvedValueOnce({ rows: [] }) // target is a new user
+			mockedPool.query.mockResolvedValueOnce({ rowCount: 1 }) // upsert
+			const res = await supertest(app)
+				.post("/authorization/setup")
+				.set("Sec-Fetch-Site", "same-origin")
+				.send({ username: "admin", password: "correct-horse-battery", token: "boot-token" })
+			expect(res.status).toBe(200)
+			expect(res.body).toEqual({ error: false })
+		})
 	})
 
 	describe("POST /authorization/login", () => {


### PR DESCRIPTION
Closes #485

`/authorization/setup` was the only state-changing route not running `blockCrossSite`. Cookie-authed routes get the check from `createAuthorize`; `/setup` carries no cookie, so nothing covered it.

Not exploitable today — `setup_TOKEN` already blocks a forged POST, and preflight forces the token to at least 32 characters. This is defense in depth and removes the one inconsistency.

Tests: cross-site POST returns 403 and never reaches the INSERT; same-origin POST still succeeds.