### PR TITLE
Address xhigh review findings on #490

### DIFF
--- a/chimera/jest.config.js
+++ b/chimera/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
 	displayName: "chimera",
 	clearMocks: true,
+	restoreMocks: true,
 	moduleFileExtensions: [
 		"js",
 		"json"

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -130,9 +130,8 @@ const varProblem = (v, val) => {
 
 const isFile = (p) => { try { return fs.statSync(p).isFile() } catch { return false } }
 
-// certbot leaves /etc/letsencrypt/live mode 0700 root on the host, so stat throws EACCES for an ordinary account — only ENOENT/ENOTDIR prove the cert is absent.
-const certMaybePresent = (p) => { try { return fs.statSync(p).isFile() } catch (e) { return e.code !== "ENOENT" && e.code !== "ENOTDIR" } }
 const certUnreadable = (p) => { try { fs.statSync(p); return null } catch (e) { return e.code === "ENOENT" || e.code === "ENOTDIR" ? null : e.code } }
+const certMaybePresent = (p) => isFile(p) || certUnreadable(p) !== null
 
 const motionDirProblem = () => !isFile(MOTION) && fs.existsSync(MOTION)
 	? "is a directory — Docker creates one when the bind-mounted file is missing; run `rm -rf motion.conf && cp motion.conf.example motion.conf`"
@@ -244,19 +243,19 @@ const cookieAmbiguousHostWarning = (lines) =>
 		? "WARNING: gateway_HOST has no scheme, so it reads as https://. If browsers actually reach this deploy over http://, login loops forever — give gateway_HOST an explicit http:// prefix"
 		: null
 
-// mirrors certPaths(): the two FILEPATH overrides win over the auto-resolved pair, and one override alone disables TLS outright
+// mirrors certPaths(): the two FILEPATH overrides win over the auto-resolved pair, one override alone disables TLS outright, and an IP literal has no Let's Encrypt path
 const configuredCertPair = (lines) => {
 	const [key, cert] = ["privateKey_FILEPATH", "certificate_FILEPATH"].map(k => getVal(lines, k) || "")
-	if (key || cert) return key && cert ? [key, cert] : []
+	if (key || cert) return { paths: key && cert ? [key, cert] : [], source: "override" }
 	const hostname = urlPart(gatewayUrl(lines), "hostname")
-	if (!hostname) return []
+	if (!hostname || hostname.startsWith("[")) return { paths: [], source: "auto" }
 	const auto = letsencryptPaths(hostname)
-	return [auto.key, auto.cert]
+	return { paths: [auto.key, auto.cert], source: "auto" }
 }
 
 const certPairMaybePresent = (lines) => {
-	const pair = configuredCertPair(lines)
-	return pair.length > 0 && pair.every(certMaybePresent)
+	const { paths } = configuredCertPair(lines)
+	return paths.length > 0 && paths.every(certMaybePresent)
 }
 
 const redirectNeedsLocalCert = (lines) =>
@@ -265,16 +264,20 @@ const redirectNeedsLocalCert = (lines) =>
 
 const certUnreadableWarning = (lines) => {
 	if (!redirectNeedsLocalCert(lines)) return null
-	const unreadable = configuredCertPair(lines).map(p => [p, certUnreadable(p)]).filter(([, code]) => code)
+	const unreadable = configuredCertPair(lines).paths.map(p => [p, certUnreadable(p)]).filter(([, code]) => code)
 	return unreadable.length
 		? `WARNING: cannot read ${unreadable.map(([p, code]) => `${p} (${code})`).join(", ")} from this account, so preflight cannot tell whether the certificate is there and will not warn about the redirect loop. Check it yourself with \`sudo test -f <path>\` — /etc/letsencrypt is mode 0700 root outside the container, and a FILEPATH names a path inside the container, which docker-compose.yml need not mount from this host`
 		: null
 }
 
-const httpsRedirectLoopWarning = (lines) =>
-	redirectNeedsLocalCert(lines) && !certPairMaybePresent(lines)
-		? "WARNING: gateway_HTTPS_Redirect=true, but nothing serves https:// here and gateway_TRUST_PROXY is not true, so every page redirects to itself (ERR_TOO_MANY_REDIRECTS). Who holds the certificate?\n  this machine — set certbot_ON=true, or give privateKey_FILEPATH and certificate_FILEPATH absolute paths to your cert pair\n  a proxy or tunnel — set gateway_TRUST_PROXY=true and make it send X-Forwarded-Proto (nginx: proxy_set_header X-Forwarded-Proto $scheme)"
-		: null
+const OVERRIDE_PATH_CAVEAT = "\n  already mounted your own pair? privateKey_FILEPATH and certificate_FILEPATH name paths inside the container, and preflight can only stat this host, so it cannot see a pair your compose file mounts from somewhere other than /etc/letsencrypt"
+
+const httpsRedirectLoopWarning = (lines) => {
+	if (!redirectNeedsLocalCert(lines) || certPairMaybePresent(lines)) return null
+	const { paths, source } = configuredCertPair(lines)
+	return "WARNING: gateway_HTTPS_Redirect=true, but nothing serves https:// here and gateway_TRUST_PROXY is not true, so every page redirects to itself (ERR_TOO_MANY_REDIRECTS). Who holds the certificate?\n  this machine — set certbot_ON=true, or give privateKey_FILEPATH and certificate_FILEPATH absolute paths to your cert pair\n  a proxy or tunnel — set gateway_TRUST_PROXY=true and make it send X-Forwarded-Proto (nginx: proxy_set_header X-Forwarded-Proto $scheme)"
+		+ (source === "override" && paths.length ? OVERRIDE_PATH_CAVEAT : "")
+}
 
 const GATEWAY_PORT_SECURE_DEFAULT = "443"
 
@@ -283,7 +286,9 @@ const httpsRedirectPortWarning = (lines) => {
 	if (getVal(lines, "gateway_TRUST_PROXY") === "true") return null
 	const url = gatewayUrl(lines)
 	if (urlPart(url, "protocol") !== "https:") return null
-	const hostPort = urlPart(url, "port") || GATEWAY_PORT_SECURE_DEFAULT
+	// gateway.js only keeps the gateway_HOST port when it names one; otherwise it appends gateway_PORT_SECURE itself
+	const hostPort = urlPart(url, "port")
+	if (!hostPort) return null
 	const securePort = getVal(lines, "gateway_PORT_SECURE") || GATEWAY_PORT_SECURE_DEFAULT
 	return hostPort === securePort
 		? null

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -510,10 +510,14 @@ describe("certUnreadableWarning", () => {
 describe("httpsRedirectPortWarning", () => {
 	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
 
-	test("fires when the TLS listener is on a port gateway_HOST does not name — the redirect lands where nothing serves TLS", () => {
-		const w = httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50" }))
+	test("stays quiet when gateway_HOST names no port — gateway.js appends gateway_PORT_SECURE itself, so the redirect reaches the listener", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50" }))).toBeNull()
+	})
+
+	test("fires when the TLS listener is on a port gateway_HOST names differently — the redirect lands where nothing serves TLS", () => {
+		const w = httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50:9443" }))
 		expect(w).toMatch(/ERR_SSL_PROTOCOL_ERROR/)
-		expect(w).toMatch(/visitors to port 443 \(gateway_HOST\)/)
+		expect(w).toMatch(/visitors to port 9443 \(gateway_HOST\)/)
 		expect(w).toMatch(/terminates TLS on port 8443 \(gateway_PORT_SECURE\)/)
 	})
 

--- a/chimera/test/preflightInteractive.test.js
+++ b/chimera/test/preflightInteractive.test.js
@@ -662,7 +662,7 @@ describe("runCheck", () => {
 
 	test("prints the https redirect port warning without blocking", () => {
 		setup({
-			env: { ...BLANK, storage_ON: "false", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET, gateway_HTTPS_Redirect: "true", gateway_HOST: "https://cam.example.com", command_COOKIE_SECURE: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443" },
+			env: { ...BLANK, storage_ON: "false", livestream_ON: "false", object_ON: "false", SECRETKEY: SECRET, gateway_HTTPS_Redirect: "true", gateway_HOST: "https://cam.example.com:9443", command_COOKIE_SECURE: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443" },
 			answers: []
 		})
 		mockState.modes[".env"] = 0o640

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -1,7 +1,7 @@
 require("dotenv").config()
 const fs = require("fs")
 const path = require("path")
-const { parseSchema, isServiceOff, typeOf, isSecret, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, hashTruncated } = require("./preflight.js")
+const { parseSchema, isServiceOff, typeOf, isSecret, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certUnreadableWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, hashTruncated } = require("./preflight.js")
 const { multiInstance, validInstances } = require("../lib/utils/multiInstance.js")
 const { validTrustedSources } = require("../lib/utils/trustedSources.js")
 const gatewayHost = require("../lib/utils/gatewayHost.js")
@@ -181,6 +181,11 @@ if (process.env.certbot_ON === "true" && process.env.gateway_HTTPS_Redirect !== 
 const redirectLoop = httpsRedirectLoopWarning(envLines)
 if (redirectLoop) {
 	console.log(redirectLoop)
+}
+
+const certUnreadable = certUnreadableWarning(envLines)
+if (certUnreadable) {
+	console.log(certUnreadable)
 }
 
 const redirectPort = httpsRedirectPortWarning(envLines)

--- a/command/README.md
+++ b/command/README.md
@@ -27,7 +27,7 @@ Three access levels: public, session (`authorize`), admin (`requireAdmin`). Auth
 
 `command_ON`, `command_PORT`, `command_HOST`, `command_PROXY_ON`, `command_COOKIE_SECURE`, `SECRETKEY`, `setup_TOKEN`; see [../env.example](../env.example).
 
-`command_COOKIE_SECURE` sets the `Secure` flag on the auth cookie. It is config, not `req.secure`: `trust proxy` reads `X-Forwarded-Proto`, which a client can prepend to and the gateway's `xfwd` appends to rather than overwrites — so the request cannot be trusted to describe its own transport. Which value to pick: [env.example](../env.example).
+`command_COOKIE_SECURE` sets the `Secure` flag on the auth cookie. It is config, not `req.secure`: `trust proxy` reads `X-Forwarded-Proto`, and a client can prepend to that header — so the request cannot be trusted to describe its own transport. Which value to pick: [env.example](../env.example).
 
 ---
 # Login limits
@@ -44,7 +44,7 @@ No budget ends in a hard block. A spent budget throttles to one credential check
 
 A response under 400, or a 5xx, refunds the slot; every 4xx spends it. A request stopped at the burst stage never reaches the daily budget, which keeps a flood of 429s from draining a shared address's day.
 
-`req.ip` is the last `X-Forwarded-For` entry, which the gateway appends as its own peer, so a forged header cannot raise the limit.
+`req.ip` reads the single `X-Forwarded-For` entry the gateway writes, which is the client it resolved, so a forged header cannot raise the limit and a proxy in front of the gateway cannot collapse every visitor onto one budget.
 
 ## Device tokens
 

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -38,7 +38,7 @@ if (memoryClient) auth.connectSessionSync(memoryClient)
 
 const rateLimit = (opts) => baseRateLimit({ ...opts, releaseOnSuccess: true })
 
-const loginLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10 })
+const setupLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10 })
 
 const passwordLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 5, keyFn: (req) => `password:${req.decoded?.username ?? ""}` })
 
@@ -63,7 +63,7 @@ app.get("/status", async (req, res) => {
 	}
 })
 
-app.post("/setup", blockCrossSite, validateBody, loginLimiter, async (req, res) => {
+app.post("/setup", blockCrossSite, validateBody, setupLimiter, async (req, res) => {
 	const { username, password, token } = req.body
 	if (!timingSafeCompare(token, process.env.setup_TOKEN)) return res.status(403).json({ error: true, errors: "Setup token does not match setup_TOKEN in .env" })
 	if (typeof username !== "string") return res.status(400).json({ error: true })

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -13,7 +13,7 @@ Proxied only when `<prefix>_PROXY_ON=true`, and only when both method and path m
 - [object](../object) — GET, POST
 - [command](../command) — GET, POST, PUT, PATCH, DELETE
 
-Forwarded with `X-Forwarded-*` (`xfwd`). Any `Authorization` header on the incoming request is dropped before forwarding. The gateway does no auth of its own — each service enforces its own after the proxy hop.
+The gateway sets `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` itself rather than letting the proxy append to whatever arrived, so a backend on `trust proxy 1` reads one entry and it is the client, not the gateway or the proxy in front of it. Any `Authorization` header on the incoming request is dropped before forwarding. The gateway does no auth of its own — each service enforces its own after the proxy hop.
 
 If you run your own proxy in front of Chimera (nginx, Caddy, a load balancer), drop `Authorization` there too. Passing it through from public traffic lets an outsider act as the scheduler.
 
@@ -26,7 +26,7 @@ The gateway runs two listeners:
 
 `gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It reads `req.secure` — by default the gateway's own TLS socket, which cannot be spoofed.
 
-Everyone lands on `gateway_HOST` and `gateway_PORT_SECURE`, whatever address they typed — so pick a name every visitor can resolve, and don't put a port on it unless it is `gateway_PORT_SECURE`. With no usable `gateway_HOST` the redirect follows the browser's own `Host` header, which anyone can forge.
+Everyone lands on `gateway_HOST` and `gateway_PORT_SECURE`, whatever address they typed — so pick a name every visitor can resolve, and don't put a port on it unless it is `gateway_PORT_SECURE`. With no usable `gateway_HOST` the redirect fails closed with a 500 rather than following the browser's own `Host` header, which anyone can forge.
 
 `gateway_TRUST_PROXY=true` enables `trust proxy`, so `req.secure` reads `X-Forwarded-Proto` instead. Set it only when something in front terminates TLS (nginx, a CDN, a tunnel); the redirect loops without it. It stays opt-in because anyone who can reach `gateway_PORT` directly can forge that header and skip the redirect.
 

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -18,6 +18,9 @@ app.use("/.well-known/", express.static(path.join(__dirname, "../.well-known/"),
 
 app.use(helmet(helmetOptions))
 
+const forwardedProto = (req) => (req.headers["x-forwarded-proto"] || "").split(",").pop().trim().toLowerCase()
+const isSecure = (req) => !!req.socket.encrypted || (trustProxy && forwardedProto(req) == "https")
+
 if(process.env.gateway_HTTPS_Redirect == "true"){
 	const securePort = process.env.gateway_PORT_SECURE || 443
 	const portSuffix = trustProxy || String(securePort) == "443" ? "" : `:${securePort}`
@@ -31,18 +34,23 @@ if(process.env.gateway_HTTPS_Redirect == "true"){
 		}
 	})()
 	app.use((req, res, next) => {
-		if(req.secure || req.path.split("/")[1] == ".well-known"){
+		if(isSecure(req) || req.path.split("/")[1] == ".well-known"){
 			next()
 		}
+		else if(redirectTarget){
+			res.redirect(`https://${redirectTarget}${req.url}`)
+		}
 		else{
-			const host = (req.headers.host || "").replace(/:\d+$/, "")
-			res.redirect(`https://${redirectTarget || `${host}${portSuffix}`}${req.url}`)
+			res.status(500).send("gateway_HOST is missing or unparseable, so there is no HTTPS redirect target")
 		}
 	})
 }
 
 app.use((req, res, next) => {
 	delete req.headers.authorization
+	req.headers["x-forwarded-for"] = req.ip || req.socket.remoteAddress || ""
+	req.headers["x-forwarded-proto"] = isSecure(req) ? "https" : "http"
+	req.headers["x-forwarded-host"] = req.headers.host || ""
 	next()
 })
 
@@ -71,7 +79,6 @@ for(const apiService of services){
 		}, {
 			target: baseURL,
 			logLevel: "silent",
-			xfwd: true,
 		}))
 	}
 }

--- a/gateway/test/forwardedHeaders.test.js
+++ b/gateway/test/forwardedHeaders.test.js
@@ -1,0 +1,58 @@
+const supertest = require("supertest")
+const express = require("express")
+
+process.env.gateway_HTTPS_Redirect = "false"
+process.env.gateway_TRUST_PROXY = "false"
+process.env.command_PROXY_ON = "true"
+
+jest.mock("memory")
+jest.mock("axios")
+
+const echo = express()
+echo.get("/echo", (req, res) => res.json(req.headers))
+
+let server
+
+beforeAll((done) => {
+	server = echo.listen(0, "127.0.0.1", () => {
+		process.env.command_HOST = `http://127.0.0.1:${server.address().port}`
+		done()
+	})
+})
+
+afterAll((done) => { server.close(done) })
+
+const headersSeenBy = (request) => {
+	jest.resetModules()
+	return request(supertest(require("../gateway.js")).get("/echo")).expect(200).then((res) => res.body)
+}
+
+describe("forwarded headers reaching a proxied service", () => {
+	afterEach(() => {
+		process.env.gateway_TRUST_PROXY = "false"
+		jest.resetModules()
+	})
+
+	test("sends exactly one X-Forwarded-For, so a backend on `trust proxy 1` reads the client and not the gateway", async () => {
+		const headers = await headersSeenBy((r) => r)
+		expect(headers["x-forwarded-for"].split(",")).toHaveLength(1)
+	})
+
+	test("an untrusted client's X-Forwarded-For is replaced, not appended to", async () => {
+		const headers = await headersSeenBy((r) => r.set("X-Forwarded-For", "203.0.113.9"))
+		expect(headers["x-forwarded-for"]).not.toMatch("203.0.113.9")
+		expect(headers["x-forwarded-for"].split(",")).toHaveLength(1)
+	})
+
+	test("with gateway_TRUST_PROXY=true the front proxy's client address is passed on alone", async () => {
+		process.env.gateway_TRUST_PROXY = "true"
+		const headers = await headersSeenBy((r) => r.set("X-Forwarded-For", "203.0.113.9"))
+		expect(headers["x-forwarded-for"]).toBe("203.0.113.9")
+	})
+
+	test("an appended X-Forwarded-Proto reaches the backend as the single value the gateway resolved", async () => {
+		process.env.gateway_TRUST_PROXY = "true"
+		const headers = await headersSeenBy((r) => r.set("X-Forwarded-Proto", "https,http"))
+		expect(headers["x-forwarded-proto"]).toBe("http")
+	})
+})

--- a/gateway/test/httpsRedirect.test.js
+++ b/gateway/test/httpsRedirect.test.js
@@ -2,6 +2,7 @@ const supertest = require("supertest")
 
 process.env.gateway_HTTPS_Redirect = "true"
 process.env.gateway_TRUST_PROXY = "true"
+process.env.gateway_HOST = "https://cam.example.com"
 const gateway = require("../gateway.js")
 
 jest.mock("memory")
@@ -90,14 +91,18 @@ describe("the redirect target comes from config, not from the request", () => {
 			.expect("location", "https://cam.example.com/command/health", done)
 	})
 
-	test("falls back to the request host when gateway_HOST is unparseable", (done) => {
+	test("fails closed when gateway_HOST is unparseable, rather than letting the request pick the target", (done) => {
 		process.env.gateway_TRUST_PROXY = "false"
 		process.env.gateway_PORT_SECURE = "8443"
 		process.env.gateway_HOST = "not a valid host"
 		supertest(freshGateway())
 			.get("/command/health")
-			.set("Host", "192.168.1.50:8080")
-			.expect("location", "https://192.168.1.50:8443/command/health", done)
+			.set("Host", "phish.example.com")
+			.expect(500)
+			.expect((res) => {
+				if (res.headers.location) throw new Error("redirected to a target taken from the request")
+			})
+			.end(done)
 	})
 
 	test("a proxied deploy redirects to the gateway_HOST port, not gateway_PORT_SECURE", (done) => {

--- a/gateway/test/httpsRedirectPort.test.js
+++ b/gateway/test/httpsRedirectPort.test.js
@@ -2,7 +2,6 @@ const supertest = require("supertest")
 
 process.env.gateway_HTTPS_Redirect = "true"
 process.env.gateway_TRUST_PROXY = "false"
-process.env.gateway_HOST = ""
 
 jest.mock("memory")
 jest.mock("axios")
@@ -12,49 +11,46 @@ const freshGateway = () => {
 	return require("../gateway.js")
 }
 
-describe("gateway_HTTPS_Redirect target port", () => {
+describe("gateway_HTTPS_Redirect with no usable gateway_HOST", () => {
 	const original = process.env.gateway_PORT_SECURE
 
 	beforeEach(() => {
 		process.env.gateway_PORT_SECURE = ""
+		process.env.gateway_HOST = ""
 	})
 
 	afterEach(() => {
 		if (original === undefined) delete process.env.gateway_PORT_SECURE
 		else process.env.gateway_PORT_SECURE = original
+		delete process.env.gateway_HOST
 		jest.resetModules()
 	})
 
-	test("a request dialled on port 80 redirects with no port suffix when gateway_PORT_SECURE is unset (defaults to 443)", (done) => {
+	test("refuses the request instead of redirecting to the Host header the client sent", (done) => {
 		supertest(freshGateway())
 			.get("/command/health")
-			.set("Host", "example.com:80")
-			.expect("location", "https://example.com/command/health")
-			.expect(302, done)
+			.set("Host", "phish.example.com")
+			.expect(500)
+			.expect((res) => {
+				if (res.headers.location) throw new Error("redirected to a client-supplied target")
+			})
+			.end(done)
 	})
 
-	test("a request dialled on a non-80 port redirects to the secure port, not back to the dialled port", (done) => {
-		supertest(freshGateway())
-			.get("/command/health")
-			.set("Host", "example.com:8080")
-			.expect("location", "https://example.com/command/health")
-			.expect(302, done)
-	})
-
-	test("appends a non-443 gateway_PORT_SECURE instead of reusing the dialled port", (done) => {
+	test("refuses on a non-443 gateway_PORT_SECURE too — the port never makes the target trustworthy", (done) => {
 		process.env.gateway_PORT_SECURE = "8443"
 		supertest(freshGateway())
 			.get("/command/health")
-			.set("Host", "example.com:80")
-			.expect("location", "https://example.com:8443/command/health")
-			.expect(302, done)
+			.set("Host", "phish.example.com:8080")
+			.expect(500, done)
 	})
 
-	test("preserves an IPv6 literal host while stripping its dialled port", (done) => {
+	test("/.well-known/ stays reachable so certbot can still issue the certificate that fixes this", (done) => {
 		supertest(freshGateway())
-			.get("/command/health")
-			.set("Host", "[::1]:8080")
-			.expect("location", "https://[::1]/command/health")
-			.expect(302, done)
+			.get("/.well-known/acme-challenge/token")
+			.expect((res) => {
+				if (res.status === 500) throw new Error("blocked the ACME challenge")
+			})
+			.end(done)
 	})
 })

--- a/gateway/test/httpsRedirectUntrustedProxy.test.js
+++ b/gateway/test/httpsRedirectUntrustedProxy.test.js
@@ -2,6 +2,7 @@ const supertest = require("supertest")
 
 process.env.gateway_HTTPS_Redirect = "true"
 process.env.gateway_TRUST_PROXY = "false"
+process.env.gateway_HOST = "https://cam.example.com"
 const gateway = require("../gateway.js")
 
 jest.mock("memory")
@@ -42,5 +43,13 @@ describe("gateway_HTTPS_Redirect without gateway_TRUST_PROXY", () => {
 				if (res.status === 302) throw new Error("redirected despite a trusted X-Forwarded-Proto")
 			})
 			.end(done)
+	})
+
+	test("a trusted proxy that appends rather than overwrites does not let the client's value win", (done) => {
+		process.env.gateway_TRUST_PROXY = "true"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("X-Forwarded-Proto", "https,http")
+			.expect(302, done)
 	})
 })

--- a/lib/test/certPaths.test.js
+++ b/lib/test/certPaths.test.js
@@ -37,6 +37,14 @@ describe("certPaths", () => {
 		expect(certPaths()).toEqual({ key: "", cert: "" })
 	})
 
+	test("empty strings for an IP-literal gateway_HOST — Let's Encrypt has no path to derive", () => {
+		const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+		process.env.gateway_HOST = "::1"
+		expect(certPaths()).toEqual({ key: "", cert: "" })
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Cannot auto-resolve"), "[::1]", expect.any(String))
+		errorSpy.mockRestore()
+	})
+
 	test("falls back to privateKey_FILEPATH and certificate_FILEPATH if set", () => {
 		process.env.privateKey_FILEPATH = "/custom/key.pem"
 		process.env.certificate_FILEPATH = "/custom/cert.pem"

--- a/lib/test/normalizeHost.test.js
+++ b/lib/test/normalizeHost.test.js
@@ -1,0 +1,29 @@
+const normalizeHost = require("../utils/normalizeHost.js")
+
+const parses = (h) => { try { return new URL(normalizeHost(h)).host } catch { return null } }
+
+describe("normalizeHost", () => {
+	test("adds the implied https:// and trims trailing slashes", () => {
+		expect(normalizeHost(" cam.example.com/ ")).toBe("https://cam.example.com")
+		expect(normalizeHost("http://127.0.0.1:8080")).toBe("http://127.0.0.1:8080")
+	})
+
+	test("blank stays blank", () => {
+		expect(normalizeHost("")).toBe("")
+		expect(normalizeHost(undefined)).toBe("")
+	})
+
+	test("brackets a bare IPv6 literal so it parses", () => {
+		expect(parses("::1")).toBe("[::1]")
+		expect(parses("2001:db8::1")).toBe("[2001:db8::1]")
+	})
+
+	test("leaves an already-bracketed IPv6 host alone", () => {
+		expect(parses("[::1]:8443")).toBe("[::1]:8443")
+	})
+
+	test("does not bracket a host that carries userinfo — two colons are not an IPv6 literal", () => {
+		expect(normalizeHost("https://user:pass@cam.example.com:8443")).toBe("https://user:pass@cam.example.com:8443")
+		expect(parses("user:pass@cam.example.com:8443")).toBe("cam.example.com:8443")
+	})
+})

--- a/lib/utils/certPaths.js
+++ b/lib/utils/certPaths.js
@@ -13,6 +13,10 @@ const certPaths = () => {
 	} catch (e) {
 		console.error("Invalid gateway_HOST:", e.message)
 	}
+	if (hostname.startsWith("[")) {
+		console.error("Cannot auto-resolve a certificate for the IP literal gateway_HOST:", hostname, "— Let's Encrypt issues for domain names only. Set privateKey_FILEPATH and certificate_FILEPATH instead.")
+		hostname = ""
+	}
 	const keyOverride = process.env.privateKey_FILEPATH
 	const certOverride = process.env.certificate_FILEPATH
 	if ((keyOverride && !certOverride) || (!keyOverride && certOverride)) {

--- a/lib/utils/normalizeHost.js
+++ b/lib/utils/normalizeHost.js
@@ -2,5 +2,6 @@ module.exports = (host) => {
 	const h = (host || "").trim().replace(/\/+$/, "")
 	if (!h) return ""
 	const withScheme = /^https?:\/\//i.test(h) ? h : `https://${h}`
-	return withScheme.replace(/^(https?:\/\/)([^/[]*:[^/]*:[^/]*)$/i, "$1[$2]")
+	try { new URL(withScheme); return withScheme } catch { /* a bare IPv6 literal needs brackets before it parses */ }
+	return withScheme.replace(/^(https?:\/\/)([0-9a-f:]*:[0-9a-f:]*)$/i, "$1[$2]")
 }

--- a/lib/utils/rateLimit.js
+++ b/lib/utils/rateLimit.js
@@ -28,19 +28,18 @@ module.exports = (namespace) => {
 		const getKey = keyFn || defaultKeyFn
 		const budget = makeReserve(opts)
 		const throttle = throttleMs && makeReserve({ windowMs: throttleMs, max: 1, keyFn: (req) => `throttle:${getKey(req)}` })
+		const tooMany = (res) => res.status(429).json({ error: true, errors: "Too many attempts" })
 		const gate = (req, res, next) => budget(req, (blocked, release) => {
 			req.throttled ||= blocked
 			if (!blocked) {
 				if (opts.releaseOnSuccess) releaseOnSuccess(res, release)
 				return next()
 			}
-			if (!throttle) return res.status(429).json({ error: true, errors: "Too many attempts" })
-			throttle(req, (tooSoon) => tooSoon
-				? res.status(429).json({ error: true, errors: "Too many attempts" })
-				: next())
+			if (!throttle) return tooMany(res)
+			// no releaseOnSuccess: a throttled request never charged the budget, so releasing it would refund a guess it never spent
+			throttle(req, (tooSoon) => tooSoon ? tooMany(res) : next())
 		})
-		// skip never rejects — knownDevice answers false for a bad token, a bad signature or a failed query
-		return skip ? (req, res, next) => skip(req).then((s) => (s ? next() : gate(req, res, next))) : gate
+		return skip ? (req, res, next) => skip(req).then((s) => (s ? next() : gate(req, res, next)), () => gate(req, res, next)) : gate
 	}
 
 	return { rateLimit, client }

--- a/memory/lib/loginAttempts.js
+++ b/memory/lib/loginAttempts.js
@@ -5,7 +5,8 @@ module.exports = () => {
 		if(hits.size > 5000) for(const [k, v] of hits) if(now > v.reset) hits.delete(k)
 		if(hits.size > MAX_KEYS){
 			const target = MAX_KEYS - (MAX_KEYS >> 3)
-			for(const k of hits.keys()){
+			const soonestFirst = [...hits.entries()].sort((a, b) => a[1].reset - b[1].reset)
+			for(const [k] of soonestFirst){
 				if(hits.size <= target) break
 				hits.delete(k)
 			}

--- a/memory/test/loginAttempts.test.js
+++ b/memory/test/loginAttempts.test.js
@@ -29,6 +29,15 @@ describe("loginAttempts", () => {
 		expect(blocked).toBe(false)
 	})
 
+	test("eviction drops the soonest-to-expire keys first, so a spent daily budget outlives a flood of short-window ones", () => {
+		const { loginReserve } = makeLoginAttempts()
+		loginReserve("day:ip:attacker", 1, 24 * 60 * 60 * 1000, () => {})
+		for (let i = 0; i < 21000; i++) loginReserve(`flood-${i}`, 100, 15 * 60 * 1000, () => {})
+		let blocked
+		loginReserve("day:ip:attacker", 1, 24 * 60 * 60 * 1000, (b) => { blocked = b })
+		expect(blocked).toBe(true)
+	})
+
 	test("eviction past MAX_KEYS is age-based, not preferential to non-saturated victim counters", () => {
 		const { loginReserve } = makeLoginAttempts()
 		loginReserve("saturated-old", 1, 60000, () => {})


### PR DESCRIPTION
Addresses the xhigh review findings on #490. Targets `develop` so the fixes land on the same branch #490 proposes.

## Correctness

**`normalizeHost` bracketed any two-colon authority** — the IPv6 fix in #508 used `([^/[]*:[^/]*:[^/]*)$`, which also matched userinfo. `https://user:pass@cam.example.com:8443` became `https://[user:pass@cam.example.com:8443]`, and `validateEnvVars` then exited 1 on a value that booted before. Now it parses first and only brackets a bare hex/colon literal.

**Redirect no longer falls back to the client's `Host` header** — with no usable `gateway_HOST` the gateway answered a 302 to whatever `Host` the client sent, which is the forged-target path #490 exists to close. It now fails closed with a 500. `validateEnvVars` already exits 1 for both cases that reach it, so this is unreachable in a validated deploy.

**`req.ip` collapsed onto the proxy behind a front proxy** — `xfwd: true` made http-proxy append the gateway's peer to `X-Forwarded-For`, so with nginx in front the backends' `trust proxy 1` resolved every client to the nginx address and all users shared one rate-limit bucket. The gateway now writes `X-Forwarded-For` / `-Proto` / `-Host` itself from its own resolved `req.ip`, so backends see exactly one entry and it is the client.

**`X-Forwarded-Proto` read leftmost** — a proxy that appends rather than overwrites let a client-supplied `https` win and skip the redirect. The gateway now reads the rightmost value.

**24h budgets were evicted first under key pressure** — `loginAttempts` evicted in Map insertion order once past 20000 keys, so the new `day:ip:*` entries (which the expiry sweep cannot touch for a day) were the first to go, resetting spent daily budgets. Eviction is now soonest-to-expire first.

**Cert diagnostics** — `certUnreadableWarning` is now printed by `validateEnvVars`, not just `preflight`, so the container boot path no longer silently suppresses the redirect-loop warning on EACCES. When the pair comes from `privateKey_FILEPATH`/`certificate_FILEPATH`, the loop warning now carries a caveat that those name container paths preflight cannot stat.

**`httpsRedirectPortWarning` false alarm** — it defaulted a portless `gateway_HOST` to 443 and compared that against `gateway_PORT_SECURE`, so every correctly-configured non-443 deploy printed an `ERR_SSL_PROTOCOL_ERROR` warning about a redirect that provably works. `gateway.js` appends `gateway_PORT_SECURE` when `gateway_HOST` names no port; the check now mirrors that and only fires on an explicit disagreeing port. Two tests pinned the false positive and were rewritten.

**IP-literal `gateway_HOST`** — bracketing made `::1` parse, so `certPaths` derived `/etc/letsencrypt/live/[::1]/privkey.pem`. It now declines to auto-resolve for an IP literal and says why; `preflight` mirrors it.

## Cleanup

- `loginLimiter` → `setupLimiter`; it has only guarded `/setup` since the limiter rework.
- `certMaybePresent` is now derived from `certUnreadable` instead of being a third hand-maintained copy of the ENOENT/ENOTDIR rule.
- Dropped the two free-floating explanatory comments; `skip` rejection now fails closed onto the gate instead of relying on prose that it never rejects.
- `restoreMocks: true` in `chimera/jest.config.js` — twelve `fs.statSync` spies were restored inline, so one failing assertion left `statSync` stubbed for every later suite in the file.

## Two findings deliberately not applied

**"POST /login lost its hard per-IP 429."** The premise doesn't hold up. It compares a burst against a sustained rate. `ipDayLimiter` gates every attempt at 100/24h plus a 15-minute drip, so one IP gets ~192 guesses/day against a username; on `master` `loginLimiter` allowed 10 per 15 minutes with no daily ceiling — 960/day. The rework is ~5x stronger per day. What did regress is the opening burst: ~100 guesses in the first ~13 minutes versus ~10 in 15 minutes. Lowering `ipLimiter` max to restore it breaks "a flood against other usernames does not lock out a user sharing the egress IP", which is a deliberate property of #487. Flagging the burst trade-off rather than trading that away unasked.

**"The 24h budget is never refunded on a successful login."** Releasing on the throttled path looks right and is wrong: a throttled request never charged the budget, so releasing it is a net refund rather than an undo. That hands anyone holding one valid credential a free guess back on every success. Four existing tests guard exactly this. The lockout the finding describes was caused by the shared-proxy `req.ip` collapse, which is fixed above.

Full suite: 1271 passed, 99 suites.
