### PR TITLE
Send the HTTPS redirect to gateway_PORT_SECURE on the configured host

### DIFF
--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -249,6 +249,19 @@ const httpsRedirectLoopWarning = (lines) =>
 		? "WARNING: gateway_HTTPS_Redirect=true, but nothing serves https:// here and gateway_TRUST_PROXY is not true, so every page redirects to itself (ERR_TOO_MANY_REDIRECTS). Who holds the certificate?\n  this machine — set certbot_ON=true, or give privateKey_FILEPATH and certificate_FILEPATH absolute paths to your cert pair\n  a proxy or tunnel — set gateway_TRUST_PROXY=true and make it send X-Forwarded-Proto (nginx: proxy_set_header X-Forwarded-Proto $scheme)"
 		: null
 
+const GATEWAY_PORT_SECURE_DEFAULT = "443"
+
+const httpsRedirectPortWarning = (lines) => {
+	if (getVal(lines, "gateway_HTTPS_Redirect") !== "true") return null
+	const url = gatewayUrl(lines)
+	if (urlPart(url, "protocol") !== "https:") return null
+	const hostPort = urlPart(url, "port") || GATEWAY_PORT_SECURE_DEFAULT
+	const securePort = getVal(lines, "gateway_PORT_SECURE") || GATEWAY_PORT_SECURE_DEFAULT
+	return hostPort === securePort
+		? null
+		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${securePort} (gateway_PORT_SECURE), but gateway_HOST says browsers reach this deploy on port ${hostPort}, so the redirect lands where nothing terminates TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
+}
+
 const certbotPortProblem = (lines) =>
 	getVal(lines, "certbot_ON") === "true" && getVal(lines, "gateway_PORT") !== "80"
 		? "gateway_PORT MUST BE 80 when certbot_ON=true — Let's Encrypt validates over HTTP-01 on port 80, and compose publishes no port but gateway_PORT, so nothing answers the challenge. Set gateway_PORT=80, or set certbot_ON=false and supply your own certs via privateKey_FILEPATH/certificate_FILEPATH"
@@ -257,8 +270,6 @@ const certbotPortProblem = (lines) =>
 const setupTokenHint = (lines) => on(lines, "command")
 	? `The first admin account needs setup_TOKEN — read it with \`grep setup_TOKEN ${path.relative(ROOT, ENV)}\`.\n`
 	: null
-
-const GATEWAY_PORT_SECURE_DEFAULT = "443"
 
 const duplicatePortProblems = (lines) => {
 	const keys = ["gateway_PORT", "gateway_PORT_SECURE", ...SERVICE_PREFIXES.map(s => `${s}_PORT`)]
@@ -328,8 +339,9 @@ const runCheck = () => {
 		if (cam.length) failed = true
 	}
 
-	const redirectLoop = httpsRedirectLoopWarning(lines)
-	if (redirectLoop) console.log(`\n${redirectLoop}`)
+	for (const w of [httpsRedirectLoopWarning(lines), httpsRedirectPortWarning(lines)]) {
+		if (w) console.log(`\n${w}`)
+	}
 
 	if (failed) {
 		console.log("\nBlocked. Run `npm run preflight` to fix interactively.")
@@ -465,8 +477,9 @@ const runInteractive = async () => {
 	const envOk = !probs.length
 	console.log(`.env ${envOk ? OK : BAD}\n`)
 
-	const redirectLoop = httpsRedirectLoopWarning(lines)
-	if (redirectLoop) console.log(`${redirectLoop}\n`)
+	for (const w of [httpsRedirectLoopWarning(lines), httpsRedirectPortWarning(lines)]) {
+		if (w) console.log(`${w}\n`)
+	}
 
 	const needCams = camerasNeeded(lines)
 	let motionOk = true, camOk = true
@@ -550,4 +563,4 @@ if (require.main === module) {
 	else runInteractive()
 }
 
-module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem, motionDirProblem }
+module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem, motionDirProblem }

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -253,6 +253,7 @@ const GATEWAY_PORT_SECURE_DEFAULT = "443"
 
 const httpsRedirectPortWarning = (lines) => {
 	if (getVal(lines, "gateway_HTTPS_Redirect") !== "true") return null
+	if (getVal(lines, "gateway_TRUST_PROXY") === "true") return null
 	const url = gatewayUrl(lines)
 	if (urlPart(url, "protocol") !== "https:") return null
 	const hostPort = urlPart(url, "port") || GATEWAY_PORT_SECURE_DEFAULT

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -117,6 +117,7 @@ const varProblem = (v, val) => {
 	if (v.key === "chimeraInstances" && !validInstances(val)) return `must be "max", -1, or an integer >= 0 (got "${val}")`
 	if (v.key === "scheduler_TRUSTED_SOURCES" && !validTrustedSources(val)) return `must be comma-separated IPs/CIDRs or proxy-addr names like "loopback" (got "${val}")`
 	if (v.key === "storage_HOST" && !/^https?:\/\//i.test(val)) return `must start with http:// or https:// (got "${val}")`
+	if (v.key === "gateway_HOST" && !urlPart(normalizeHost(val), "hostname")) return `must be a valid URL (got "${val}")`
 	if (v.key === "object_ALERT_ON" && !["true", "text", "false"].includes(val)) return `must be true, text, or false (got "${val}")`
 	if (isSecret(v.key) && val.length < 32) return `must be at least 32 characters (got ${val.length})`
 	const t = typeOf(v.key, v.placeholder)
@@ -260,7 +261,7 @@ const httpsRedirectPortWarning = (lines) => {
 	const securePort = getVal(lines, "gateway_PORT_SECURE") || GATEWAY_PORT_SECURE_DEFAULT
 	return hostPort === securePort
 		? null
-		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${securePort} (gateway_PORT_SECURE), but gateway_HOST says browsers reach this deploy on port ${hostPort}, so the redirect lands where nothing terminates TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
+		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${hostPort} (gateway_HOST), but this deploy terminates TLS on port ${securePort} (gateway_PORT_SECURE), so the redirect lands where nothing terminates TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
 }
 
 const certbotPortProblem = (lines) =>

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -22,7 +22,7 @@ jest.mock("fs", () => {
 })
 
 const fs = require("fs")
-const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, envProblems, hashTruncated, looseMode } = require("../preflight.js")
+const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, envProblems, hashTruncated, looseMode } = require("../preflight.js")
 
 describe("parseSchema", () => {
 	test("parses required keys", () => {
@@ -403,6 +403,48 @@ describe("httpsRedirectLoopWarning", () => {
 		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }) })
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toBeTruthy()
 		statSpy.mockRestore()
+	})
+})
+
+describe("httpsRedirectPortWarning", () => {
+	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
+
+	test("fires when the TLS listener is on a port gateway_HOST does not name — the redirect lands where nothing serves TLS", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50" }))).toMatch(/ERR_SSL_PROTOCOL_ERROR/)
+	})
+
+	test("fires when gateway_HOST names a port the TLS listener does not use", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "443", gateway_HOST: "https://192.168.1.50:8443" }))).toBeTruthy()
+	})
+
+	test("matching ports pass", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50:8443" }))).toBeNull()
+	})
+
+	test("a bare gateway_HOST reads as https on 443, so a blank gateway_PORT_SECURE matches it", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "80", gateway_HOST: "cam.example.com" }))).toBeNull()
+	})
+
+	test("an explicit :443 in gateway_HOST is the same 443 the default names", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_HOST: "https://cam.example.com:443" }))).toBeNull()
+	})
+
+	test("a blank gateway_PORT_SECURE still fires against a non-443 gateway_HOST — the listener falls back to 443", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_HOST: "https://cam.example.com:8443" }))).toBeTruthy()
+	})
+
+	test("never fires while the redirect is off — nothing redirects, so nothing can miss the listener", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "false", gateway_PORT_SECURE: "8443", gateway_HOST: "https://cam.example.com" }))).toBeNull()
+		expect(httpsRedirectPortWarning(lines({ gateway_PORT_SECURE: "8443", gateway_HOST: "https://cam.example.com" }))).toBeNull()
+	})
+
+	test("an explicit http:// gateway_HOST names the plain port, not the TLS one, so it says nothing", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "http://192.168.1.50:8080" }))).toBeNull()
+	})
+
+	test("a blank or unparseable gateway_HOST names no port to disagree with", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "" }))).toBeNull()
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "not a valid host" }))).toBeNull()
 	})
 })
 

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -446,6 +446,10 @@ describe("httpsRedirectPortWarning", () => {
 		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "" }))).toBeNull()
 		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "not a valid host" }))).toBeNull()
 	})
+
+	test("gateway_TRUST_PROXY=true rules it out — the container's TLS port and the browser-facing port are meant to differ behind a proxy", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_TRUST_PROXY: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "https://cam.example.com" }))).toBeNull()
+	})
 })
 
 describe("certbotPortProblem", () => {

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -84,6 +84,7 @@ describe("varProblem", () => {
 	const optVar = { key: "alert_TZ", placeholder: "IANA tz ***", optional: true }
 	const instancesVar = { key: "chimeraInstances", placeholder: "Number of instances", optional: false }
 	const storageHostVar = { key: "storage_HOST", placeholder: "https://storage.server.example or http://127.0.0.1:8081", optional: false }
+	const gatewayHostVar = { key: "gateway_HOST", placeholder: "https://gateway.server.example or http://127.0.0.1:8080 (protocol defaults to https:// if omitted)", optional: false }
 	const alertOnVar = { key: "object_ALERT_ON", placeholder: "(true | text | false, default true)", optional: true }
 	const tokenVar = { key: "setup_TOKEN", placeholder: "required token gating /authorization/setup", optional: false }
 	const schedulerAuthVar = { key: "scheduler_AUTH", placeholder: "Authorization token for scheduler server", optional: false }
@@ -158,6 +159,17 @@ describe("varProblem", () => {
 	test("storage_HOST: explicit protocol → null", () => {
 		expect(varProblem(storageHostVar, "http://127.0.0.1:8081")).toBeNull()
 		expect(varProblem(storageHostVar, "https://storage.server.example")).toBeNull()
+	})
+
+	test("gateway_HOST: unparseable → error, matching the boot gate instead of writing it to .env", () => {
+		expect(varProblem(gatewayHostVar, "not a valid host")).toBeTruthy()
+		expect(varProblem(gatewayHostVar, "https://cam.example.com:notaport")).toBeTruthy()
+	})
+
+	test("gateway_HOST: parseable with or without a scheme → null", () => {
+		expect(varProblem(gatewayHostVar, "cam.example.com")).toBeNull()
+		expect(varProblem(gatewayHostVar, "https://cam.example.com:8443")).toBeNull()
+		expect(varProblem(gatewayHostVar, "http://127.0.0.1:8080")).toBeNull()
 	})
 
 	test("setup_TOKEN: under 32 characters → error, so preflight blocks what validateEnvVars would crash-loop on", () => {
@@ -410,11 +422,16 @@ describe("httpsRedirectPortWarning", () => {
 	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
 
 	test("fires when the TLS listener is on a port gateway_HOST does not name — the redirect lands where nothing serves TLS", () => {
-		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50" }))).toMatch(/ERR_SSL_PROTOCOL_ERROR/)
+		const w = httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50" }))
+		expect(w).toMatch(/ERR_SSL_PROTOCOL_ERROR/)
+		expect(w).toMatch(/visitors to port 443 \(gateway_HOST\)/)
+		expect(w).toMatch(/terminates TLS on port 8443 \(gateway_PORT_SECURE\)/)
 	})
 
 	test("fires when gateway_HOST names a port the TLS listener does not use", () => {
-		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "443", gateway_HOST: "https://192.168.1.50:8443" }))).toBeTruthy()
+		const w = httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "443", gateway_HOST: "https://192.168.1.50:8443" }))
+		expect(w).toMatch(/visitors to port 8443 \(gateway_HOST\)/)
+		expect(w).toMatch(/terminates TLS on port 443 \(gateway_PORT_SECURE\)/)
 	})
 
 	test("matching ports pass", () => {

--- a/chimera/test/preflightInteractive.test.js
+++ b/chimera/test/preflightInteractive.test.js
@@ -662,7 +662,7 @@ describe("runCheck", () => {
 
 	test("prints the https redirect port warning without blocking", () => {
 		setup({
-			env: { ...BLANK, storage_ON: "false", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET, gateway_HTTPS_Redirect: "true", gateway_TRUST_PROXY: "true", gateway_HOST: "https://cam.example.com", command_COOKIE_SECURE: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443" },
+			env: { ...BLANK, storage_ON: "false", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET, gateway_HTTPS_Redirect: "true", gateway_HOST: "https://cam.example.com", command_COOKIE_SECURE: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443" },
 			answers: []
 		})
 		mockState.modes[".env"] = 0o640

--- a/chimera/test/preflightInteractive.test.js
+++ b/chimera/test/preflightInteractive.test.js
@@ -659,4 +659,16 @@ describe("runCheck", () => {
 		expect(out).toContain("All checks passed")
 		expect(exitCode).toBe(0)
 	})
+
+	test("prints the https redirect port warning without blocking", () => {
+		setup({
+			env: { ...BLANK, storage_ON: "false", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET, gateway_HTTPS_Redirect: "true", gateway_TRUST_PROXY: "true", gateway_HOST: "https://cam.example.com", command_COOKIE_SECURE: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443" },
+			answers: []
+		})
+		mockState.modes[".env"] = 0o640
+		const { out, exitCode } = runCheckOnce()
+		expect(out).toContain("ERR_SSL_PROTOCOL_ERROR")
+		expect(out).toContain("All checks passed")
+		expect(exitCode).toBe(0)
+	})
 })

--- a/chimera/test/validateEnvVars.test.js
+++ b/chimera/test/validateEnvVars.test.js
@@ -401,10 +401,10 @@ describe("validateEnvVars insecure-cookie warning", () => {
 		expect(res.status).toBe(1)
 	})
 
-	test("warns on a malformed gateway_HOST instead of silently skipping the check", () => {
+	test("a malformed gateway_HOST blocks boot before the cookie check ever runs", () => {
 		const res = run({ gateway_HOST: "not a valid host", command_COOKIE_SECURE: "false", gateway_HTTPS_Redirect: "false" })
-		expect(res.stdout).toContain("WARNING: auth cookie may be sent over plaintext HTTP")
-		expect(res.status).toBe(0)
+		expect(res.stdout).toContain("gateway_HOST MUST BE A VALID URL")
+		expect(res.status).toBe(1)
 	})
 
 	test("no warning on a public gateway_HOST when the command service is off", () => {
@@ -542,6 +542,28 @@ describe("validateEnvVars storage_HOST protocol gate", () => {
 
 	test("quiet when storage is off and nothing dials storage_HOST", () => {
 		const res = run({ storage_ON: "false", storage_PROXY_ON: "false", schedule_ON: "false", schedule_PROXY_ON: "false", scheduler_AUTH: "", storage_HOST: "127.0.0.1:8081" })
+		expect(res.stdout).not.toContain(MESSAGE)
+		expect(res.status).toBe(0)
+	})
+})
+
+describe("validateEnvVars gateway_HOST URL gate", () => {
+	const MESSAGE = "gateway_HOST MUST BE A VALID URL"
+
+	test("blocks boot when gateway_HOST does not parse as a URL", () => {
+		const res = run({ gateway_HOST: "not a valid host" })
+		expect(res.stdout).toContain(MESSAGE)
+		expect(res.status).toBe(1)
+	})
+
+	test("accepts a loopback gateway_HOST", () => {
+		const res = run({ gateway_HOST: "http://127.0.0.1:8080" })
+		expect(res.stdout).not.toContain(MESSAGE)
+		expect(res.status).toBe(0)
+	})
+
+	test.each(["cam.example.com", "https://cam.example.com"])("accepts %s", (val) => {
+		const res = run({ gateway_HOST: val, command_COOKIE_SECURE: "true" })
 		expect(res.stdout).not.toContain(MESSAGE)
 		expect(res.status).toBe(0)
 	})

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -1,7 +1,7 @@
 require("dotenv").config()
 const fs = require("fs")
 const path = require("path")
-const { parseSchema, isServiceOff, typeOf, isSecret, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certbotPortProblem, duplicatePortProblems, hashTruncated } = require("./preflight.js")
+const { parseSchema, isServiceOff, typeOf, isSecret, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, hashTruncated } = require("./preflight.js")
 const { multiInstance, validInstances } = require("../lib/utils/multiInstance.js")
 const { validTrustedSources } = require("../lib/utils/trustedSources.js")
 const gatewayHost = require("../lib/utils/gatewayHost.js")
@@ -30,6 +30,15 @@ const rawStorageHost = (process.env.storage_HOST || "").trim()
 if (!isServiceOff(envLines, "storage_HOST") && rawStorageHost !== "" && !/^https?:\/\//i.test(rawStorageHost)) {
 	console.log("storage_HOST MUST START WITH http:// OR https:// — storage serves plain HTTP, so an implied https:// fails the TLS handshake")
 	allEnvPresent = false
+}
+
+const rawGatewayHost = (process.env.gateway_HOST || "").trim()
+if (!isServiceOff(envLines, "gateway_HOST") && rawGatewayHost !== "") {
+	try { new URL(gatewayHost()) }
+	catch {
+		console.log("gateway_HOST MUST BE A VALID URL — an unparseable value falls back to req.hostname, and with gateway_TRUST_PROXY=true that resolves from the client-supplied X-Forwarded-Host, letting a forged Host header pick the HTTPS redirect target")
+		allEnvPresent = false
+	}
 }
 
 const objectFeed = objectFeedProblem(envLines)
@@ -172,6 +181,11 @@ if (process.env.certbot_ON === "true" && process.env.gateway_HTTPS_Redirect !== 
 const redirectLoop = httpsRedirectLoopWarning(envLines)
 if (redirectLoop) {
 	console.log(redirectLoop)
+}
+
+const redirectPort = httpsRedirectPortWarning(envLines)
+if (redirectPort) {
+	console.log(redirectPort)
 }
 
 const LOOPBACK = ["localhost", "127.0.0.1", "::1", "[::1]"]

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -4,7 +4,7 @@ const helmet = require("helmet")
 var {
 	createProxyMiddleware
 }              = require("http-proxy-middleware")
-const { helmetOptions } = require("lib")
+const { helmetOptions, gatewayHost } = require("lib")
 
 var app = express()
 if(process.env.gateway_TRUST_PROXY == "true"){
@@ -18,12 +18,22 @@ app.use("/.well-known/", express.static(path.join(__dirname, "../.well-known/"),
 app.use(helmet(helmetOptions))
 
 if(process.env.gateway_HTTPS_Redirect == "true"){
+	const securePort = process.env.gateway_PORT_SECURE || 443
+	const portSuffix = securePort == 443 ? "" : `:${securePort}`
+	const redirectHost = (() => {
+		try{
+			return new URL(gatewayHost()).hostname
+		}
+		catch{
+			return ""
+		}
+	})()
 	app.use((req, res, next) => {
 		if(req.secure || req.path.split("/")[1] == ".well-known"){
 			next()
 		}
 		else{
-			res.redirect(`https://${req.headers.host}${req.url}`)
+			res.redirect(`https://${redirectHost || req.hostname}${portSuffix}${req.url}`)
 		}
 	})
 }

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -20,9 +20,10 @@ app.use(helmet(helmetOptions))
 if(process.env.gateway_HTTPS_Redirect == "true"){
 	const securePort = process.env.gateway_PORT_SECURE || 443
 	const portSuffix = securePort == 443 ? "" : `:${securePort}`
-	const redirectHost = (() => {
+	const redirectTarget = (() => {
 		try{
-			return new URL(gatewayHost()).hostname
+			const url = new URL(gatewayHost())
+			return url.protocol == "https:" ? url.host : `${url.hostname}${portSuffix}`
 		}
 		catch{
 			return ""
@@ -33,7 +34,7 @@ if(process.env.gateway_HTTPS_Redirect == "true"){
 			next()
 		}
 		else{
-			res.redirect(`https://${redirectHost || req.hostname}${portSuffix}${req.url}`)
+			res.redirect(`https://${redirectTarget || `${req.hostname}${portSuffix}`}${req.url}`)
 		}
 	})
 }

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -7,7 +7,8 @@ var {
 const { helmetOptions, gatewayHost } = require("lib")
 
 var app = express()
-if(process.env.gateway_TRUST_PROXY == "true"){
+const trustProxy = process.env.gateway_TRUST_PROXY == "true"
+if(trustProxy){
 	app.set("trust proxy", 1)
 }
 
@@ -19,7 +20,7 @@ app.use(helmet(helmetOptions))
 
 if(process.env.gateway_HTTPS_Redirect == "true"){
 	const securePort = process.env.gateway_PORT_SECURE || 443
-	const portSuffix = securePort == 443 ? "" : `:${securePort}`
+	const portSuffix = trustProxy || securePort == 443 ? "" : `:${securePort}`
 	const redirectTarget = (() => {
 		try{
 			const url = new URL(gatewayHost())

--- a/gateway/test/httpsRedirect.test.js
+++ b/gateway/test/httpsRedirect.test.js
@@ -41,3 +41,60 @@ describe("gateway_HTTPS_Redirect with gateway_TRUST_PROXY=true", () => {
 			.end(done)
 	})
 })
+
+describe("the redirect target comes from config, not from the request", () => {
+	const freshGateway = () => {
+		jest.resetModules()
+		return require("../gateway.js")
+	}
+
+	afterEach(() => {
+		delete process.env.gateway_PORT_SECURE
+		delete process.env.gateway_HOST
+		jest.resetModules()
+	})
+
+	test("targets gateway_PORT_SECURE, not the port the client connected on", (done) => {
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "https://192.168.1.50:8443"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "192.168.1.50:8080")
+			.expect(302)
+			.expect("location", "https://192.168.1.50:8443/command/health", done)
+	})
+
+	test("drops the client's port when gateway_PORT_SECURE is 443", (done) => {
+		process.env.gateway_PORT_SECURE = "443"
+		process.env.gateway_HOST = "https://cam.example.com"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "cam.example.com:8080")
+			.expect("location", "https://cam.example.com/command/health", done)
+	})
+
+	test("an unset gateway_PORT_SECURE reads as 443", (done) => {
+		process.env.gateway_HOST = "https://cam.example.com"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "cam.example.com:8080")
+			.expect("location", "https://cam.example.com/command/health", done)
+	})
+
+	test("the host comes from gateway_HOST, so a forged Host header cannot pick the target", (done) => {
+		process.env.gateway_HOST = "https://cam.example.com"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "phish.example.com")
+			.expect("location", "https://cam.example.com/command/health", done)
+	})
+
+	test("falls back to the request host when gateway_HOST is unparseable", (done) => {
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "not a valid host"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "192.168.1.50:8080")
+			.expect("location", "https://192.168.1.50:8443/command/health", done)
+	})
+})

--- a/gateway/test/httpsRedirect.test.js
+++ b/gateway/test/httpsRedirect.test.js
@@ -97,4 +97,22 @@ describe("the redirect target comes from config, not from the request", () => {
 			.set("Host", "192.168.1.50:8080")
 			.expect("location", "https://192.168.1.50:8443/command/health", done)
 	})
+
+	test("a proxied deploy redirects to the gateway_HOST port, not gateway_PORT_SECURE", (done) => {
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "https://cam.example.com"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "cam.example.com")
+			.expect("location", "https://cam.example.com/command/health", done)
+	})
+
+	test("an http:// gateway_HOST with a plain port redirects to hostname + gateway_PORT_SECURE", (done) => {
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "http://192.168.1.50:8080"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "192.168.1.50:8080")
+			.expect("location", "https://192.168.1.50:8443/command/health", done)
+	})
 })

--- a/gateway/test/httpsRedirect.test.js
+++ b/gateway/test/httpsRedirect.test.js
@@ -51,6 +51,7 @@ describe("the redirect target comes from config, not from the request", () => {
 	afterEach(() => {
 		delete process.env.gateway_PORT_SECURE
 		delete process.env.gateway_HOST
+		process.env.gateway_TRUST_PROXY = "true"
 		jest.resetModules()
 	})
 
@@ -90,6 +91,7 @@ describe("the redirect target comes from config, not from the request", () => {
 	})
 
 	test("falls back to the request host when gateway_HOST is unparseable", (done) => {
+		process.env.gateway_TRUST_PROXY = "false"
 		process.env.gateway_PORT_SECURE = "8443"
 		process.env.gateway_HOST = "not a valid host"
 		supertest(freshGateway())
@@ -108,11 +110,22 @@ describe("the redirect target comes from config, not from the request", () => {
 	})
 
 	test("an http:// gateway_HOST with a plain port redirects to hostname + gateway_PORT_SECURE", (done) => {
+		process.env.gateway_TRUST_PROXY = "false"
 		process.env.gateway_PORT_SECURE = "8443"
 		process.env.gateway_HOST = "http://192.168.1.50:8080"
 		supertest(freshGateway())
 			.get("/command/health")
 			.set("Host", "192.168.1.50:8080")
 			.expect("location", "https://192.168.1.50:8443/command/health", done)
+	})
+
+	test("an http:// gateway_HOST behind a proxy keeps the proxy's port, not the container's TLS port", (done) => {
+		process.env.gateway_TRUST_PROXY = "true"
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "http://cam.example.com"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("X-Forwarded-Proto", "http")
+			.expect("location", "https://cam.example.com/command/health", done)
 	})
 })

--- a/gateway/test/httpsRedirectPort.test.js
+++ b/gateway/test/httpsRedirectPort.test.js
@@ -2,7 +2,7 @@ const supertest = require("supertest")
 
 process.env.gateway_HTTPS_Redirect = "true"
 process.env.gateway_TRUST_PROXY = "false"
-delete process.env.gateway_HOST
+process.env.gateway_HOST = ""
 
 jest.mock("memory")
 jest.mock("axios")

--- a/gateway/test/httpsRedirectPort.test.js
+++ b/gateway/test/httpsRedirectPort.test.js
@@ -2,6 +2,7 @@ const supertest = require("supertest")
 
 process.env.gateway_HTTPS_Redirect = "true"
 process.env.gateway_TRUST_PROXY = "false"
+delete process.env.gateway_HOST
 
 jest.mock("memory")
 jest.mock("axios")


### PR DESCRIPTION
`gateway/gateway.js` built the HTTPS redirect from the request's own `Host` header, which carries the port the client connected on. Swapping only the scheme meant the redirect kept that port, so it reached the TLS listener only when `gateway_PORT` was 80 and `gateway_PORT_SECURE` was 443. On any other pair — say `8080` and `8443` — `http://host:8080/` redirected to `https://host:8080/`, which is the plain-HTTP listener: `ERR_SSL_PROTOCOL_ERROR`. The same line also let a client choose the redirect target by forging `Host`.

Both halves come from the request, so both are fixed by taking them from config instead. `gateway_HOST` is the origin browsers use. `gateway_PORT_SECURE` is the container's own TLS listener. The two are equal only when nothing sits in front, so the redirect reads the port from `gateway_HOST` and falls back to `gateway_PORT_SECURE`:

```
redirect target from gateway_HOST
  ├─ https:// → host (hostname + port as configured)
  │     ├─ https://cam.example.com    → cam.example.com        proxy keeps 443
  │     └─ https://192.168.1.50:8443  → 192.168.1.50:8443      direct deploy
  ├─ http://  → hostname + gateway_PORT_SECURE (443 drops the suffix)
  │     └─ http://192.168.1.50:8080   → 192.168.1.50:8443      upgrade, not the plain port
  └─ unparseable → req.hostname + gateway_PORT_SECURE          unreachable; boot blocks first
```

`certbot_ON=true` was never affected — `certbotPortProblem` already forces `gateway_PORT=80`.

**Preflight.** Adds `httpsRedirectPortWarning`, in a file that already catches the redirect loop, the certbot port and the cookie mismatch. It fires when `gateway_HTTPS_Redirect=true` and the https port implied by `gateway_HOST` differs from `gateway_PORT_SECURE`. It stays silent in three cases: an explicit `http://` `gateway_HOST`, where that port is the plain listener rather than a TLS claim; a blank or unparseable host; and `gateway_TRUST_PROXY=true`, where the two ports are meant to differ. It warns without blocking.

**Boot.** `chimera/validateEnvVars.js` runs on every start (`entrypoint.sh:12`) and now prints the same warning, next to the redirect-loop one. It also rejects a `gateway_HOST` that does not parse, beside the existing `storage_HOST` check. Without that gate a typo reached the gateway, failed `new URL(...)`, and fell back to `req.hostname` — which `gateway_TRUST_PROXY=true` resolves from the client's own `X-Forwarded-Host`.

## Decisions

These questions came up in review. The answers are settled, so later readers do not re-open them.

| question | decision | effect |
| --- | --- | --- |
| Can the container's TLS port differ from the port browsers use? | Yes. A proxy or tunnel may hold public 443 while the container publishes another port. | The redirect takes the port from `gateway_HOST`, not from `gateway_PORT_SECURE`. |
| A LAN client reaches the gateway at `192.168.1.50` while `gateway_HOST` is a public name. Where does the redirect send it? | To `gateway_HOST`. One origin, always. | Alternate addresses redirect to the public name. This is the point of the fix, not a regression. |
| Is `http://` `gateway_HOST` with `gateway_HTTPS_Redirect=true` allowed? | Yes. The redirect exists to upgrade those visitors. | The plain port in an `http://` host is never copied into an `https://` redirect. Preflight says nothing. |
| A typo makes `gateway_HOST` unparseable. What happens? | Boot stops. | The forgeable `req.hostname` fallback is unreachable in a running deploy. |
| Must a preflight warning also print at boot? | Yes. `.env` can change after preflight ran. | `validateEnvVars.js` prints `httpsRedirectPortWarning` too. |

**Testing.** Five tests in `gateway/test/httpsRedirect.test.js` cover the redirect target, plus two more: a proxied deploy keeps 443, and an `http://` host upgrades to `gateway_PORT_SECURE`. Ten cover `httpsRedirectPortWarning` in `chimera/test/preflight.test.js`, the last one for the proxy gate. Four cover the boot gate in `chimera/test/validateEnvVars.test.js`. One earlier test changed: a malformed `gateway_HOST` now blocks boot instead of warning. `npx jest gateway chimera` → 1227 passing, 7 skipped, 0 failing across 95 suites. ESLint on the changed files: 0 errors.

Pre-existing since v5.1.1; the line was unchanged across the v6 rewrite.

Closes #494
