### PR TITLE
Fix audit CI: bump pm2's js-yaml to patched 4.3.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10991,9 +10991,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -12790,7 +12790,7 @@
         "debug": "4.4.3",
         "eventemitter2": "6.4.9",
         "fast-json-patch": "3.1.1",
-        "js-yaml": "4.3.0",
+        "js-yaml": "^4.3.1",
         "pidusage": "4.0.1",
         "pm2-deploy": "1.0.2",
         "proxy-agent": "6.5.0",
@@ -22941,9 +22941,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -24169,7 +24169,7 @@
         "debug": "4.4.3",
         "eventemitter2": "6.4.9",
         "fast-json-patch": "3.1.1",
-        "js-yaml": "4.3.0",
+        "js-yaml": "^4.3.1",
         "pidusage": "4.0.1",
         "pm2-deploy": "1.0.2",
         "proxy-agent": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "node": ">=22.12.0"
   },
   "overrides": {
-    "adm-zip": "^0.6.0"
+    "adm-zip": "^0.6.0",
+    "pm2": {
+      "js-yaml": "^4.3.1"
+    }
   },
   "workspaces": [
     "command",


### PR DESCRIPTION
The `audit` job fails on `npm audit --omit=dev --audit-level=high`.

pm2 7.x pins `js-yaml` to exactly `4.3.0`, which is in the vulnerable range for [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (high, quadratic CPU consumption in `!!omap` resolution). It is the only high-severity finding, and the job gates at `--audit-level=high`.

## Fix

Scoped override bumping pm2's js-yaml to the patched `4.3.1`:

```json
"overrides": {
  "adm-zip": "^0.6.0",
  "pm2": { "js-yaml": "^4.3.1" }
}
```

Two alternatives were rejected:

- **`npm audit fix --force`** resolves this by downgrading pm2 `7.0.3` -> `5.3.1`, two majors back.
- **A global `js-yaml` override** drags `@istanbuljs/load-nyc-config` off js-yaml 3.x onto v4, which removed `safeLoad`. Scoping to pm2 leaves that consumer on `3.15.1`.

`npm-shrinkwrap.json` was edited surgically rather than regenerated. A full `npm install --package-lock-only` produced 146 lines of unrelated churn: `dev`/`peer` flag reshuffling plus dropping two optional `@emnapi/*` entries. The emnapi entries are wasm32 fallbacks that never install on CI or in production, but the dev/peer flag changes could shift what `npm ci --omit=dev` installs in production, which shouldn't ride along on a security patch. The diff here is 16 lines.

## Verification

- `npm audit --omit=dev --audit-level=high` exits 0
- `npm ci` installs clean, confirming the integrity hash; pm2 loads and js-yaml resolves `4.3.1`
- `@istanbuljs/load-nyc-config` still resolves `js-yaml@3.15.1`
- lint: 0 errors; tests: 1202/1202 pass

## Out of scope

react-router has two moderate advisories, including an open redirect via backslash in `<Link>`/`useNavigate` ([GHSA-wrjc-x8rr-h8h6](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6)). These do not trip the `high` gate. The entire 6.x line is affected, so `command` would need `react-router-dom` `^6.26.2` -> `7.x`, a breaking major bump that warrants its own PR.