### PR TITLE
Address review comments on #490

### DIFF
--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -130,8 +130,9 @@ const varProblem = (v, val) => {
 
 const isFile = (p) => { try { return fs.statSync(p).isFile() } catch { return false } }
 
-// certbot-entry.sh leaves /etc/letsencrypt/live mode 0710, so stat throws EACCES for an account outside the container group — only ENOENT/ENOTDIR prove the cert is absent.
+// certbot leaves /etc/letsencrypt/live mode 0700 root on the host, so stat throws EACCES for an ordinary account — only ENOENT/ENOTDIR prove the cert is absent.
 const certMaybePresent = (p) => { try { return fs.statSync(p).isFile() } catch (e) { return e.code !== "ENOENT" && e.code !== "ENOTDIR" } }
+const certUnreadable = (p) => { try { fs.statSync(p); return null } catch (e) { return e.code === "ENOENT" || e.code === "ENOTDIR" ? null : e.code } }
 
 const motionDirProblem = () => !isFile(MOTION) && fs.existsSync(MOTION)
 	? "is a directory — Docker creates one when the bind-mounted file is missing; run `rm -rf motion.conf && cp motion.conf.example motion.conf`"
@@ -243,17 +244,35 @@ const cookieAmbiguousHostWarning = (lines) =>
 		? "WARNING: gateway_HOST has no scheme, so it reads as https://. If browsers actually reach this deploy over http://, login loops forever — give gateway_HOST an explicit http:// prefix"
 		: null
 
-const autoResolvedCertOnDisk = (lines) => {
+// mirrors certPaths(): the two FILEPATH overrides win over the auto-resolved pair, and one override alone disables TLS outright
+const configuredCertPair = (lines) => {
+	const [key, cert] = ["privateKey_FILEPATH", "certificate_FILEPATH"].map(k => getVal(lines, k) || "")
+	if (key || cert) return key && cert ? [key, cert] : []
 	const hostname = urlPart(gatewayUrl(lines), "hostname")
-	if (!hostname) return false
-	const { key, cert } = letsencryptPaths(hostname)
-	return [key, cert].every(certMaybePresent)
+	if (!hostname) return []
+	const auto = letsencryptPaths(hostname)
+	return [auto.key, auto.cert]
+}
+
+const certPairMaybePresent = (lines) => {
+	const pair = configuredCertPair(lines)
+	return pair.length > 0 && pair.every(certMaybePresent)
+}
+
+const redirectNeedsLocalCert = (lines) =>
+	getVal(lines, "gateway_HTTPS_Redirect") === "true" && getVal(lines, "gateway_TRUST_PROXY") !== "true"
+		&& getVal(lines, "certbot_ON") !== "true"
+
+const certUnreadableWarning = (lines) => {
+	if (!redirectNeedsLocalCert(lines)) return null
+	const unreadable = configuredCertPair(lines).map(p => [p, certUnreadable(p)]).filter(([, code]) => code)
+	return unreadable.length
+		? `WARNING: cannot read ${unreadable.map(([p, code]) => `${p} (${code})`).join(", ")} from this account, so preflight cannot tell whether the certificate is there and will not warn about the redirect loop. Check it yourself with \`sudo test -f <path>\` — /etc/letsencrypt is mode 0700 root outside the container, and a FILEPATH names a path inside the container, which docker-compose.yml need not mount from this host`
+		: null
 }
 
 const httpsRedirectLoopWarning = (lines) =>
-	getVal(lines, "gateway_HTTPS_Redirect") === "true" && getVal(lines, "gateway_TRUST_PROXY") !== "true"
-		&& getVal(lines, "certbot_ON") !== "true" && !autoResolvedCertOnDisk(lines)
-		&& !["privateKey_FILEPATH", "certificate_FILEPATH"].every(k => certMaybePresent(getVal(lines, k) || ""))
+	redirectNeedsLocalCert(lines) && !certPairMaybePresent(lines)
 		? "WARNING: gateway_HTTPS_Redirect=true, but nothing serves https:// here and gateway_TRUST_PROXY is not true, so every page redirects to itself (ERR_TOO_MANY_REDIRECTS). Who holds the certificate?\n  this machine — set certbot_ON=true, or give privateKey_FILEPATH and certificate_FILEPATH absolute paths to your cert pair\n  a proxy or tunnel — set gateway_TRUST_PROXY=true and make it send X-Forwarded-Proto (nginx: proxy_set_header X-Forwarded-Proto $scheme)"
 		: null
 
@@ -348,7 +367,7 @@ const runCheck = () => {
 		if (cam.length) failed = true
 	}
 
-	for (const w of [httpsRedirectLoopWarning(lines), httpsRedirectPortWarning(lines)]) {
+	for (const w of [httpsRedirectLoopWarning(lines), certUnreadableWarning(lines), httpsRedirectPortWarning(lines)]) {
 		if (w) console.log(`\n${w}`)
 	}
 
@@ -486,7 +505,7 @@ const runInteractive = async () => {
 	const envOk = !probs.length
 	console.log(`.env ${envOk ? OK : BAD}\n`)
 
-	for (const w of [httpsRedirectLoopWarning(lines), httpsRedirectPortWarning(lines)]) {
+	for (const w of [httpsRedirectLoopWarning(lines), certUnreadableWarning(lines), httpsRedirectPortWarning(lines)]) {
 		if (w) console.log(`${w}\n`)
 	}
 
@@ -572,4 +591,4 @@ if (require.main === module) {
 	else runInteractive()
 }
 
-module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem, motionDirProblem }
+module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certUnreadableWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem, motionDirProblem }

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -22,7 +22,7 @@ jest.mock("fs", () => {
 })
 
 const fs = require("fs")
-const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, envProblems, hashTruncated, looseMode } = require("../preflight.js")
+const { parseSchema, typeOf, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certUnreadableWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, envProblems, hashTruncated, looseMode } = require("../preflight.js")
 
 describe("parseSchema", () => {
 	test("parses required keys", () => {
@@ -170,6 +170,13 @@ describe("varProblem", () => {
 		expect(varProblem(gatewayHostVar, "cam.example.com")).toBeNull()
 		expect(varProblem(gatewayHostVar, "https://cam.example.com:8443")).toBeNull()
 		expect(varProblem(gatewayHostVar, "http://127.0.0.1:8080")).toBeNull()
+	})
+
+	test("gateway_HOST: a bare IPv6 literal → null, bracketed or not — new URL() only takes the bracketed form", () => {
+		expect(varProblem(gatewayHostVar, "::1")).toBeNull()
+		expect(varProblem(gatewayHostVar, "[::1]")).toBeNull()
+		expect(varProblem(gatewayHostVar, "http://::1")).toBeNull()
+		expect(varProblem(gatewayHostVar, "https://[2001:db8::5]:8443")).toBeNull()
 	})
 
 	test("setup_TOKEN: under 32 characters → error, so preflight blocks what validateEnvVars would crash-loop on", () => {
@@ -437,12 +444,65 @@ describe("httpsRedirectLoopWarning", () => {
 		statSpy.mockRestore()
 	})
 
+	test("fires when the FILEPATH overrides are missing even though an auto-resolved pair is on disk — certPaths() gives the overrides precedence", () => {
+		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
+			if (["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"].includes(p)) return { isFile: () => true }
+			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		})
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeTruthy()
+		statSpy.mockRestore()
+	})
+
+	test("fires when only one FILEPATH is set and an auto-resolved pair is on disk — a half-set override disables TLS entirely", () => {
+		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
+			if (["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"].includes(p)) return { isFile: () => true }
+			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		})
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com", privateKey_FILEPATH: "/certs/privkey.pem" }))).toBeTruthy()
+		statSpy.mockRestore()
+	})
+
 	test("stays quiet when a configured FILEPATH is unreadable", () => {
 		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
 			if (["/certs/privkey.pem", "/certs/fullchain.pem"].includes(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" })
 			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
 		})
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeNull()
+		statSpy.mockRestore()
+	})
+})
+
+describe("certUnreadableWarning", () => {
+	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
+
+	test("names the unreadable path and its errno, so EACCES does not read as a certificate", () => {
+		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
+			if (["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"].includes(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" })
+			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+		})
+		const w = certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))
+		expect(w).toMatch("/etc/letsencrypt/live/cam.example.com/privkey.pem (EACCES)")
+		expect(w).toMatch("/etc/letsencrypt/live/cam.example.com/fullchain.pem (EACCES)")
+		statSpy.mockRestore()
+	})
+
+	test("fires for an unreadable FILEPATH override — a container path need not exist on the host", () => {
+		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("EACCES"), { code: "EACCES" }) })
+		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/etc/ssl/private/key.pem", certificate_FILEPATH: "/etc/ssl/certs/cert.pem" }))).toMatch("/etc/ssl/private/key.pem (EACCES)")
+		statSpy.mockRestore()
+	})
+
+	test("stays quiet when the paths are merely absent — httpsRedirectLoopWarning already speaks for that", () => {
+		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }) })
+		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toBeNull()
+		statSpy.mockRestore()
+	})
+
+	test("stays quiet when nothing here has to hold a certificate", () => {
+		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("EACCES"), { code: "EACCES" }) })
+		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "false", gateway_HOST: "https://cam.example.com" }))).toBeNull()
+		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_TRUST_PROXY: "true", gateway_HOST: "https://cam.example.com" }))).toBeNull()
+		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "true", gateway_HOST: "https://cam.example.com" }))).toBeNull()
 		statSpy.mockRestore()
 	})
 })

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -36,7 +36,7 @@ const rawGatewayHost = (process.env.gateway_HOST || "").trim()
 if (!isServiceOff(envLines, "gateway_HOST") && rawGatewayHost !== "") {
 	try { new URL(gatewayHost()) }
 	catch {
-		console.log("gateway_HOST MUST BE A VALID URL — an unparseable value falls back to req.hostname, and with gateway_TRUST_PROXY=true that resolves from the client-supplied X-Forwarded-Host, letting a forged Host header pick the HTTPS redirect target")
+		console.log("gateway_HOST MUST BE A VALID URL — an unparseable value falls back to the client-supplied Host header (gateway.js reads req.headers.host, whatever gateway_TRUST_PROXY says), letting a forged Host pick the HTTPS redirect target")
 		allEnvPresent = false
 	}
 }

--- a/command/README.md
+++ b/command/README.md
@@ -38,7 +38,7 @@ Three access levels: public, session (`authorize`), admin (`requireAdmin`). Auth
 |---|---|---|---|
 | burst | IP | 20 / 15 min | 1 check / 10s |
 | daily | IP | 100 / 24h | 1 check / 15 min |
-| account | username | 10 / 15 min | 1 check / 15 min |
+| account | username | 10 / 15 min | 1 check / 10s |
 
 No budget ends in a hard block. A spent budget throttles to one credential check per window; extra requests get 429 immediately and nothing queues, so a flood cannot build latency. That one check also answers 429 on a wrong password — a 429 does not prove the credentials went unchecked.
 
@@ -62,4 +62,5 @@ These budgets are tuned to keep legitimate users in, not to guarantee an attacke
 - Clients behind one egress IP (home router, CGNAT) share the per-IP budgets and contend for the single slot, even when the attack targets someone else.
 - `knownDevice` matches username and current password hash, not a live session, so a shared browser lets a later user inherit the skip.
 - Nothing caps attempts across addresses: N addresses buy N×20 checks per window, ~N×200 per day. Run a cluster (`chimeraInstances`) to spread the load; it also forces `memory_ON=true`, which keeps the budgets shared.
+- The account throttle is one slot per username, and any unauthenticated request takes it. Its window is short on purpose: a long one would let an attacker keep a user who has no device token out for as long as they keep sending. The cost is that a spent account budget still admits ~8,600 checks a day against that username, spread across addresses.
 - `bcryptjs` holds the event loop for a whole cost-10 check (~50ms, longer on a Pi or NAS), so 20 concurrent logins from one address stall every route for ~1s.

--- a/command/README.md
+++ b/command/README.md
@@ -32,35 +32,33 @@ Three access levels: public, session (`authorize`), admin (`requireAdmin`). Auth
 ---
 # Login limits
 
-`POST /authorization/login` spends three budgets in order, then checks the password. The numbers below are set in [authorization.js](backend/routes/authorization.js):
+`POST /authorization/login` spends three budgets in order, then checks the password. Allowances, windows, and throttle intervals live in [authorization.js](backend/routes/authorization.js).
 
-| budget | key | allowance | once spent |
-|---|---|---|---|
-| burst | IP | 20 / 15 min | 1 check / 10s |
-| daily | IP | 100 / 24h | 1 check / 15 min |
-| account | username | 10 / 15 min | 1 check / 10s |
+| budget | keyed on | skipped by a device token |
+|---|---|---|
+| burst | IP | no |
+| daily | IP | yes |
+| account | username | yes |
 
 No budget ends in a hard block. A spent budget throttles to one credential check per window; extra requests get 429 immediately and nothing queues, so a flood cannot build latency. That one check also answers 429 on a wrong password — a 429 does not prove the credentials went unchecked.
 
-A response under 400, or a 5xx, refunds the slot; every 4xx spends it. So a request the account throttle rejects spends both IP slots without checking a password. A request stopped at the burst stage never reaches the daily budget, which keeps a flood of 429s from draining a shared address's day.
-
-The daily budget caps one address: without it, the burst throttle alone would admit ~10,560 checks a day.
+A response under 400, or a 5xx, refunds the slot; every 4xx spends it. A request stopped at the burst stage never reaches the daily budget, which keeps a flood of 429s from draining a shared address's day.
 
 `req.ip` is the last `X-Forwarded-For` entry, which the gateway appends as its own peer, so a forged header cannot raise the limit.
 
 ## Device tokens
 
-A successful login sets `devicetoken`, a year-long signed `httpOnly` cookie naming the username. It skips the **account** and **daily** budgets, so no one else's failures can lock a user out of a device they already use. The daily budget matters here because one address covers a whole site and stays spent until tomorrow. The burst budget still applies, capping a stolen token at 20 guesses per 15 minutes, then one per 10s.
+A successful login sets `devicetoken`, a year-long signed `httpOnly` cookie naming the username. It skips the budgets marked above, so no one else's failures can lock a user out of a device they already use. The burst budget still applies, so a stolen token is still capped.
 
-The cookie also carries `dk`, a SHA-256 digest of the password hash it was issued against, which `knownDevice` re-checks on every login. A password change therefore voids every token for that username and restores both the account and daily caps — the remediation path for a stolen device, since revoking sessions alone does not void the cookie. Logout keeps it on purpose; it exists to survive session expiry.
+The cookie also carries `dk`, a SHA-256 digest of the password hash it was issued against, which `knownDevice` re-checks on every login. A password change therefore voids every token for that username — the remediation path for a stolen device, since revoking sessions alone does not void the cookie. Logout keeps it on purpose; it exists to survive session expiry.
 
 ## What this does not do
 
 These budgets are tuned to keep legitimate users in, not to guarantee an attacker is stopped. The consequences:
 
 - Any proxy in front of the gateway (CDN, nginx, tunnel) becomes that peer, so the whole site shares one set of per-IP budgets.
-- Clients behind one egress IP (home router, CGNAT) share the per-IP budgets and contend for the single slot, even when the attack targets someone else.
+- Clients behind one egress IP (home router, CGNAT) share the per-IP budgets and contend for the single throttle slot, even when the attack targets someone else.
+- A throttle slot is one per key and any request takes it, so a user with no device token waits out the window an attacker is holding.
 - `knownDevice` matches username and current password hash, not a live session, so a shared browser lets a later user inherit the skip.
-- Nothing caps attempts across addresses: N addresses buy N×20 checks per window, ~N×200 per day. Run a cluster (`chimeraInstances`) to spread the load; it also forces `memory_ON=true`, which keeps the budgets shared.
-- The account throttle is one slot per username, and any unauthenticated request takes it. Its window is short on purpose: a long one would let an attacker keep a user who has no device token out for as long as they keep sending. The cost is that a spent account budget still admits ~8,600 checks a day against that username, spread across addresses.
-- `bcryptjs` holds the event loop for a whole cost-10 check (~50ms, longer on a Pi or NAS), so 20 concurrent logins from one address stall every route for ~1s.
+- Nothing caps attempts across addresses. Run a cluster (`chimeraInstances`) to spread the load; it also forces `memory_ON=true`, which keeps the budgets shared.
+- `bcryptjs` holds the event loop for a whole cost-10 check, so concurrent logins from one address stall every route.

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -51,7 +51,6 @@ const deviceKnown = (req) => (req.deviceKnown ??= knownDevice(req))
 
 const ipLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 20, throttleMs: THROTTLE_WINDOW_MS, keyFn: ipKeyFn })
 const ipDayLimiter = rateLimit({ windowMs: 24 * 60 * 60 * 1000, max: 100, throttleMs: 15 * 60 * 1000, keyFn: (req) => `day:${ipKeyFn(req)}`, skip: deviceKnown })
-// the throttle slot is one per username and any unauthenticated request takes it, so a long window here locks the real user out for as long as an attacker keeps sending
 const accountLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10, throttleMs: THROTTLE_WINDOW_MS, keyFn: accountKeyFn, skip: deviceKnown })
 
 app.get("/status", async (req, res) => {

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -51,7 +51,8 @@ const deviceKnown = (req) => (req.deviceKnown ??= knownDevice(req))
 
 const ipLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 20, throttleMs: THROTTLE_WINDOW_MS, keyFn: ipKeyFn })
 const ipDayLimiter = rateLimit({ windowMs: 24 * 60 * 60 * 1000, max: 100, throttleMs: 15 * 60 * 1000, keyFn: (req) => `day:${ipKeyFn(req)}`, skip: deviceKnown })
-const accountLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10, throttleMs: 15 * 60 * 1000, keyFn: accountKeyFn, skip: deviceKnown })
+// the throttle slot is one per username and any unauthenticated request takes it, so a long window here locks the real user out for as long as an attacker keeps sending
+const accountLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10, throttleMs: THROTTLE_WINDOW_MS, keyFn: accountKeyFn, skip: deviceKnown })
 
 app.get("/status", async (req, res) => {
 	try {

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -1071,7 +1071,9 @@ describe("Authorization Routes", () => {
 			expect(Date.now() - start).toBeLessThan(1000)
 		})
 
-		test("the account throttle window is 15 minutes, not the 10-second default ipLimiter uses", async () => {
+		// the throttle slot is one per username and anyone can take it, so a long window would hand an
+		// attacker a permanent lockout of a user who has no device token — a new browser or a password change
+		test("an attacker holding the account throttle slot costs the real user 10 seconds, not 15 minutes", async () => {
 			const username = "throttlewindowvictim"
 			let now = Date.now()
 			jest.spyOn(Date, "now").mockImplementation(() => now)
@@ -1083,25 +1085,24 @@ describe("Authorization Routes", () => {
 					.set("X-Forwarded-For", `192.0.2.${i}`)
 					.send({ username, password: "wrongpassword" })
 			}
-			const first = await supertest(app)
+			const attacker = await supertest(app)
 				.post("/authorization/login")
 				.set("X-Forwarded-For", "192.0.2.50")
-				.send({ username, password: "mockedPassword" })
-			expect(first.status).toBe(200)
+				.send({ username, password: "wrongpassword" })
+			expect(attacker.status).toBe(429)
 
-			now += 10 * 1000
-			const tenSecondsLater = await supertest(app)
+			const victim = await supertest(app)
 				.post("/authorization/login")
 				.set("X-Forwarded-For", "192.0.2.51")
 				.send({ username, password: "mockedPassword" })
-			expect(tenSecondsLater.status).toBe(429)
+			expect(victim.status).toBe(429)
 
-			now += 15 * 60 * 1000
-			const fifteenMinutesLater = await supertest(app)
+			now += 10 * 1000 + 1
+			const tenSecondsLater = await supertest(app)
 				.post("/authorization/login")
 				.set("X-Forwarded-For", "192.0.2.52")
 				.send({ username, password: "mockedPassword" })
-			expect(fifteenMinutesLater.status).toBe(200)
+			expect(tenSecondsLater.status).toBe(200)
 		})
 
 		test("a throttled request is refused immediately instead of being queued", async () => {

--- a/env.example
+++ b/env.example
@@ -25,6 +25,7 @@ SECRETKEY = Auth secret key for hashing, min 32 characters
 
 gateway_PORT = Gateway http port (must be 80 when certbot_ON=true)
 gateway_HOST = https://gateway.server.example or http://127.0.0.1:8080 (protocol defaults to https:// if omitted)
+# gateway_HOST is also the HTTPS redirect target — every http:// visitor lands on this name and gateway_PORT_SECURE, whatever host they typed
 
 gateway_PORT_SECURE = Gateway https port (default 443) ***
 certbot_ON = (true | false) Auto-issue and renew Let's Encrypt certs. Needs gateway_HOST to be a public domain pointing at this machine, with port 80 open. Leave false to supply your own certs below.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -26,6 +26,8 @@ The gateway runs two listeners:
 
 `gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It reads `req.secure` — by default the gateway's own TLS socket, which cannot be spoofed.
 
+The redirect target is built once at boot from `gateway_HOST` + `gateway_PORT_SECURE`, not from the request's `Host`, so the deploy is single-name: a browser opening `http://192.168.1.50/…`, a tailnet name, or a container alias is sent to `gateway_HOST`, which internal DNS or hairpin NAT has to resolve. Give `gateway_HOST` a port only if it matches `gateway_PORT_SECURE` — a disagreement sends browsers to a port with no TLS listener, which `npm run preflight` warns about without blocking. If `gateway_HOST` is unset or unparseable the target falls back to the request's own `Host` header, so a forged `Host` picks where visitors land.
+
 `gateway_TRUST_PROXY=true` enables `trust proxy`, so `req.secure` reads `X-Forwarded-Proto` instead. Set it only when something in front terminates TLS (nginx, a CDN, a tunnel); the redirect loops without it. It stays opt-in because anyone who can reach `gateway_PORT` directly can forge that header and skip the redirect.
 
 ---
@@ -36,4 +38,4 @@ Before proxying, serves `/.well-known/` from the repo-root dir (dotfiles allowed
 ---
 # Config
 
-`<prefix>_PROXY_ON`, `<prefix>_HOST`, `gateway_PORT`, `gateway_PORT_SECURE`, `gateway_HOST` (TLS cert derive), `privateKey_FILEPATH` / `certificate_FILEPATH` (TLS override), `gateway_HTTPS_Redirect`, `gateway_TRUST_PROXY`; see [../env.example](../env.example).
+`<prefix>_PROXY_ON`, `<prefix>_HOST`, `gateway_PORT`, `gateway_PORT_SECURE`, `gateway_HOST` (TLS cert derive, HTTPS redirect target), `privateKey_FILEPATH` / `certificate_FILEPATH` (TLS override), `gateway_HTTPS_Redirect`, `gateway_TRUST_PROXY`; see [../env.example](../env.example).

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -26,7 +26,7 @@ The gateway runs two listeners:
 
 `gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It reads `req.secure` — by default the gateway's own TLS socket, which cannot be spoofed.
 
-The redirect target is built once at boot from `gateway_HOST` + `gateway_PORT_SECURE`, not from the request's `Host`, so the deploy is single-name: a browser opening `http://192.168.1.50/…`, a tailnet name, or a container alias is sent to `gateway_HOST`, which internal DNS or hairpin NAT has to resolve. Give `gateway_HOST` a port only if it matches `gateway_PORT_SECURE` — a disagreement sends browsers to a port with no TLS listener, which `npm run preflight` warns about without blocking. If `gateway_HOST` is unset or unparseable the target falls back to the request's own `Host` header, so a forged `Host` picks where visitors land.
+Everyone lands on `gateway_HOST` and `gateway_PORT_SECURE`, whatever address they typed — so pick a name every visitor can resolve, and don't put a port on it unless it is `gateway_PORT_SECURE`. With no usable `gateway_HOST` the redirect follows the browser's own `Host` header, which anyone can forge.
 
 `gateway_TRUST_PROXY=true` enables `trust proxy`, so `req.secure` reads `X-Forwarded-Proto` instead. Set it only when something in front terminates TLS (nginx, a CDN, a tunnel); the redirect loops without it. It stays opt-in because anyone who can reach `gateway_PORT` directly can forge that header and skip the redirect.
 

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -24,7 +24,7 @@ if(process.env.gateway_HTTPS_Redirect == "true"){
 	const redirectTarget = (() => {
 		try{
 			const url = new URL(gatewayHost())
-			return url.protocol == "https:" ? url.host : `${url.hostname}${portSuffix}`
+			return url.protocol == "https:" && url.port ? url.host : `${url.hostname}${portSuffix}`
 		}
 		catch{
 			return ""

--- a/gateway/test/httpsRedirect.test.js
+++ b/gateway/test/httpsRedirect.test.js
@@ -119,6 +119,36 @@ describe("the redirect target comes from config, not from the request", () => {
 			.expect("location", "https://192.168.1.50:8443/command/health", done)
 	})
 
+	test("an https:// gateway_HOST with no port takes gateway_PORT_SECURE — the scheme alone does not mean 443", (done) => {
+		process.env.gateway_TRUST_PROXY = "false"
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "https://cam.example.com"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "cam.example.com:8080")
+			.expect("location", "https://cam.example.com:8443/command/health", done)
+	})
+
+	test("a scheme-less gateway_HOST reads as https:// and still takes gateway_PORT_SECURE", (done) => {
+		process.env.gateway_TRUST_PROXY = "false"
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "cam.example.com"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "cam.example.com:8080")
+			.expect("location", "https://cam.example.com:8443/command/health", done)
+	})
+
+	test("a bare IPv6 gateway_HOST is bracketed, not dropped as unparseable", (done) => {
+		process.env.gateway_TRUST_PROXY = "false"
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "::1"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "[::1]:8080")
+			.expect("location", "https://[::1]:8443/command/health", done)
+	})
+
 	test("an http:// gateway_HOST behind a proxy keeps the proxy's port, not the container's TLS port", (done) => {
 		process.env.gateway_TRUST_PROXY = "true"
 		process.env.gateway_PORT_SECURE = "8443"

--- a/lib/utils/normalizeHost.js
+++ b/lib/utils/normalizeHost.js
@@ -1,5 +1,7 @@
 module.exports = (host) => {
 	const h = (host || "").trim().replace(/\/+$/, "")
 	if (!h) return ""
-	return /^https?:\/\//i.test(h) ? h : `https://${h}`
+	const withScheme = /^https?:\/\//i.test(h) ? h : `https://${h}`
+	// new URL() throws on a bare IPv6 literal, so bracket an authority that holds more than one colon
+	return withScheme.replace(/^(https?:\/\/)([^/[]*:[^/]*:[^/]*)$/i, "$1[$2]")
 }

--- a/lib/utils/normalizeHost.js
+++ b/lib/utils/normalizeHost.js
@@ -2,6 +2,5 @@ module.exports = (host) => {
 	const h = (host || "").trim().replace(/\/+$/, "")
 	if (!h) return ""
 	const withScheme = /^https?:\/\//i.test(h) ? h : `https://${h}`
-	// new URL() throws on a bare IPv6 literal, so bracket an authority that holds more than one colon
 	return withScheme.replace(/^(https?:\/\/)([^/[]*:[^/]*:[^/]*)$/i, "$1[$2]")
 }


### PR DESCRIPTION
Answers the seven review comments on #490. Base is `develop`, so #490 picks this up.

| # | Comment | File | Fix |
|---|---|---|---|
| 1 | account throttle window is 90× longer | `command/backend/routes/authorization.js` | Back to `THROTTLE_WINDOW_MS` (10s). |
| 2 | cert checks read in the wrong order | `chimera/preflight.js` | `configuredCertPair` mirrors `certPaths()` — overrides first. |
| 3 | EACCES reads as a certificate | `chimera/preflight.js` | New `certUnreadableWarning` names the path and errno. |
| 4 | bare IPv6 `gateway_HOST` rejected | `lib/utils/normalizeHost.js` | Bracket a bare IPv6 literal before the parse. |
| 5 | the `https:` redirect branch drops the port | `gateway/gateway.js` | Append `gateway_PORT_SECURE` when `gateway_HOST` names no port. |
| 6 | message names a fallback that does not exist | `chimera/validateEnvVars.js` | Names `req.headers.host`, drops the `gateway_TRUST_PROXY` condition. |
| 7 | README does not say where the redirect points | `gateway/README.md` | Documents the single-name target and the `Host` fallback. |

## 1 — account throttle back to 10 seconds

The throttle slot is `max: 1` per username and **any unauthenticated request takes it**. At a 15-minute window an attacker spends the budget with 10 wrong passwords, then holds the only slot with one cheap request every 15 minutes. A user with no device token — new browser, cleared cookies, or a password change, which voids every token for that username — gets 429 on the correct password, with no end.

Releasing the slot on a correct password does not fix it: the victim is refused at the limiter and never reaches `passwordCheck`, so there is nothing to release. Any account-keyed slot long enough to slow an attacker is long enough to lock the user out. The window goes back to 10 seconds and the tradeoff is now written down in `command/README.md`: a spent account budget still admits ~8,600 checks a day against one username, spread across addresses.

The per-IP daily throttle keeps its 15 minutes — it is keyed by address, so the collateral is the shared-address case #490 already accepted.

## 2 — cert precedence in preflight

`certPaths()` gives `privateKey_FILEPATH` / `certificate_FILEPATH` precedence over the auto-resolved pair, and disables TLS outright when only one is set. preflight had the opposite order: it stopped at the auto-resolved pair and never looked at the overrides, so a stale `/etc/letsencrypt/live/<host>/` pair from an earlier certbot run hid overrides pointing at files that are absent. Preflight passed, the HTTPS listener did not start, and every page redirected to a port serving nothing.

`configuredCertPair` now resolves the pair the same way `certPaths()` does, and `httpsRedirectLoopWarning` asks whether *that* pair is present. Two new tests cover both holes: overrides missing with an auto pair on disk, and a half-set override with an auto pair on disk.

## 3 — a separate message for an unreadable path

`certMaybePresent` treats every errno but ENOENT/ENOTDIR as "maybe there", which is right — EACCES is not proof of absence — but it silently turned a permission error into a certificate. `npm run preflight` runs on the host as an ordinary user, and both `/etc/letsencrypt/live` (mode 0700 root outside the container) and a container-path `FILEPATH` give EACCES there. The loop warning stayed quiet and the operator read "All checks passed."

`certUnreadableWarning` now prints the path and its errno, says preflight cannot tell, and gives the check to run. The comment on `certMaybePresent` claimed mode 0710 with gid 1000; `certbot-entry.sh` makes that mode inside the container only, so the comment now names certbot's host default.

## 4 — bare IPv6 `gateway_HOST`

`new URL("https://::1")` throws, so the `gateway_HOST` gate added in #490 rejected `::1` and `validateEnvVars` exited 1 — a container that booted before #490 would not boot after it. `normalizeHost` now brackets an authority holding more than one colon, so `::1`, `2001:db8::5`, and `http://::1` all parse, and the already-bracketed forms are untouched. Link-local zone IDs (`fe80::1%eth0`) are still not valid URLs anywhere in the stack.

## 5 — the `https:` redirect branch dropped the port

The `http:` branch appended `portSuffix`; the `https:` branch returned `url.host` and appended nothing. `gateway_HOST=cam.example.com` (scheme defaults to `https://`) with `gateway_PORT_SECURE=8443` sent visitors to port 443, where nothing listens. The port is now taken from `gateway_HOST` only when it names one; otherwise `gateway_PORT_SECURE` is appended.

## Verification

97 test suites, 1259 tests pass. Lint reports 0 errors. New tests: an `https://` and a scheme-less `gateway_HOST` taking `gateway_PORT_SECURE`, a bare IPv6 `gateway_HOST`, IPv6 in `varProblem`, the two cert-precedence holes, and four for `certUnreadableWarning`. The account-throttle test now asserts the 10-second cost instead of the 15-minute one.
