### PR TITLE
Warn when gateway_HTTPS_Redirect will loop

### DIFF
--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -227,7 +227,7 @@ const cookiePlainHttpProblem = (lines) =>
 	!isServiceOff(lines, "command_COOKIE_SECURE") && getVal(lines, "command_COOKIE_SECURE") === "true"
 		&& /^http:\/\//i.test(rawGatewayHost(lines)) && getVal(lines, "gateway_HTTPS_Redirect") !== "true" && getVal(lines, "certbot_ON") !== "true"
 		&& !LOOPBACK.includes(urlPart(rawGatewayHost(lines), "hostname") || rawGatewayHost(lines).replace(/^https?:\/\//i, ""))
-		? "command_COOKIE_SECURE MUST BE false — gateway_HOST carries an explicit http:// prefix and neither gateway_HTTPS_Redirect nor certbot_ON says this deploy is HTTPS, so browsers drop the Secure cookie on the plain-HTTP origin and the login form loops forever with no error; for an HTTPS deploy drop the http:// prefix (or write https://) and set gateway_HTTPS_Redirect or certbot_ON true, because command_COOKIE_SECURE=true only survives on a host browsers reach over HTTPS"
+		? "command_COOKIE_SECURE MUST BE false — gateway_HOST carries an explicit http:// prefix and neither gateway_HTTPS_Redirect nor certbot_ON says this deploy is HTTPS, so browsers drop the Secure cookie on the plain-HTTP origin and the login form loops forever with no error; for an HTTPS deploy write gateway_HOST as https:// — that alone clears this, because browsers only keep a Secure cookie on an https:// address. Do not set gateway_HTTPS_Redirect=true instead; it loops every page when something in front holds the cert"
 		: null
 
 const cookieAmbiguousHostWarning = (lines) =>
@@ -236,6 +236,12 @@ const cookieAmbiguousHostWarning = (lines) =>
 		&& getVal(lines, "gateway_HTTPS_Redirect") !== "true" && getVal(lines, "certbot_ON") !== "true"
 		&& !LOOPBACK.includes(urlPart(gatewayUrl(lines), "hostname") || rawGatewayHost(lines))
 		? "WARNING: gateway_HOST has no scheme, so it is read as https:// — if browsers actually reach this deploy over http://, command_COOKIE_SECURE=true never protects the cookie and login loops forever; give gateway_HOST an explicit http:// prefix if that is the case"
+		: null
+
+const httpsRedirectLoopWarning = (lines) =>
+	getVal(lines, "gateway_HTTPS_Redirect") === "true" && getVal(lines, "certbot_ON") !== "true"
+		&& !getVal(lines, "privateKey_FILEPATH") && !getVal(lines, "certificate_FILEPATH")
+		? "WARNING: gateway_HTTPS_Redirect=true, but no cert is configured here (certbot_ON is not true, both FILEPATH lines blank). Who serves https:// to your visitors?\n  this machine — fine, ignore this; your cert must be in /etc/letsencrypt/live/<gateway_HOST domain>/\n  Cloudflare, nginx or a tunnel — set gateway_HTTPS_Redirect=false, or every page redirects to itself forever (ERR_TOO_MANY_REDIRECTS)"
 		: null
 
 const certbotPortProblem = (lines) =>
@@ -533,4 +539,4 @@ if (require.main === module) {
 	else runInteractive()
 }
 
-module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem, motionDirProblem }
+module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem, motionDirProblem }

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -240,8 +240,8 @@ const cookieAmbiguousHostWarning = (lines) =>
 
 const httpsRedirectLoopWarning = (lines) =>
 	getVal(lines, "gateway_HTTPS_Redirect") === "true" && getVal(lines, "certbot_ON") !== "true"
-		&& !getVal(lines, "privateKey_FILEPATH") && !getVal(lines, "certificate_FILEPATH")
-		? "WARNING: gateway_HTTPS_Redirect=true, but no cert is configured here (certbot_ON is not true, both FILEPATH lines blank). Who serves https:// to your visitors?\n  this machine — fine, ignore this; your cert must be in /etc/letsencrypt/live/<gateway_HOST domain>/\n  Cloudflare, nginx or a tunnel — set gateway_HTTPS_Redirect=false, or every page redirects to itself forever (ERR_TOO_MANY_REDIRECTS)"
+		&& !(getVal(lines, "privateKey_FILEPATH") && getVal(lines, "certificate_FILEPATH"))
+		? "WARNING: gateway_HTTPS_Redirect=true, but no cert is configured here (certbot_ON is not true, and privateKey_FILEPATH/certificate_FILEPATH are not both set). Who serves https:// to your visitors?\n  this machine — fine, ignore this; your cert must be in /etc/letsencrypt/live/<gateway_HOST domain>/\n  Cloudflare, nginx or a tunnel — set gateway_HTTPS_Redirect=false, or every page redirects to itself forever (ERR_TOO_MANY_REDIRECTS)"
 		: null
 
 const certbotPortProblem = (lines) =>
@@ -322,6 +322,9 @@ const runCheck = () => {
 		cam.forEach(p => console.log(`                  - ${p}`))
 		if (cam.length) failed = true
 	}
+
+	const redirectLoop = httpsRedirectLoopWarning(lines)
+	if (redirectLoop) console.log(`\n${redirectLoop}`)
 
 	if (failed) {
 		console.log("\nBlocked. Run `npm run preflight` to fix interactively.")
@@ -456,6 +459,9 @@ const runInteractive = async () => {
 	probs.forEach(([k, p]) => console.log(`\n  ${k} ${BAD} ${p}`))
 	const envOk = !probs.length
 	console.log(`.env ${envOk ? OK : BAD}\n`)
+
+	const redirectLoop = httpsRedirectLoopWarning(lines)
+	if (redirectLoop) console.log(`${redirectLoop}\n`)
 
 	const needCams = camerasNeeded(lines)
 	let motionOk = true, camOk = true

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -227,7 +227,7 @@ const cookiePlainHttpProblem = (lines) =>
 	!isServiceOff(lines, "command_COOKIE_SECURE") && getVal(lines, "command_COOKIE_SECURE") === "true"
 		&& /^http:\/\//i.test(rawGatewayHost(lines)) && getVal(lines, "gateway_HTTPS_Redirect") !== "true" && getVal(lines, "certbot_ON") !== "true"
 		&& !LOOPBACK.includes(urlPart(rawGatewayHost(lines), "hostname") || rawGatewayHost(lines).replace(/^https?:\/\//i, ""))
-		? "command_COOKIE_SECURE MUST BE false — gateway_HOST carries an explicit http:// prefix and neither gateway_HTTPS_Redirect nor certbot_ON says this deploy is HTTPS, so browsers drop the Secure cookie on the plain-HTTP origin and the login form loops forever with no error; for an HTTPS deploy write gateway_HOST as https:// — that alone clears this, because browsers only keep a Secure cookie on an https:// address. Do not set gateway_HTTPS_Redirect=true instead; it loops every page when something in front holds the cert"
+		? "command_COOKIE_SECURE MUST BE false — gateway_HOST carries an explicit http:// prefix and neither gateway_HTTPS_Redirect nor certbot_ON says this deploy is HTTPS, so browsers drop the Secure cookie on the plain-HTTP origin and the login form loops forever with no error; for an HTTPS deploy write gateway_HOST as https:// — that alone clears this, because browsers only keep a Secure cookie on an https:// address"
 		: null
 
 const cookieAmbiguousHostWarning = (lines) =>
@@ -241,7 +241,7 @@ const cookieAmbiguousHostWarning = (lines) =>
 const httpsRedirectLoopWarning = (lines) =>
 	getVal(lines, "gateway_HTTPS_Redirect") === "true" && getVal(lines, "certbot_ON") !== "true"
 		&& !(getVal(lines, "privateKey_FILEPATH") && getVal(lines, "certificate_FILEPATH"))
-		? "WARNING: gateway_HTTPS_Redirect=true, but no cert is configured here (certbot_ON is not true, and privateKey_FILEPATH/certificate_FILEPATH are not both set). Who serves https:// to your visitors?\n  this machine — fine, ignore this; your cert must be in /etc/letsencrypt/live/<gateway_HOST domain>/\n  Cloudflare, nginx or a tunnel — set gateway_HTTPS_Redirect=false, or every page redirects to itself forever (ERR_TOO_MANY_REDIRECTS)"
+		? "WARNING: gateway_HTTPS_Redirect=true, but no cert is configured here (certbot_ON is not true, and privateKey_FILEPATH/certificate_FILEPATH are not both set). Who serves https:// to your visitors?\n  this machine — fine, ignore this; your cert must be in /etc/letsencrypt/live/<gateway_HOST domain>/\n  Cloudflare, nginx or a tunnel — it must send X-Forwarded-Proto (nginx needs proxy_set_header X-Forwarded-Proto $scheme); without it every page redirects to itself forever (ERR_TOO_MANY_REDIRECTS)"
 		: null
 
 const certbotPortProblem = (lines) =>

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -354,12 +354,16 @@ describe("httpsRedirectLoopWarning", () => {
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "true" }))).toBeNull()
 	})
 
-	test("a privateKey_FILEPATH rules it out — the operator supplied a certificate", () => {
-		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "" }))).toBeNull()
+	test("both FILEPATHs set rules it out — the operator supplied a matched certificate pair", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeNull()
 	})
 
-	test("a certificate_FILEPATH rules it out — the operator supplied a certificate", () => {
-		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeNull()
+	test("only privateKey_FILEPATH set still fires — certPaths.js requires both-or-neither and disables TLS entirely on a mismatched pair", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "" }))).toBeTruthy()
+	})
+
+	test("only certificate_FILEPATH set still fires — same both-or-neither gap", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeTruthy()
 	})
 
 	test("never fires while the redirect is off — nothing redirects, so nothing can loop", () => {

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -322,7 +322,7 @@ describe("cookieAmbiguousHostWarning", () => {
 		expect(cookieAmbiguousHostWarning(lines({ gateway_HOST: "example.com", command_COOKIE_SECURE: "true", certbot_ON: "true" }))).toBeNull()
 	})
 
-	test("gateway_HTTPS_Redirect=true rules it out — the flag declares an HTTPS deploy, not ambiguous", () => {
+	test("gateway_HTTPS_Redirect=true rules it out — reverse-proxy TLS termination, not ambiguous", () => {
 		expect(cookieAmbiguousHostWarning(lines({ gateway_HOST: "example.com", command_COOKIE_SECURE: "true", gateway_HTTPS_Redirect: "true" }))).toBeNull()
 	})
 

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -21,7 +21,7 @@ jest.mock("fs", () => {
 	}
 })
 
-const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, envProblems, hashTruncated, looseMode } = require("../preflight.js")
+const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, envProblems, hashTruncated, looseMode } = require("../preflight.js")
 
 describe("parseSchema", () => {
 	test("parses required keys", () => {
@@ -322,7 +322,7 @@ describe("cookieAmbiguousHostWarning", () => {
 		expect(cookieAmbiguousHostWarning(lines({ gateway_HOST: "example.com", command_COOKIE_SECURE: "true", certbot_ON: "true" }))).toBeNull()
 	})
 
-	test("gateway_HTTPS_Redirect=true rules it out — reverse-proxy TLS termination, not ambiguous", () => {
+	test("gateway_HTTPS_Redirect=true rules it out — the flag declares an HTTPS deploy, not ambiguous", () => {
 		expect(cookieAmbiguousHostWarning(lines({ gateway_HOST: "example.com", command_COOKIE_SECURE: "true", gateway_HTTPS_Redirect: "true" }))).toBeNull()
 	})
 
@@ -336,6 +336,36 @@ describe("cookieAmbiguousHostWarning", () => {
 
 	test("a blank gateway_HOST has nothing to be ambiguous about", () => {
 		expect(cookieAmbiguousHostWarning(lines({ gateway_HOST: "", command_COOKIE_SECURE: "true" }))).toBeNull()
+	})
+})
+
+describe("httpsRedirectLoopWarning", () => {
+	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
+
+	test("fires when the redirect is on and nothing here gives this machine a certificate", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", privateKey_FILEPATH: "", certificate_FILEPATH: "" }))).toMatch(/ERR_TOO_MANY_REDIRECTS/)
+	})
+
+	test("fires when those lines are missing from .env entirely, not merely blank", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true" }))).toBeTruthy()
+	})
+
+	test("certbot_ON=true rules it out — certbot gets this machine its own certificate", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "true" }))).toBeNull()
+	})
+
+	test("a privateKey_FILEPATH rules it out — the operator supplied a certificate", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "" }))).toBeNull()
+	})
+
+	test("a certificate_FILEPATH rules it out — the operator supplied a certificate", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeNull()
+	})
+
+	test("never fires while the redirect is off — nothing redirects, so nothing can loop", () => {
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "false" }))).toBeNull()
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "" }))).toBeNull()
+		expect(httpsRedirectLoopWarning(lines({}))).toBeNull()
 	})
 })
 

--- a/chimera/test/validateEnvVars.test.js
+++ b/chimera/test/validateEnvVars.test.js
@@ -326,6 +326,26 @@ describe("validateEnvVars certbot redirect warning", () => {
 	})
 })
 
+describe("validateEnvVars https-redirect loop warning", () => {
+	test("warns (non-fatal) when the redirect is on but this machine holds no certificate", () => {
+		const res = run({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", privateKey_FILEPATH: "", certificate_FILEPATH: "" })
+		expect(res.stdout).toContain("ERR_TOO_MANY_REDIRECTS")
+		expect(res.status).toBe(0)
+	})
+
+	test("no warning when certbot_ON=true issues the cert", () => {
+		const res = run({ gateway_HTTPS_Redirect: "true", certbot_ON: "true", gateway_PORT: "80" })
+		expect(res.stdout).not.toContain("ERR_TOO_MANY_REDIRECTS")
+		expect(res.status).toBe(0)
+	})
+
+	test("no warning when the operator supplies their own cert", () => {
+		const res = run({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "/certs/fullchain.pem" })
+		expect(res.stdout).not.toContain("ERR_TOO_MANY_REDIRECTS")
+		expect(res.status).toBe(0)
+	})
+})
+
 describe("validateEnvVars insecure-cookie warning", () => {
 	test("fails on an HTTPS-resolved public gateway_HOST with an insecure cookie", () => {
 		const res = run({ gateway_HOST: "example.com", command_COOKIE_SECURE: "false", gateway_HTTPS_Redirect: "false" })

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -1,7 +1,7 @@
 require("dotenv").config()
 const fs = require("fs")
 const path = require("path")
-const { parseSchema, isServiceOff, typeOf, isSecret, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, certbotPortProblem, duplicatePortProblems, hashTruncated } = require("./preflight.js")
+const { parseSchema, isServiceOff, typeOf, isSecret, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certbotPortProblem, duplicatePortProblems, hashTruncated } = require("./preflight.js")
 const { multiInstance, validInstances } = require("../lib/utils/multiInstance.js")
 const { validTrustedSources } = require("../lib/utils/trustedSources.js")
 const gatewayHost = require("../lib/utils/gatewayHost.js")
@@ -167,6 +167,11 @@ duplicatePorts.forEach(([k, p]) => {
 
 if (process.env.certbot_ON === "true" && process.env.gateway_HTTPS_Redirect !== "true") {
 	console.log("WARNING: certbot_ON=true but gateway_HTTPS_Redirect is not true — port 80 stays open for HTTP-01 and keeps serving the whole app, so the login form and password cross the network in cleartext and the browser then drops the Secure session cookie, silently failing the login")
+}
+
+const redirectLoop = httpsRedirectLoopWarning(envLines)
+if (redirectLoop) {
+	console.log(redirectLoop)
 }
 
 const LOOPBACK = ["localhost", "127.0.0.1", "::1", "[::1]"]

--- a/env.example
+++ b/env.example
@@ -31,7 +31,7 @@ certbot_ON = (true | false) Auto-issue and renew Let's Encrypt certs. Needs gate
 # TLS certs auto-resolve to /etc/letsencrypt/live/<gateway_HOST domain>/{privkey,fullchain}.pem
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
-gateway_HTTPS_Redirect = (true | false) Redirect HTTP to HTTPS. Set true when certbot_ON=true, or port 80 keeps serving the login form in cleartext. ***
+gateway_HTTPS_Redirect = (true | false) Sends http:// visitors to https://. true only if this machine holds the HTTPS cert (certbot_ON=true, or the two FILEPATH lines above). If Cloudflare, nginx or a tunnel holds the cert, use false — they forward plain http here, so true loops every page until the browser errors. ***
 
 ##################################################################
 # Command

--- a/env.example
+++ b/env.example
@@ -31,7 +31,7 @@ certbot_ON = (true | false) Auto-issue and renew Let's Encrypt certs. Needs gate
 # TLS certs auto-resolve to /etc/letsencrypt/live/<gateway_HOST domain>/{privkey,fullchain}.pem
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
-gateway_HTTPS_Redirect = (true | false) Sends http:// visitors to https://. true only if this machine holds the HTTPS cert (certbot_ON=true, or the two FILEPATH lines above). If Cloudflare, nginx or a tunnel holds the cert, use false — they forward plain http here, so true loops every page until the browser errors. ***
+gateway_HTTPS_Redirect = (true | false) Sends http:// visitors to https://. Behind a proxy it needs X-Forwarded-Proto — Cloudflare and cloudflared send it, nginx needs proxy_set_header X-Forwarded-Proto $scheme — or every page redirects to itself. ***
 
 ##################################################################
 # Command

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -7,6 +7,7 @@ var {
 const { helmetOptions } = require("lib")
 
 var app = express()
+app.set("trust proxy", 1)
 
 app.use("/.well-known/", express.static(path.join(__dirname, "../.well-known/"), {
 	dotfiles: "allow"

--- a/gateway/test/httpsRedirect.test.js
+++ b/gateway/test/httpsRedirect.test.js
@@ -1,0 +1,39 @@
+const supertest = require("supertest")
+
+process.env.gateway_HTTPS_Redirect = "true"
+const gateway = require("../gateway.js")
+
+jest.mock("memory")
+jest.mock("axios")
+
+describe("gateway_HTTPS_Redirect", () => {
+	test("redirects a plain request with no X-Forwarded-Proto", (done) => {
+		supertest(gateway)
+			.get("/command/health")
+			.expect(302)
+			.expect("location", /^https:\/\//, done)
+	})
+
+	test("X-Forwarded-Proto: https passes through — the proxy already served TLS", (done) => {
+		supertest(gateway)
+			.get("/command/health")
+			.set("X-Forwarded-Proto", "https")
+			.expect(504, done)
+	})
+
+	test("X-Forwarded-Proto: http still redirects", (done) => {
+		supertest(gateway)
+			.get("/command/health")
+			.set("X-Forwarded-Proto", "http")
+			.expect(302, done)
+	})
+
+	test("/.well-known/ is exempt so certbot HTTP-01 can reach it", (done) => {
+		supertest(gateway)
+			.get("/.well-known/acme-challenge/token")
+			.expect((res) => {
+				if (res.status === 302) throw new Error("redirected the ACME challenge")
+			})
+			.end(done)
+	})
+})


### PR DESCRIPTION
gateway_HTTPS_Redirect=true loops every page when something in front serves HTTPS instead of the gateway. Nothing warned.