### PR TITLE
Address the 18 open review threads on #490

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,26 @@ No users exist yet, so you land on a setup screen. It wants a username, a passwo
 
 Look at the address you type in the browser, then match it:
 
-- **`http://`** — set `command_COOKIE_SECURE=false`. Give `gateway_HOST` an explicit `http://` prefix (`http://192.168.1.50:8080`) and leave `gateway_HTTPS_Redirect` and `certbot_ON` at `false`.
-- **`https://`** — set `command_COOKIE_SECURE=true`, however the certificate gets there. If something in front of Chimera holds the certificate (nginx, a CDN, a tunnel), also set `gateway_TRUST_PROXY=true`, or `gateway_HTTPS_Redirect=true` sends every page back to itself.
+| you type | `command_COOKIE_SECURE` | also do this |
+|---|---|---|
+| `http://…` | `false` | give `gateway_HOST` an explicit `http://` prefix (`http://192.168.1.50:8080`), and leave `gateway_HTTPS_Redirect` and `certbot_ON` at `false` |
+| `https://…` | `true` | if something in front of Chimera holds the certificate (nginx, a CDN, a tunnel), also set `gateway_TRUST_PROXY=true`. If you do not, `gateway_HTTPS_Redirect=true` sends every page back to itself. |
 
-Get it backwards and you pay either way: `true` on plain HTTP breaks login outright, `false` on HTTPS quietly drops the `Secure` flag from your login cookies.
+Get it backwards and you pay either way:
+
+- `true` on plain HTTP breaks the login outright.
+- `false` on HTTPS drops the `Secure` flag from your login cookies, and tells you nothing.
 
 An HTTPS port is published either way — `gateway_PORT_SECURE`, or 443 when you leave it blank — so name a free port if something else already holds 443.
 
-The config check blocks on `false` while something says HTTPS, and on `true` when `gateway_HOST` carries an explicit `http://` prefix. Left bare, the host reads as HTTPS, so `true` is merely ambiguous — the boot check warns instead of blocking. Nothing is checked when `command_ON=false`, or when `gateway_HOST` is blank or loopback.
+What the config check does:
+
+| your setting | result |
+|---|---|
+| `false`, and something says this deploy is HTTPS | blocked |
+| `true`, and `gateway_HOST` has an explicit `http://` prefix | blocked |
+| `true`, and `gateway_HOST` has no prefix | warned at boot. A bare host reads as HTTPS, so `true` is only ambiguous. |
+| `command_ON=false`, or `gateway_HOST` blank or loopback | not checked |
 
 Why the cookie can't just read the request: [command](command#config).
 

--- a/chimera/README.md
+++ b/chimera/README.md
@@ -49,7 +49,11 @@ npm run preflight -- --check # report-only, exits 1 if blocked (CI, non-TTY)
 
 - Seeding blanks every right-hand side, since `env.example` holds a description rather than a value. A line whose comment starts with `# default` is the exception — that value is real (Docker paths, Postgres host and port), so it is copied as-is and never prompted for.
 - Checks presence, types, ranges, formats, and secret length — 32+ for `SECRETKEY` and any `_AUTH` / `_TOKEN` / `_PASSWORD` key. Interactive offers a `crypto.randomBytes(32)` value for those and uses it on a blank Enter.
-- Cross-checks: `object_ON` requires `livestream_ON`; `command_COOKIE_SECURE` must be `true` on an HTTPS deploy at a non-loopback host, and `false` when `gateway_HOST` carries an explicit `http://` prefix with neither `gateway_HTTPS_Redirect` nor `certbot_ON` set; `gateway_PORT` must be `80` when `certbot_ON=true`, the only port compose publishes for the HTTP-01 challenge; no two enabled services may share a port (including `gateway_PORT` / `gateway_PORT_SECURE`), since the second to bind fails with `EADDRINUSE`.
+- Cross-checks:
+  - `object_ON` requires `livestream_ON`.
+  - `command_COOKIE_SECURE` must be `true` on an HTTPS deploy at a non-loopback host. It must be `false` when `gateway_HOST` carries an explicit `http://` prefix and neither `gateway_HTTPS_Redirect` nor `certbot_ON` is set.
+  - `gateway_PORT` must be `80` when `certbot_ON=true`. Compose publishes no other port, so nothing else can answer the HTTP-01 challenge.
+  - No two enabled services may share a port, `gateway_PORT` and `gateway_PORT_SECURE` included. The second to bind fails with `EADDRINUSE`.
 - No value may contain `#` — dotenv reads it as a comment. Checked on wizard answers and on values already in the file.
 - The walk repeats until stable, since answering one key can unskip an earlier one. `livestream_ON`/`object_ON`, `gateway_HOST`/`command_COOKIE_SECURE`, and `certbot_ON`/`gateway_PORT` are re-asked as pairs — each is valid alone, so one pass would never revisit them.
 - EOF (Ctrl-D) aborts with exit `1` and says whether anything was written. `.env` is written once, after the schema walk goes quiet, so aborting mid-walk leaves no half-filled file. Seeding and the motion.conf/camera prompts fall outside that write, so an abort there keeps a complete `.env` and any conf already created. Re-running picks up from disk.

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -20,7 +20,7 @@ try {
 const { parseConf, buildFullUrl, urlProblem } = loadCameras
 const { multiInstance, validInstances } = multiInstanceLib
 const { validTrustedSources } = trustedSourcesLib
-const { letsencryptPaths } = certPaths
+const { letsencryptPaths, isIpLiteral } = certPaths
 
 const ROOT = path.join(__dirname, "..")
 const ENV = path.join(ROOT, ".env")
@@ -130,8 +130,22 @@ const varProblem = (v, val) => {
 
 const isFile = (p) => { try { return fs.statSync(p).isFile() } catch { return false } }
 
-const certUnreadable = (p) => { try { fs.statSync(p); return null } catch (e) { return e.code === "ENOENT" || e.code === "ENOTDIR" ? null : e.code } }
-const certMaybePresent = (p) => isFile(p) || certUnreadable(p) !== null
+const ABSENT = "ENOENT"
+const certStatus = (p) => {
+	let fd
+	try {
+		fd = fs.openSync(p, "r")
+		return fs.fstatSync(fd).isFile() ? null : ABSENT
+	}
+	catch (e) {
+		return e.code === "ENOENT" || e.code === "ENOTDIR" ? ABSENT : (e.code || "EACCES")
+	}
+	finally {
+		if (fd !== undefined) fs.closeSync(fd)
+	}
+}
+const certUnreadable = (p) => { const code = certStatus(p); return code === ABSENT ? null : code }
+const certMaybePresent = (p) => certStatus(p) !== ABSENT
 
 const motionDirProblem = () => !isFile(MOTION) && fs.existsSync(MOTION)
 	? "is a directory — Docker creates one when the bind-mounted file is missing; run `rm -rf motion.conf && cp motion.conf.example motion.conf`"
@@ -243,12 +257,11 @@ const cookieAmbiguousHostWarning = (lines) =>
 		? "WARNING: gateway_HOST has no scheme, so it reads as https://. If browsers actually reach this deploy over http://, login loops forever — give gateway_HOST an explicit http:// prefix"
 		: null
 
-// mirrors certPaths(): the two FILEPATH overrides win over the auto-resolved pair, one override alone disables TLS outright, and an IP literal has no Let's Encrypt path
 const configuredCertPair = (lines) => {
 	const [key, cert] = ["privateKey_FILEPATH", "certificate_FILEPATH"].map(k => getVal(lines, k) || "")
 	if (key || cert) return { paths: key && cert ? [key, cert] : [], source: "override" }
 	const hostname = urlPart(gatewayUrl(lines), "hostname")
-	if (!hostname || hostname.startsWith("[")) return { paths: [], source: "auto" }
+	if (!hostname || isIpLiteral(hostname)) return { paths: [], source: "auto" }
 	const auto = letsencryptPaths(hostname)
 	return { paths: [auto.key, auto.cert], source: "auto" }
 }
@@ -265,12 +278,13 @@ const redirectNeedsLocalCert = (lines) =>
 const certUnreadableWarning = (lines) => {
 	if (!redirectNeedsLocalCert(lines)) return null
 	const unreadable = configuredCertPair(lines).paths.map(p => [p, certUnreadable(p)]).filter(([, code]) => code)
-	return unreadable.length
-		? `WARNING: cannot read ${unreadable.map(([p, code]) => `${p} (${code})`).join(", ")} from this account, so preflight cannot tell whether the certificate is there and will not warn about the redirect loop. Check it yourself with \`sudo test -f <path>\` — /etc/letsencrypt is mode 0700 root outside the container, and a FILEPATH names a path inside the container, which docker-compose.yml need not mount from this host`
-		: null
+	if (!unreadable.length) return null
+	const named = unreadable.map(([p, code]) => `${p} (${code})`).join(", ")
+	const blind = certPairMaybePresent(lines) ? ", and an unreadable path is not proof the certificate is absent, so the redirect-loop warning stays silent" : ""
+	return `WARNING: cannot read ${named} as this user${blind}. The gateway opens the same paths as uid 1000 and leaves the secure listener down if it cannot — /etc/letsencrypt is mode 0700 root, and a FILEPATH names a path inside the container, so docker-compose.yml must mount it and uid 1000 must be able to read it`
 }
 
-const OVERRIDE_PATH_CAVEAT = "\n  already mounted your own pair? privateKey_FILEPATH and certificate_FILEPATH name paths inside the container, and preflight can only stat this host, so it cannot see a pair your compose file mounts from somewhere other than /etc/letsencrypt"
+const OVERRIDE_PATH_CAVEAT = "\n  already mounted your own pair? privateKey_FILEPATH and certificate_FILEPATH name paths inside the container, and this check can only look at the filesystem it runs on — from the host that is the mount source, not the container path"
 
 const httpsRedirectLoopWarning = (lines) => {
 	if (!redirectNeedsLocalCert(lines) || certPairMaybePresent(lines)) return null
@@ -283,10 +297,12 @@ const GATEWAY_PORT_SECURE_DEFAULT = "443"
 
 const httpsRedirectPortWarning = (lines) => {
 	if (getVal(lines, "gateway_HTTPS_Redirect") !== "true") return null
-	if (getVal(lines, "gateway_TRUST_PROXY") === "true") return null
 	const url = gatewayUrl(lines)
-	if (urlPart(url, "protocol") !== "https:") return null
-	// gateway.js only keeps the gateway_HOST port when it names one; otherwise it appends gateway_PORT_SECURE itself
+	if (!urlPart(url, "hostname")) return null
+	if (urlPart(url, "protocol") !== "https:") {
+		return "WARNING: gateway_HTTPS_Redirect=true but gateway_HOST is http:// — the redirect always sends visitors to https://, so the scheme is ignored and any port gateway_HOST names is dropped whenever gateway_TRUST_PROXY=true, landing them on 443. Write gateway_HOST as https:// with the port browsers reach, or turn the redirect off"
+	}
+	if (getVal(lines, "gateway_TRUST_PROXY") === "true") return null
 	const hostPort = urlPart(url, "port")
 	if (!hostPort) return null
 	const securePort = getVal(lines, "gateway_PORT_SECURE") || GATEWAY_PORT_SECURE_DEFAULT
@@ -294,6 +310,9 @@ const httpsRedirectPortWarning = (lines) => {
 		? null
 		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${hostPort} (gateway_HOST), but this deploy terminates TLS on port ${securePort} (gateway_PORT_SECURE), so the redirect lands where nothing terminates TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
 }
+
+const redirectWarnings = (lines) =>
+	[httpsRedirectLoopWarning(lines), certUnreadableWarning(lines), httpsRedirectPortWarning(lines)].filter(Boolean)
 
 const certbotPortProblem = (lines) =>
 	getVal(lines, "certbot_ON") === "true" && getVal(lines, "gateway_PORT") !== "80"
@@ -372,9 +391,7 @@ const runCheck = () => {
 		if (cam.length) failed = true
 	}
 
-	for (const w of [httpsRedirectLoopWarning(lines), certUnreadableWarning(lines), httpsRedirectPortWarning(lines)]) {
-		if (w) console.log(`\n${w}`)
-	}
+	for (const w of redirectWarnings(lines)) console.log(`\n${w}`)
 
 	if (failed) {
 		console.log("\nBlocked. Run `npm run preflight` to fix interactively.")
@@ -510,9 +527,7 @@ const runInteractive = async () => {
 	const envOk = !probs.length
 	console.log(`.env ${envOk ? OK : BAD}\n`)
 
-	for (const w of [httpsRedirectLoopWarning(lines), certUnreadableWarning(lines), httpsRedirectPortWarning(lines)]) {
-		if (w) console.log(`${w}\n`)
-	}
+	for (const w of redirectWarnings(lines)) console.log(`${w}\n`)
 
 	const needCams = camerasNeeded(lines)
 	let motionOk = true, camOk = true
@@ -596,4 +611,4 @@ if (require.main === module) {
 	else runInteractive()
 }
 
-module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certUnreadableWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, setupTokenHint, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem, motionDirProblem }
+module.exports = { parseSchema, typeOf, isSecret, varProblem, cameraProblems, isServiceOff, blankDisables, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certUnreadableWarning, httpsRedirectPortWarning, redirectWarnings, certbotPortProblem, duplicatePortProblems, setupTokenHint, answerProblem, envProblems, hashTruncated, runInteractive, runCheck, readLines, getVal, setVal, looseMode, confModeProblem, motionDirProblem }

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -239,14 +239,14 @@ const insecureCookie = (lines) => {
 
 const cookieSecureProblem = (lines) =>
 	insecureCookie(lines) && (urlPart(gatewayUrl(lines), "protocol") === "https:" || getVal(lines, "gateway_HTTPS_Redirect") === "true" || getVal(lines, "certbot_ON") === "true")
-		? "command_COOKIE_SECURE MUST BE true — this deploy serves HTTPS on a non-loopback host (gateway_HOST scheme, gateway_HTTPS_Redirect, or certbot_ON), so the session cookie ships without Secure and leaks on the first plain-HTTP request. For a plain-HTTP deploy, give gateway_HOST an explicit http:// prefix and leave gateway_HTTPS_Redirect and certbot_ON false"
+		? "command_COOKIE_SECURE MUST BE true — this deploy serves HTTPS on a non-loopback host (the gateway_HOST scheme, gateway_HTTPS_Redirect, or certbot_ON says so). The session cookie ships without Secure and leaks on the first plain-HTTP request. For a plain-HTTP deploy, give gateway_HOST an explicit http:// prefix, and leave gateway_HTTPS_Redirect and certbot_ON false"
 		: null
 
 const cookiePlainHttpProblem = (lines) =>
 	!isServiceOff(lines, "command_COOKIE_SECURE") && getVal(lines, "command_COOKIE_SECURE") === "true"
 		&& /^http:\/\//i.test(rawGatewayHost(lines)) && getVal(lines, "gateway_HTTPS_Redirect") !== "true" && getVal(lines, "certbot_ON") !== "true"
 		&& !LOOPBACK.includes(urlPart(rawGatewayHost(lines), "hostname") || rawGatewayHost(lines).replace(/^https?:\/\//i, ""))
-		? "command_COOKIE_SECURE MUST BE false — gateway_HOST is http:// and neither gateway_HTTPS_Redirect nor certbot_ON marks this deploy HTTPS, so browsers drop the Secure cookie and login loops with no error. For HTTPS, terminate TLS (certbot_ON, your own certs, or a proxy) and write gateway_HOST as https://"
+		? "command_COOKIE_SECURE MUST BE false — gateway_HOST is http://, and neither gateway_HTTPS_Redirect nor certbot_ON marks this deploy as HTTPS. Browsers drop the Secure cookie, so the login loops with no error. For HTTPS, terminate TLS (certbot_ON, your own certs, or a proxy) and write gateway_HOST as https://"
 		: null
 
 const cookieAmbiguousHostWarning = (lines) =>
@@ -254,7 +254,7 @@ const cookieAmbiguousHostWarning = (lines) =>
 		&& rawGatewayHost(lines) !== "" && !/^https?:\/\//i.test(rawGatewayHost(lines))
 		&& getVal(lines, "gateway_HTTPS_Redirect") !== "true" && getVal(lines, "certbot_ON") !== "true"
 		&& !LOOPBACK.includes(urlPart(gatewayUrl(lines), "hostname") || rawGatewayHost(lines))
-		? "WARNING: gateway_HOST has no scheme, so it reads as https://. If browsers actually reach this deploy over http://, login loops forever — give gateway_HOST an explicit http:// prefix"
+		? "WARNING: gateway_HOST has no scheme, so it reads as https://. If browsers reach this deploy over http://, the login loops forever. Give gateway_HOST an explicit http:// prefix"
 		: null
 
 const configuredCertPair = (lines) => {
@@ -280,16 +280,18 @@ const certUnreadableWarning = (lines) => {
 	const unreadable = configuredCertPair(lines).paths.map(p => [p, certUnreadable(p)]).filter(([, code]) => code)
 	if (!unreadable.length) return null
 	const named = unreadable.map(([p, code]) => `${p} (${code})`).join(", ")
-	const blind = certPairMaybePresent(lines) ? ", and an unreadable path is not proof the certificate is absent, so the redirect-loop warning stays silent" : ""
-	return `WARNING: cannot read ${named} as this user${blind}. The gateway opens the same paths as uid 1000 and leaves the secure listener down if it cannot — /etc/letsencrypt is mode 0700 root, and a FILEPATH names a path inside the container, so docker-compose.yml must mount it and uid 1000 must be able to read it`
+	const blind = certPairMaybePresent(lines) ? "\n  A path this user cannot read is not proof the certificate is absent, so the redirect-loop warning stays silent." : ""
+	return `WARNING: this user cannot read ${named}.${blind}`
+		+ "\n  The gateway opens the same paths as uid 1000. If it cannot open them, the secure listener stays down."
+		+ "\n  /etc/letsencrypt is mode 0700 root. A FILEPATH names a path inside the container, so docker-compose.yml must mount it, and uid 1000 must be able to read it."
 }
 
-const OVERRIDE_PATH_CAVEAT = "\n  already mounted your own pair? privateKey_FILEPATH and certificate_FILEPATH name paths inside the container, and this check can only look at the filesystem it runs on — from the host that is the mount source, not the container path"
+const OVERRIDE_PATH_CAVEAT = "\n  Already mounted your own pair? privateKey_FILEPATH and certificate_FILEPATH name paths inside the container. This check can only look at the filesystem it runs on. From the host, that is the mount source, not the container path."
 
 const httpsRedirectLoopWarning = (lines) => {
 	if (!redirectNeedsLocalCert(lines) || certPairMaybePresent(lines)) return null
 	const { paths, source } = configuredCertPair(lines)
-	return "WARNING: gateway_HTTPS_Redirect=true, but nothing serves https:// here and gateway_TRUST_PROXY is not true, so every page redirects to itself (ERR_TOO_MANY_REDIRECTS). Who holds the certificate?\n  this machine — set certbot_ON=true, or give privateKey_FILEPATH and certificate_FILEPATH absolute paths to your cert pair\n  a proxy or tunnel — set gateway_TRUST_PROXY=true and make it send X-Forwarded-Proto (nginx: proxy_set_header X-Forwarded-Proto $scheme)"
+	return "WARNING: gateway_HTTPS_Redirect=true, but nothing here serves https:// and gateway_TRUST_PROXY is not true. Every page redirects to itself (ERR_TOO_MANY_REDIRECTS).\n  Who holds the certificate?\n  this machine — set certbot_ON=true, or give privateKey_FILEPATH and certificate_FILEPATH absolute paths to your cert pair\n  a proxy or tunnel — set gateway_TRUST_PROXY=true, and make the proxy send X-Forwarded-Proto (nginx: proxy_set_header X-Forwarded-Proto $scheme)"
 		+ (source === "override" && paths.length ? OVERRIDE_PATH_CAVEAT : "")
 }
 
@@ -300,7 +302,7 @@ const httpsRedirectPortWarning = (lines) => {
 	const url = gatewayUrl(lines)
 	if (!urlPart(url, "hostname")) return null
 	if (urlPart(url, "protocol") !== "https:") {
-		return "WARNING: gateway_HTTPS_Redirect=true but gateway_HOST is http:// — the redirect always sends visitors to https://, so the scheme is ignored and any port gateway_HOST names is dropped whenever gateway_TRUST_PROXY=true, landing them on 443. Write gateway_HOST as https:// with the port browsers reach, or turn the redirect off"
+		return "WARNING: gateway_HTTPS_Redirect=true but gateway_HOST is http://. The redirect always sends visitors to https://, so it ignores the scheme. With gateway_TRUST_PROXY=true it also drops any port gateway_HOST names and lands visitors on 443. Write gateway_HOST as https:// with the port browsers reach, or turn the redirect off"
 	}
 	if (getVal(lines, "gateway_TRUST_PROXY") === "true") return null
 	const hostPort = urlPart(url, "port")
@@ -308,7 +310,7 @@ const httpsRedirectPortWarning = (lines) => {
 	const securePort = getVal(lines, "gateway_PORT_SECURE") || GATEWAY_PORT_SECURE_DEFAULT
 	return hostPort === securePort
 		? null
-		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${hostPort} (gateway_HOST), but this deploy terminates TLS on port ${securePort} (gateway_PORT_SECURE), so the redirect lands where nothing terminates TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
+		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${hostPort} (gateway_HOST), but this deploy terminates TLS on port ${securePort} (gateway_PORT_SECURE). The redirect lands on a port that serves no TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
 }
 
 const redirectWarnings = (lines) =>

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -359,6 +359,21 @@ describe("cookieAmbiguousHostWarning", () => {
 	})
 })
 
+const mockCertFs = (readable = [], unreadable = [], code = "EACCES") => {
+	const spies = [
+		jest.spyOn(fs, "openSync").mockImplementation((p) => {
+			if (readable.includes(p)) return 3
+			const err = unreadable.includes(p) ? code : "ENOENT"
+			throw Object.assign(new Error(err), { code: err })
+		}),
+		jest.spyOn(fs, "fstatSync").mockImplementation(() => ({ isFile: () => true })),
+		jest.spyOn(fs, "closeSync").mockImplementation(() => {})
+	]
+	return () => spies.forEach(s => s.mockRestore())
+}
+
+const LE = ["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"]
+
 describe("httpsRedirectLoopWarning", () => {
 	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
 
@@ -379,18 +394,15 @@ describe("httpsRedirectLoopWarning", () => {
 	})
 
 	test("both FILEPATHs set rules it out — the operator supplied a matched certificate pair", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
-			if (["/certs/privkey.pem", "/certs/fullchain.pem"].includes(p)) return { isFile: () => true }
-			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-		})
+		const restore = mockCertFs(["/certs/privkey.pem", "/certs/fullchain.pem"])
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeNull()
-		statSpy.mockRestore()
+		restore()
 	})
 
 	test("both FILEPATHs absolute but missing on disk still fires — an absolute path alone does not prove the cert is there", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }) })
+		const restore = mockCertFs()
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeTruthy()
-		statSpy.mockRestore()
+		restore()
 	})
 
 	test("only privateKey_FILEPATH set still fires — certPaths.js requires both-or-neither and disables TLS entirely on a mismatched pair", () => {
@@ -412,63 +424,60 @@ describe("httpsRedirectLoopWarning", () => {
 	})
 
 	test("auto-resolved cert files on disk for gateway_HOST rule it out — a certbot run on the host outside chimera's own flow still holds the certificate", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
-			if (["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"].includes(p)) return { isFile: () => true }
-			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-		})
+		const restore = mockCertFs(LE)
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toBeNull()
-		statSpy.mockRestore()
+		restore()
 	})
 
 	test("still fires when only one of the two auto-resolved cert files exists", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
-			if (p === "/etc/letsencrypt/live/cam.example.com/privkey.pem") return { isFile: () => true }
-			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-		})
+		const restore = mockCertFs([LE[0]])
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toBeTruthy()
-		statSpy.mockRestore()
+		restore()
 	})
 
 	test("still fires when gateway_HOST is set but no cert files exist there yet", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }) })
+		const restore = mockCertFs()
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toBeTruthy()
-		statSpy.mockRestore()
+		restore()
+	})
+
+	test("fires for an IPv4-literal gateway_HOST — Let's Encrypt issues for domain names only, so there is no auto-resolved pair to find", () => {
+		const restore = mockCertFs()
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://192.168.1.50" }))).toBeTruthy()
+		restore()
 	})
 
 	test("stays quiet when the auto-resolved cert dir is unreadable — certbot-entry.sh leaves it mode 0710, and EACCES is not proof the cert is absent", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
-			if (["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"].includes(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" })
-			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-		})
+		const restore = mockCertFs([], LE)
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toBeNull()
+		restore()
+	})
+
+	test("a cert that stats fine but cannot be opened counts as unreadable — handleSecureServerStart reads the file, it does not stat it", () => {
+		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => ({ isFile: () => true }))
+		const restore = mockCertFs([], LE)
+		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toBeNull()
+		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toMatch("(EACCES)")
+		restore()
 		statSpy.mockRestore()
 	})
 
 	test("fires when the FILEPATH overrides are missing even though an auto-resolved pair is on disk — certPaths() gives the overrides precedence", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
-			if (["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"].includes(p)) return { isFile: () => true }
-			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-		})
+		const restore = mockCertFs(LE)
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeTruthy()
-		statSpy.mockRestore()
+		restore()
 	})
 
 	test("fires when only one FILEPATH is set and an auto-resolved pair is on disk — a half-set override disables TLS entirely", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
-			if (["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"].includes(p)) return { isFile: () => true }
-			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-		})
+		const restore = mockCertFs(LE)
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com", privateKey_FILEPATH: "/certs/privkey.pem" }))).toBeTruthy()
-		statSpy.mockRestore()
+		restore()
 	})
 
 	test("stays quiet when a configured FILEPATH is unreadable", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
-			if (["/certs/privkey.pem", "/certs/fullchain.pem"].includes(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" })
-			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-		})
+		const restore = mockCertFs([], ["/certs/privkey.pem", "/certs/fullchain.pem"])
 		expect(httpsRedirectLoopWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/certs/privkey.pem", certificate_FILEPATH: "/certs/fullchain.pem" }))).toBeNull()
-		statSpy.mockRestore()
+		restore()
 	})
 })
 
@@ -476,34 +485,42 @@ describe("certUnreadableWarning", () => {
 	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
 
 	test("names the unreadable path and its errno, so EACCES does not read as a certificate", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
-			if (["/etc/letsencrypt/live/cam.example.com/privkey.pem", "/etc/letsencrypt/live/cam.example.com/fullchain.pem"].includes(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" })
-			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-		})
+		const restore = mockCertFs([], LE)
 		const w = certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))
 		expect(w).toMatch("/etc/letsencrypt/live/cam.example.com/privkey.pem (EACCES)")
 		expect(w).toMatch("/etc/letsencrypt/live/cam.example.com/fullchain.pem (EACCES)")
-		statSpy.mockRestore()
+		expect(w).toMatch("the redirect-loop warning stays silent")
+		restore()
 	})
 
 	test("fires for an unreadable FILEPATH override — a container path need not exist on the host", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("EACCES"), { code: "EACCES" }) })
+		const restore = mockCertFs([], ["/etc/ssl/private/key.pem", "/etc/ssl/certs/cert.pem"])
 		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/etc/ssl/private/key.pem", certificate_FILEPATH: "/etc/ssl/certs/cert.pem" }))).toMatch("/etc/ssl/private/key.pem (EACCES)")
-		statSpy.mockRestore()
+		restore()
+	})
+
+	test("a mixed pair does not claim the loop warning stayed silent — one unreadable path and one missing fires both", () => {
+		const opts = { gateway_HTTPS_Redirect: "true", privateKey_FILEPATH: "/etc/ssl/private/key.pem", certificate_FILEPATH: "/etc/ssl/certs/cert.pem" }
+		const restore = mockCertFs([], ["/etc/ssl/private/key.pem"])
+		expect(httpsRedirectLoopWarning(lines(opts))).toBeTruthy()
+		const w = certUnreadableWarning(lines(opts))
+		expect(w).toMatch("/etc/ssl/private/key.pem (EACCES)")
+		expect(w).not.toMatch("stays silent")
+		restore()
 	})
 
 	test("stays quiet when the paths are merely absent — httpsRedirectLoopWarning already speaks for that", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }) })
+		const restore = mockCertFs()
 		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "false", gateway_HOST: "https://cam.example.com" }))).toBeNull()
-		statSpy.mockRestore()
+		restore()
 	})
 
 	test("stays quiet when nothing here has to hold a certificate", () => {
-		const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => { throw Object.assign(new Error("EACCES"), { code: "EACCES" }) })
+		const restore = mockCertFs([], LE)
 		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "false", gateway_HOST: "https://cam.example.com" }))).toBeNull()
 		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_TRUST_PROXY: "true", gateway_HOST: "https://cam.example.com" }))).toBeNull()
 		expect(certUnreadableWarning(lines({ gateway_HTTPS_Redirect: "true", certbot_ON: "true", gateway_HOST: "https://cam.example.com" }))).toBeNull()
-		statSpy.mockRestore()
+		restore()
 	})
 })
 
@@ -548,8 +565,12 @@ describe("httpsRedirectPortWarning", () => {
 		expect(httpsRedirectPortWarning(lines({ gateway_PORT_SECURE: "8443", gateway_HOST: "https://cam.example.com" }))).toBeNull()
 	})
 
-	test("an explicit http:// gateway_HOST names the plain port, not the TLS one, so it says nothing", () => {
-		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "http://192.168.1.50:8080" }))).toBeNull()
+	test("an explicit http:// gateway_HOST fires — the redirect targets https:// regardless, so the scheme contradicts itself", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "http://192.168.1.50:8080" }))).toMatch(/gateway_HOST is http:\/\//)
+	})
+
+	test("an http:// gateway_HOST behind a trusted proxy still fires — the port it names is the one gateway.js drops", () => {
+		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_TRUST_PROXY: "true", gateway_PORT_SECURE: "8443", gateway_HOST: "http://cam.example.com:8443" }))).toMatch(/gateway_HOST is http:\/\//)
 	})
 
 	test("a blank or unparseable gateway_HOST names no port to disagree with", () => {

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -36,7 +36,7 @@ const rawGatewayHost = (process.env.gateway_HOST || "").trim()
 if (!isServiceOff(envLines, "gateway_HOST") && rawGatewayHost !== "") {
 	try { new URL(gatewayHost()) }
 	catch {
-		console.log("gateway_HOST MUST BE A VALID URL — gateway.js builds the HTTPS redirect target from it and refuses to substitute the client-supplied Host header, so an unparseable value answers every http:// request with a 500 instead of redirecting")
+		console.log("gateway_HOST MUST BE A VALID URL — gateway.js builds the https:// redirect target from it, and will not fall back to the Host header the client sent. An unparseable value answers every http:// request with a 500 instead of a redirect")
 		allEnvPresent = false
 	}
 }
@@ -175,7 +175,7 @@ duplicatePorts.forEach(([k, p]) => {
 })
 
 if (process.env.certbot_ON === "true" && process.env.gateway_HTTPS_Redirect !== "true") {
-	console.log("WARNING: certbot_ON=true but gateway_HTTPS_Redirect is not true — port 80 keeps serving the whole app, so passwords cross the network in cleartext and the browser drops the Secure cookie, failing the login silently")
+	console.log("WARNING: certbot_ON=true but gateway_HTTPS_Redirect is not true — port 80 keeps serving the whole app. Passwords cross the network in cleartext, and the browser drops the Secure cookie, so the login fails and says nothing")
 }
 
 redirectWarnings(envLines).forEach(w => console.log(w))

--- a/chimera/validateEnvVars.js
+++ b/chimera/validateEnvVars.js
@@ -1,7 +1,7 @@
 require("dotenv").config()
 const fs = require("fs")
 const path = require("path")
-const { parseSchema, isServiceOff, typeOf, isSecret, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, httpsRedirectLoopWarning, certUnreadableWarning, httpsRedirectPortWarning, certbotPortProblem, duplicatePortProblems, hashTruncated } = require("./preflight.js")
+const { parseSchema, isServiceOff, typeOf, isSecret, objectFeedProblem, insecureCookie, cookieSecureProblem, cookiePlainHttpProblem, cookieAmbiguousHostWarning, redirectWarnings, certbotPortProblem, duplicatePortProblems, hashTruncated } = require("./preflight.js")
 const { multiInstance, validInstances } = require("../lib/utils/multiInstance.js")
 const { validTrustedSources } = require("../lib/utils/trustedSources.js")
 const gatewayHost = require("../lib/utils/gatewayHost.js")
@@ -36,7 +36,7 @@ const rawGatewayHost = (process.env.gateway_HOST || "").trim()
 if (!isServiceOff(envLines, "gateway_HOST") && rawGatewayHost !== "") {
 	try { new URL(gatewayHost()) }
 	catch {
-		console.log("gateway_HOST MUST BE A VALID URL — an unparseable value falls back to the client-supplied Host header (gateway.js reads req.headers.host, whatever gateway_TRUST_PROXY says), letting a forged Host pick the HTTPS redirect target")
+		console.log("gateway_HOST MUST BE A VALID URL — gateway.js builds the HTTPS redirect target from it and refuses to substitute the client-supplied Host header, so an unparseable value answers every http:// request with a 500 instead of redirecting")
 		allEnvPresent = false
 	}
 }
@@ -178,20 +178,7 @@ if (process.env.certbot_ON === "true" && process.env.gateway_HTTPS_Redirect !== 
 	console.log("WARNING: certbot_ON=true but gateway_HTTPS_Redirect is not true — port 80 keeps serving the whole app, so passwords cross the network in cleartext and the browser drops the Secure cookie, failing the login silently")
 }
 
-const redirectLoop = httpsRedirectLoopWarning(envLines)
-if (redirectLoop) {
-	console.log(redirectLoop)
-}
-
-const certUnreadable = certUnreadableWarning(envLines)
-if (certUnreadable) {
-	console.log(certUnreadable)
-}
-
-const redirectPort = httpsRedirectPortWarning(envLines)
-if (redirectPort) {
-	console.log(redirectPort)
-}
+redirectWarnings(envLines).forEach(w => console.log(w))
 
 const LOOPBACK = ["localhost", "127.0.0.1", "::1", "[::1]"]
 const originOf = (url) => { try { return new URL(url).host } catch { return "" } }

--- a/command/README.md
+++ b/command/README.md
@@ -44,7 +44,7 @@ No budget ends in a hard block. A spent budget throttles to one credential check
 
 A response under 400, or a 5xx, refunds the slot; every 4xx spends it. A request stopped at the burst stage never reaches the daily budget, which keeps a flood of 429s from draining a shared address's day.
 
-`req.ip` reads the single `X-Forwarded-For` entry the gateway writes, so a header a client forged cannot raise the limit. This holds only while the gateway is the sole reachable port — a published `command_PORT` or an off-box `command_HOST` lets anyone write that entry and shop for a key. What the entry names depends on `gateway_TRUST_PROXY`: with it off the gateway records its own peer, which behind a front proxy is that proxy; with it on, and that proxy setting `X-Forwarded-For`, each client gets its own budget.
+`req.ip` reads the single `X-Forwarded-For` entry the gateway writes, so a forged header cannot buy a fresh budget — but only while the gateway is the sole reachable port. A published `command_PORT` or an off-box `command_HOST` lets anyone write that entry and shop for a key. What the entry names follows `gateway_TRUST_PROXY`: off, it is the gateway's peer, which behind a front proxy is that proxy; on, it is the client the proxy named.
 
 ## Device tokens
 
@@ -57,7 +57,7 @@ The cookie also carries `dk`, a SHA-256 digest of the password hash it was issue
 These budgets are tuned to keep legitimate users in, not to guarantee an attacker is stopped. The consequences:
 
 - Any proxy in front of the gateway (CDN, nginx, tunnel) becomes that peer unless `gateway_TRUST_PROXY=true`, so by default the whole site shares one set of per-IP budgets.
-- The account budget throttles to one check every 10 seconds, not one per window, so an attacker rotating source addresses still gets roughly 8,600 guesses a day at one username — the per-IP budgets cap each address, not the account. A longer throttle would instead let that attacker hold a user with no device token out of their own account.
+- The account budget throttles to one check every 10 seconds, not one per window, so an attacker rotating addresses still gets ~8,600 guesses a day at one username. A longer throttle would instead let them hold a user with no device token out of their own account.
 - Clients behind one egress IP (home router, CGNAT) share the per-IP budgets and contend for the single throttle slot, even when the attack targets someone else.
 - A throttle slot is one per key and any request takes it, so a user with no device token waits out the window an attacker is holding.
 - `knownDevice` matches username and current password hash, not a live session, so a shared browser lets a later user inherit the skip.

--- a/command/README.md
+++ b/command/README.md
@@ -27,39 +27,49 @@ Three access levels: public, session (`authorize`), admin (`requireAdmin`). Auth
 
 `command_ON`, `command_PORT`, `command_HOST`, `command_PROXY_ON`, `command_COOKIE_SECURE`, `SECRETKEY`, `setup_TOKEN`; see [../env.example](../env.example).
 
-`command_COOKIE_SECURE` sets the `Secure` flag on the auth cookie. It is config, not `req.secure`: `trust proxy` reads `X-Forwarded-Proto`, and a client can prepend to that header — so the request cannot be trusted to describe its own transport. Which value to pick: [env.example](../env.example).
+`command_COOKIE_SECURE` sets the `Secure` flag on the auth cookie. It is a config value, not `req.secure`. With `trust proxy`, `req.secure` reads `X-Forwarded-Proto`, and a client can add a value at the start of that header. A request therefore cannot be trusted to describe its own transport. To pick a value: [env.example](../env.example).
 
 ---
 # Login limits
 
-`POST /authorization/login` spends three budgets in order, then checks the password. Allowances, windows, and throttle intervals live in [authorization.js](backend/routes/authorization.js).
+`POST /authorization/login` counts against three limits in order, then it checks the password. [authorization.js](backend/routes/authorization.js) holds the allowances, the windows, and the throttle intervals.
 
-| budget | keyed on | skipped by a device token |
+| limit | counted per | a device token skips it |
 |---|---|---|
-| burst | IP | no |
-| daily | IP | yes |
+| burst | IP address | no |
+| daily | IP address | yes |
 | account | username | yes |
 
-No budget ends in a hard block. A spent budget throttles to one credential check per window; extra requests get 429 immediately and nothing queues, so a flood cannot build latency. That one check also answers 429 on a wrong password — a 429 does not prove the credentials went unchecked.
+No limit ends in a hard block. Once a limit is used up, the route runs one password check per window and answers 429 to every other request at once. Nothing waits in a queue, so a flood cannot build latency. That one check also answers 429 when the password is wrong, so a 429 does not prove the password went unchecked.
 
-A response under 400, or a 5xx, refunds the slot; every 4xx spends it. A request stopped at the burst stage never reaches the daily budget, which keeps a flood of 429s from draining a shared address's day.
+| response | the slot is |
+|---|---|
+| below 400 | refunded |
+| 4xx | used |
+| 5xx | refunded |
 
-The gateway overwrites `X-Forwarded-For` with one entry of its own, so a client cannot fake the address `req.ip` returns. This only holds while the gateway is the one reachable port. A published `command_PORT` or an off-box `command_HOST` lets anyone set that header and pick their own budget key. `gateway_TRUST_PROXY` sets what the entry holds: `false`, the address the gateway sees, which is your front proxy if you run one; `true`, the client address that proxy reports.
+A request that the burst limit stops never reaches the daily limit. A flood of 429s therefore cannot use up the day of a shared address.
+
+## Which address the limits count
+
+The gateway replaces `X-Forwarded-For` with one value of its own, so a client cannot fake the address that `req.ip` returns. This holds only while the gateway is the one port outsiders can reach. A published `command_PORT`, or a `command_HOST` on another machine, lets anyone write that header and choose their own key. Which address the gateway writes: [gateway](../gateway#headers).
 
 ## Device tokens
 
-A successful login sets `devicetoken`, a year-long signed `httpOnly` cookie naming the username. It skips the budgets marked above, so no one else's failures can lock a user out of a device they already use. The burst budget still applies, so a stolen token is still capped.
+A successful login sets `devicetoken`. It is a signed `httpOnly` cookie, it lasts one year, and it names the username. It skips the limits marked above, so the failures of other people cannot lock a user out of a device they already use. The burst limit still applies, so a stolen token is still capped.
 
-The cookie also carries `dk`, a SHA-256 digest of the password hash it was issued against, which `knownDevice` re-checks on every login. A password change therefore voids every token for that username — the remediation path for a stolen device, since revoking sessions alone does not void the cookie. Logout keeps it on purpose; it exists to survive session expiry.
+The cookie also carries `dk`, a SHA-256 digest of the password hash it was issued against. `knownDevice` re-checks `dk` at every login. A password change therefore voids every token for that username. This is how you recover from a stolen device: if you only revoke the sessions, the cookie stays valid. Logout keeps the cookie on purpose, because the cookie has to survive the end of a session.
 
-## What this does not do
+## What these limits do not do
 
-These budgets are tuned to keep legitimate users in, not to guarantee an attacker is stopped. The consequences:
+These limits are tuned to keep real users in. They do not guarantee that an attacker is stopped. The costs:
 
-- Any proxy in front of the gateway (CDN, nginx, tunnel) becomes that peer unless `gateway_TRUST_PROXY=true`, so by default the whole site shares one set of per-IP budgets.
-- The account budget throttles to one check every 10 seconds, not one per window, so an attacker rotating addresses still gets ~8,600 guesses a day at one username. A longer throttle would instead let them hold a user with no device token out of their own account.
-- Clients behind one egress IP (home router, CGNAT) share the per-IP budgets and contend for the single throttle slot, even when the attack targets someone else.
-- A throttle slot is one per key and any request takes it, so a user with no device token waits out the window an attacker is holding.
-- `knownDevice` matches username and current password hash, not a live session, so a shared browser lets a later user inherit the skip.
-- Nothing caps attempts across addresses. Run a cluster (`chimeraInstances`) to spread the load; it also forces `memory_ON=true`, which keeps the budgets shared.
-- `bcryptjs` holds the event loop for a whole cost-10 check, so concurrent logins from one address stall every route.
+| the limit | what it costs you |
+|---|---|
+| `gateway_TRUST_PROXY` is not `true` | every visitor behind a front proxy (CDN, nginx, tunnel) counts as one address, so the whole site shares one set of per-IP limits |
+| the account limit throttles to one check per 10 seconds, not one per window | an attacker who changes address still gets about 8,600 guesses a day at one username. A longer throttle would instead let the attacker hold a user with no device token out of their own account. |
+| clients share one exit address (home router, CGNAT) | they share the per-IP limits and compete for the single throttle slot, even when the attack targets somebody else |
+| a key has one throttle slot, and any request takes it | a user with no device token waits out the window that an attacker holds |
+| `knownDevice` matches the username and the current password hash, not a live session | on a shared browser, a later user inherits the skip |
+| nothing caps attempts across addresses | run a cluster (`chimeraInstances`) to spread the load. A cluster also forces `memory_ON=true`, which keeps the limits shared. |
+| `bcryptjs` holds the event loop for a whole cost-10 check | many logins at once from one address stall every route |

--- a/command/README.md
+++ b/command/README.md
@@ -44,7 +44,7 @@ No budget ends in a hard block. A spent budget throttles to one credential check
 
 A response under 400, or a 5xx, refunds the slot; every 4xx spends it. A request stopped at the burst stage never reaches the daily budget, which keeps a flood of 429s from draining a shared address's day.
 
-`req.ip` reads the single `X-Forwarded-For` entry the gateway writes, which is the client it resolved, so a forged header cannot raise the limit and a proxy in front of the gateway cannot collapse every visitor onto one budget.
+`req.ip` reads the single `X-Forwarded-For` entry the gateway writes, so a header a client forged cannot raise the limit. This holds only while the gateway is the sole reachable port — a published `command_PORT` or an off-box `command_HOST` lets anyone write that entry and shop for a key. What the entry names depends on `gateway_TRUST_PROXY`: with it off the gateway records its own peer, which behind a front proxy is that proxy; with it on, and that proxy setting `X-Forwarded-For`, each client gets its own budget.
 
 ## Device tokens
 
@@ -56,7 +56,8 @@ The cookie also carries `dk`, a SHA-256 digest of the password hash it was issue
 
 These budgets are tuned to keep legitimate users in, not to guarantee an attacker is stopped. The consequences:
 
-- Any proxy in front of the gateway (CDN, nginx, tunnel) becomes that peer, so the whole site shares one set of per-IP budgets.
+- Any proxy in front of the gateway (CDN, nginx, tunnel) becomes that peer unless `gateway_TRUST_PROXY=true`, so by default the whole site shares one set of per-IP budgets.
+- The account budget throttles to one check every 10 seconds, not one per window, so an attacker rotating source addresses still gets roughly 8,600 guesses a day at one username — the per-IP budgets cap each address, not the account. A longer throttle would instead let that attacker hold a user with no device token out of their own account.
 - Clients behind one egress IP (home router, CGNAT) share the per-IP budgets and contend for the single throttle slot, even when the attack targets someone else.
 - A throttle slot is one per key and any request takes it, so a user with no device token waits out the window an attacker is holding.
 - `knownDevice` matches username and current password hash, not a live session, so a shared browser lets a later user inherit the skip.

--- a/command/README.md
+++ b/command/README.md
@@ -44,7 +44,7 @@ No budget ends in a hard block. A spent budget throttles to one credential check
 
 A response under 400, or a 5xx, refunds the slot; every 4xx spends it. A request stopped at the burst stage never reaches the daily budget, which keeps a flood of 429s from draining a shared address's day.
 
-`req.ip` reads the single `X-Forwarded-For` entry the gateway writes, so a forged header cannot buy a fresh budget — but only while the gateway is the sole reachable port. A published `command_PORT` or an off-box `command_HOST` lets anyone write that entry and shop for a key. What the entry names follows `gateway_TRUST_PROXY`: off, it is the gateway's peer, which behind a front proxy is that proxy; on, it is the client the proxy named.
+The gateway overwrites `X-Forwarded-For` with one entry of its own, so a client cannot fake the address `req.ip` returns. This only holds while the gateway is the one reachable port. A published `command_PORT` or an off-box `command_HOST` lets anyone set that header and pick their own budget key. `gateway_TRUST_PROXY` sets what the entry holds: `false`, the address the gateway sees, which is your front proxy if you run one; `true`, the client address that proxy reports.
 
 ## Device tokens
 

--- a/env.example
+++ b/env.example
@@ -33,7 +33,7 @@ certbot_ON = (true | false) Auto-issue and renew Let's Encrypt certs. Needs gate
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
 gateway_HTTPS_Redirect = (true | false) Sends http:// visitors to https://. Behind a proxy it needs gateway_TRUST_PROXY=true, or pages redirect to themselves. ***
-gateway_TRUST_PROXY = (true | false) Believe X-Forwarded-For and X-Forwarded-Proto from the proxy or tunnel in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). It decides the https:// redirect above and the address the per-IP login budgets key on: false records the gateway's own peer, so behind a front proxy every visitor shares one budget; true records the client that proxy names. Set true only when nothing but that proxy can reach gateway_PORT — anyone who can reach it forges both headers, skipping the redirect and picking their own login budget. ***
+gateway_TRUST_PROXY = (true | false) Believe X-Forwarded-For and X-Forwarded-Proto from the proxy or tunnel in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). Decides the https:// redirect above and which address the per-IP login budgets key on: false, every visitor behind a front proxy shares one budget; true, each gets their own. Set true only when nothing but that proxy can reach gateway_PORT — anyone who can forges both headers, skipping the redirect and picking their own budget. ***
 
 ##################################################################
 # Command

--- a/env.example
+++ b/env.example
@@ -25,17 +25,17 @@ SECRETKEY = Auth secret key for hashing, min 32 characters
 
 gateway_PORT = Gateway http port (must be 80 when certbot_ON=true)
 gateway_HOST = https://gateway.server.example or http://127.0.0.1:8080 (protocol defaults to https:// if omitted)
-# gateway_HOST is also the HTTPS redirect target — every http:// visitor lands on this name and gateway_PORT_SECURE, whatever host they typed
+# gateway_HOST is also the target of the https:// redirect. Every http:// visitor lands on this name and gateway_PORT_SECURE, whatever host they typed.
 
 gateway_PORT_SECURE = Gateway https port (default 443) ***
-certbot_ON = (true | false) Auto-issue and renew Let's Encrypt certs. Needs gateway_HOST to be a public domain pointing at this machine, with port 80 open. Leave false to supply your own certs below.
-# TLS certs auto-resolve to /etc/letsencrypt/live/<gateway_HOST domain>/{privkey,fullchain}.pem
-privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
-certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
-gateway_HTTPS_Redirect = (true | false) Sends http:// visitors to https://. Behind a proxy it needs gateway_TRUST_PROXY=true, or pages redirect to themselves. ***
+certbot_ON = (true | false) Get and renew Let's Encrypt certs automatically. Needs gateway_HOST to be a public domain that points at this machine, with port 80 open. Leave false to supply your own certs below.
+# Without the two FILEPATHs below, the gateway looks for the certs at /etc/letsencrypt/live/<gateway_HOST domain>/{privkey,fullchain}.pem
+privateKey_FILEPATH = Custom TLS private key path (set both FILEPATHs, or neither) ***
+certificate_FILEPATH = Custom TLS certificate path (set both FILEPATHs, or neither) ***
+gateway_HTTPS_Redirect = (true | false) Send http:// visitors to https://. Behind a proxy, also set gateway_TRUST_PROXY=true, or every page redirects to itself. ***
 gateway_TRUST_PROXY = (true | false) Trust X-Forwarded-For and X-Forwarded-Proto from the proxy in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). ***
-# false: everyone behind that proxy looks like one address, so they share one per-IP login budget, and the redirect cannot see a request was already https
-# true: each visitor gets their own address and budget, and the redirect works. Only set true if nothing but the proxy can reach gateway_PORT — anyone who reaches it directly can fake both headers
+# false: the gateway sees every visitor behind that proxy as one address. They share one per-IP login limit, and the redirect cannot tell that the visit was already https.
+# true: each visitor gets their own address and their own limit, and the redirect works. Set true only when nothing but the proxy can reach gateway_PORT, because anyone who reaches it directly can forge both headers.
 
 ##################################################################
 # Command
@@ -45,7 +45,7 @@ command_ON = (true | false)
 command_PROXY_ON = (true | false)
 command_PORT = Command http port
 command_HOST = https://command.server.example or http://127.0.0.1:8081
-command_COOKIE_SECURE = (true | false) Secure flag on the auth cookie. true when browsers reach the site over HTTPS, however TLS is terminated; false only for plain-HTTP deploys, where browsers drop a Secure cookie and login breaks.
+command_COOKIE_SECURE = (true | false) Secure flag on the auth cookie. Set true when browsers reach the site over HTTPS, whatever terminates TLS. Set false only for a plain-HTTP deploy, where browsers drop a Secure cookie and the login breaks.
 setup_TOKEN = Token gating /authorization/setup, min 32 characters. Creates the first admin only when none exists; cannot reset an existing one.
 
 ##################################################################

--- a/env.example
+++ b/env.example
@@ -33,7 +33,9 @@ certbot_ON = (true | false) Auto-issue and renew Let's Encrypt certs. Needs gate
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
 gateway_HTTPS_Redirect = (true | false) Sends http:// visitors to https://. Behind a proxy it needs gateway_TRUST_PROXY=true, or pages redirect to themselves. ***
-gateway_TRUST_PROXY = (true | false) Believe X-Forwarded-For and X-Forwarded-Proto from the proxy or tunnel in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). Decides the https:// redirect above and which address the per-IP login budgets key on: false, every visitor behind a front proxy shares one budget; true, each gets their own. Set true only when nothing but that proxy can reach gateway_PORT — anyone who can forges both headers, skipping the redirect and picking their own budget. ***
+gateway_TRUST_PROXY = (true | false) Trust X-Forwarded-For and X-Forwarded-Proto from the proxy in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). ***
+# false: everyone behind that proxy looks like one address, so they share one per-IP login budget, and the redirect cannot see a request was already https
+# true: each visitor gets their own address and budget, and the redirect works. Only set true if nothing but the proxy can reach gateway_PORT — anyone who reaches it directly can fake both headers
 
 ##################################################################
 # Command

--- a/env.example
+++ b/env.example
@@ -33,7 +33,7 @@ certbot_ON = (true | false) Auto-issue and renew Let's Encrypt certs. Needs gate
 privateKey_FILEPATH = Custom TLS private key path (overrides auto-resolve) ***
 certificate_FILEPATH = Custom TLS certificate path (overrides auto-resolve) ***
 gateway_HTTPS_Redirect = (true | false) Sends http:// visitors to https://. Behind a proxy it needs gateway_TRUST_PROXY=true, or pages redirect to themselves. ***
-gateway_TRUST_PROXY = (true | false) Believe X-Forwarded-Proto from the proxy or tunnel in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). It only decides the https:// redirect above; per-IP login budgets key off the address the gateway itself sees either way. Set true only when nothing but that proxy can reach gateway_PORT — anyone who can reach it forges the header and skips the redirect. ***
+gateway_TRUST_PROXY = (true | false) Believe X-Forwarded-For and X-Forwarded-Proto from the proxy or tunnel in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). It decides the https:// redirect above and the address the per-IP login budgets key on: false records the gateway's own peer, so behind a front proxy every visitor shares one budget; true records the client that proxy names. Set true only when nothing but that proxy can reach gateway_PORT — anyone who can reach it forges both headers, skipping the redirect and picking their own login budget. ***
 
 ##################################################################
 # Command

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -13,7 +13,7 @@ Proxied only when `<prefix>_PROXY_ON=true`, and only when both method and path m
 - [object](../object) — GET, POST
 - [command](../command) — GET, POST, PUT, PATCH, DELETE
 
-The gateway sets `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` itself rather than letting the proxy append to whatever arrived, so a backend on `trust proxy 1` reads exactly one entry and a client cannot prepend to it. That entry is whatever the gateway resolved as the caller: its own peer by default — the proxy in front, if there is one — or the client that proxy names, once `gateway_TRUST_PROXY=true`. Turning the flag on therefore trusts whatever reaches `gateway_PORT` to name its own address, which is why it stays opt-in. Any `Authorization` header on the incoming request is dropped before forwarding. The gateway does no auth of its own — each service enforces its own after the proxy hop.
+The gateway sets `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` itself rather than letting the proxy append to whatever arrived, so a backend on `trust proxy 1` reads exactly one entry and no client can prepend to it. That entry is the gateway's own peer — a proxy in front, if there is one — unless `gateway_TRUST_PROXY=true`, which takes the client that proxy names instead. Any `Authorization` header on the incoming request is dropped before forwarding. The gateway does no auth of its own — each service enforces its own after the proxy hop.
 
 If you run your own proxy in front of Chimera (nginx, Caddy, a load balancer), drop `Authorization` there too. Passing it through from public traffic lets an outsider act as the scheduler.
 
@@ -24,11 +24,11 @@ The gateway runs two listeners:
 - `gateway_PORT` — HTTP.
 - `gateway_PORT_SECURE` — HTTPS, key/cert auto-resolved from `gateway_HOST` under `/etc/letsencrypt/live/` (override with `privateKey_FILEPATH` / `certificate_FILEPATH` — both or neither); if either is unreadable the secure listener stays down.
 
-`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It deliberately does not use Express's `req.secure`; by default it reads the gateway's own TLS socket, which cannot be spoofed.
+`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. By default it reads the gateway's own TLS socket, which cannot be spoofed.
 
 Everyone lands on `gateway_HOST` and `gateway_PORT_SECURE`, whatever address they typed — so pick a name every visitor can resolve, and don't put a port on it unless it is `gateway_PORT_SECURE`. With no usable `gateway_HOST` the redirect fails closed with a 500 rather than following the browser's own `Host` header, which anyone can forge.
 
-`gateway_TRUST_PROXY=true` enables `trust proxy`, and the redirect then also accepts `X-Forwarded-Proto` — the **last** entry, which the front proxy appended, not the first, which a client can prepend. `req.secure` takes the first, so reaching for it here reopens that bypass. Set the flag only when something in front terminates TLS (nginx, a CDN, a tunnel); the redirect loops without it. It stays opt-in because anyone who can reach `gateway_PORT` directly can forge that header and skip the redirect.
+`gateway_TRUST_PROXY=true` enables `trust proxy`, and the redirect then also accepts `X-Forwarded-Proto` — the **last** entry, set by the proxy in front, not the first, which a client can prepend. Express's `req.secure` takes the first, which is why it is not used here. Set the flag only when something in front terminates TLS (nginx, a CDN, a tunnel); the redirect loops without it, and anyone who can reach `gateway_PORT` directly can forge the header and skip it.
 
 ---
 # ACME challenges

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -13,7 +13,9 @@ Proxied only when `<prefix>_PROXY_ON=true`, and only when both method and path m
 - [object](../object) — GET, POST
 - [command](../command) — GET, POST, PUT, PATCH, DELETE
 
-The gateway sets `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` itself rather than letting the proxy append to whatever arrived, so a backend on `trust proxy 1` reads exactly one entry and no client can prepend to it. That entry is the gateway's own peer — a proxy in front, if there is one — unless `gateway_TRUST_PROXY=true`, which takes the client that proxy names instead. Any `Authorization` header on the incoming request is dropped before forwarding. The gateway does no auth of its own — each service enforces its own after the proxy hop.
+The gateway writes `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` from scratch instead of appending to what the client sent, so a backend on `trust proxy 1` sees exactly one entry and no client can add one in front of it. `gateway_TRUST_PROXY` sets what that entry holds: `false`, the address the gateway sees, which is your front proxy if you run one; `true`, the client address that proxy reports.
+
+The gateway deletes any `Authorization` header before forwarding. It does no auth itself; each service checks its own.
 
 If you run your own proxy in front of Chimera (nginx, Caddy, a load balancer), drop `Authorization` there too. Passing it through from public traffic lets an outsider act as the scheduler.
 
@@ -28,7 +30,9 @@ The gateway runs two listeners:
 
 Everyone lands on `gateway_HOST` and `gateway_PORT_SECURE`, whatever address they typed — so pick a name every visitor can resolve, and don't put a port on it unless it is `gateway_PORT_SECURE`. With no usable `gateway_HOST` the redirect fails closed with a 500 rather than following the browser's own `Host` header, which anyone can forge.
 
-`gateway_TRUST_PROXY=true` enables `trust proxy`, and the redirect then also accepts `X-Forwarded-Proto` — the **last** entry, set by the proxy in front, not the first, which a client can prepend. Express's `req.secure` takes the first, which is why it is not used here. Set the flag only when something in front terminates TLS (nginx, a CDN, a tunnel); the redirect loops without it, and anyone who can reach `gateway_PORT` directly can forge the header and skip it.
+`gateway_TRUST_PROXY=true` turns on Express `trust proxy`. The redirect then also counts a request as secure if `X-Forwarded-Proto` says `https`. It reads the **last** value in that header: each proxy appends, so the last one comes from the proxy in front, while anything a client writes lands first and is ignored. Express's `req.secure` reads the first value, which is why the code does not use it.
+
+Set the flag only when something in front terminates TLS (nginx, a CDN, a tunnel), and keep `gateway_PORT` closed to everything but that proxy. Without the flag the redirect loops; with it, anyone who reaches `gateway_PORT` directly can fake the header and skip the redirect.
 
 ---
 # ACME challenges

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,45 +1,95 @@
 # Gateway <img src="../command/frontend/res/logo.png" alt="logo" width="20"/> 
 
-Reverse proxy and single public entrypoint; matches each request by method + path ([services.js](services.js)) and forwards it to that service's `<prefix>_HOST`.
+Reverse proxy and the only public entry point. It matches each request by method and path ([services.js](services.js)), then sends the request to that service's `<prefix>_HOST`.
 
 ---
 # Proxied services
 
-Proxied only when `<prefix>_PROXY_ON=true`, and only when both method and path match its start-anchored regexes ([services.js](services.js)):
+The gateway forwards a request only when both of these are true:
 
-- [storage](../storage) — GET, POST, DELETE
-- [schedule](../schedule) — GET, POST
-- [livestream](../livestream) — GET, POST
-- [object](../object) — GET, POST
-- [command](../command) — GET, POST, PUT, PATCH, DELETE
+1. `<prefix>_PROXY_ON=true`.
+2. The method and the path match that service's start-anchored regexes ([services.js](services.js)).
 
-The gateway writes `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` from scratch instead of appending to what the client sent, so a backend on `trust proxy 1` sees exactly one entry and no client can add one in front of it. `gateway_TRUST_PROXY` sets what that entry holds: `false`, the address the gateway sees, which is your front proxy if you run one; `true`, the client address that proxy reports.
+| service | methods |
+|---|---|
+| [storage](../storage) | GET, POST, DELETE |
+| [schedule](../schedule) | GET, POST |
+| [livestream](../livestream) | GET, POST |
+| [object](../object) | GET, POST |
+| [command](../command) | GET, POST, PUT, PATCH, DELETE |
 
-The gateway deletes any `Authorization` header before forwarding. It does no auth itself; each service checks its own.
+## Headers
 
-If you run your own proxy in front of Chimera (nginx, Caddy, a load balancer), drop `Authorization` there too. Passing it through from public traffic lets an outsider act as the scheduler.
+The gateway writes `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` itself. It does not add to the values that arrived with the request. A backend on `trust proxy 1` therefore reads exactly one value, and no client can put a value in front of it.
+
+`gateway_TRUST_PROXY` selects the address that goes in `X-Forwarded-For`:
+
+| `gateway_TRUST_PROXY` | address the gateway writes |
+|---|---|
+| `false` | the address the gateway sees. This is your own proxy, if you run one in front. |
+| `true` | the client address that your own proxy reports |
+
+The gateway deletes any `Authorization` header before it forwards the request. The gateway runs no authentication of its own. Each service runs its own after the proxy hop.
+
+If you run your own proxy in front of Chimera (nginx, Caddy, a load balancer), delete `Authorization` there too. If you let it through from public traffic, an outsider can act as the scheduler.
 
 ---
 # Ports & TLS
 
-The gateway runs two listeners:
-- `gateway_PORT` — HTTP.
-- `gateway_PORT_SECURE` — HTTPS, key/cert auto-resolved from `gateway_HOST` under `/etc/letsencrypt/live/` (override with `privateKey_FILEPATH` / `certificate_FILEPATH` — both or neither); if either is unreadable the secure listener stays down.
+The gateway opens two listeners:
 
-`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. By default it reads the gateway's own TLS socket, which cannot be spoofed.
+| listener | port | opens when |
+|---|---|---|
+| HTTP | `gateway_PORT` | always |
+| HTTPS | `gateway_PORT_SECURE` (default 443) | the gateway can read both the key and the certificate |
 
-Everyone lands on `gateway_HOST` and `gateway_PORT_SECURE`, whatever address they typed — so pick a name every visitor can resolve, and don't put a port on it unless it is `gateway_PORT_SECURE`. With no usable `gateway_HOST` the redirect fails closed with a 500 rather than following the browser's own `Host` header, which anyone can forge.
+Where the gateway looks for the pair:
 
-`gateway_TRUST_PROXY=true` turns on Express `trust proxy`. The redirect then also counts a request as secure if `X-Forwarded-Proto` says `https`. It reads the **last** value in that header: each proxy appends, so the last one comes from the proxy in front, while anything a client writes lands first and is ignored. Express's `req.secure` reads the first value, which is why the code does not use it.
+```
+privateKey_FILEPATH and certificate_FILEPATH set?
+├─ yes → those two paths          (set both, or set neither)
+└─ no  → /etc/letsencrypt/live/<gateway_HOST domain>/privkey.pem
+                                                    /fullchain.pem
+```
 
-Set the flag only when something in front terminates TLS (nginx, a CDN, a tunnel), and keep `gateway_PORT` closed to everything but that proxy. Without the flag the redirect loops; with it, anyone who reaches `gateway_PORT` directly can fake the header and skip the redirect.
+If the gateway cannot read either file, the HTTPS listener stays down.
+
+## The HTTPS redirect
+
+`gateway_HTTPS_Redirect=true` sends every non-secure request to HTTPS. Requests under `/.well-known/` are the exception.
+
+Every visitor lands on `gateway_HOST` and `gateway_PORT_SECURE`, whatever address they typed. Two rules follow:
+
+- Give `gateway_HOST` a name that every visitor can resolve.
+- Put a port on `gateway_HOST` only when it is the same port as `gateway_PORT_SECURE`.
+
+If `gateway_HOST` is not usable, the redirect answers 500. It does not fall back to the browser's own `Host` header, because anyone can forge that header.
+
+## How the redirect decides a request is secure
+
+| `gateway_TRUST_PROXY` | the gateway reads |
+|---|---|
+| `false` | its own TLS socket. Nobody can forge this. |
+| `true` | its own TLS socket, or `X-Forwarded-Proto` |
+
+With `true`, the gateway reads the **last** value in `X-Forwarded-Proto`. Each proxy adds its value at the end, so the last value comes from the proxy directly in front. A client can only add a value at the start, so the gateway ignores it. Express `req.secure` reads the first value, and this is why the code does not use `req.secure`.
+
+Set `gateway_TRUST_PROXY=true` only when both of these are true:
+
+1. Something in front of the gateway terminates TLS (nginx, a CDN, a tunnel).
+2. Nothing but that proxy can reach `gateway_PORT`.
+
+| you get | when |
+|---|---|
+| a redirect loop (`ERR_TOO_MANY_REDIRECTS`) | a proxy holds the certificate, and `gateway_TRUST_PROXY` is not `true` |
+| a redirect that anyone can skip | `gateway_TRUST_PROXY=true`, and outsiders can reach `gateway_PORT` |
 
 ---
 # ACME challenges
 
-Before proxying, serves `/.well-known/` from the repo-root dir (dotfiles allowed) so HTTP-01 challenge files are answered directly and skip the HTTPS redirect. `entrypoint.sh` creates the dir on boot. `helmet` ([lib](../lib) `helmetOptions`) applies to every response except these static files.
+Before it proxies, the gateway serves `/.well-known/` from the repo-root dir, dotfiles included. HTTP-01 challenge files are therefore answered directly and skip the HTTPS redirect. `entrypoint.sh` creates the dir at boot. `helmet` ([lib](../lib) `helmetOptions`) applies to every response except these static files.
 
 ---
 # Config
 
-`<prefix>_PROXY_ON`, `<prefix>_HOST`, `gateway_PORT`, `gateway_PORT_SECURE`, `gateway_HOST` (TLS cert derive, HTTPS redirect target), `privateKey_FILEPATH` / `certificate_FILEPATH` (TLS override), `gateway_HTTPS_Redirect`, `gateway_TRUST_PROXY`; see [../env.example](../env.example).
+`<prefix>_PROXY_ON`, `<prefix>_HOST`, `gateway_PORT`, `gateway_PORT_SECURE`, `gateway_HOST` (TLS cert path, HTTPS redirect target), `privateKey_FILEPATH` / `certificate_FILEPATH` (TLS override), `gateway_HTTPS_Redirect`, `gateway_TRUST_PROXY`; see [../env.example](../env.example).

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -13,7 +13,7 @@ Proxied only when `<prefix>_PROXY_ON=true`, and only when both method and path m
 - [object](../object) — GET, POST
 - [command](../command) — GET, POST, PUT, PATCH, DELETE
 
-The gateway sets `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` itself rather than letting the proxy append to whatever arrived, so a backend on `trust proxy 1` reads one entry and it is the client, not the gateway or the proxy in front of it. Any `Authorization` header on the incoming request is dropped before forwarding. The gateway does no auth of its own — each service enforces its own after the proxy hop.
+The gateway sets `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host` itself rather than letting the proxy append to whatever arrived, so a backend on `trust proxy 1` reads exactly one entry and a client cannot prepend to it. That entry is whatever the gateway resolved as the caller: its own peer by default — the proxy in front, if there is one — or the client that proxy names, once `gateway_TRUST_PROXY=true`. Turning the flag on therefore trusts whatever reaches `gateway_PORT` to name its own address, which is why it stays opt-in. Any `Authorization` header on the incoming request is dropped before forwarding. The gateway does no auth of its own — each service enforces its own after the proxy hop.
 
 If you run your own proxy in front of Chimera (nginx, Caddy, a load balancer), drop `Authorization` there too. Passing it through from public traffic lets an outsider act as the scheduler.
 
@@ -24,11 +24,11 @@ The gateway runs two listeners:
 - `gateway_PORT` — HTTP.
 - `gateway_PORT_SECURE` — HTTPS, key/cert auto-resolved from `gateway_HOST` under `/etc/letsencrypt/live/` (override with `privateKey_FILEPATH` / `certificate_FILEPATH` — both or neither); if either is unreadable the secure listener stays down.
 
-`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It reads `req.secure` — by default the gateway's own TLS socket, which cannot be spoofed.
+`gateway_HTTPS_Redirect=true` redirects non-secure requests (except `/.well-known/`) to HTTPS. It deliberately does not use Express's `req.secure`; by default it reads the gateway's own TLS socket, which cannot be spoofed.
 
 Everyone lands on `gateway_HOST` and `gateway_PORT_SECURE`, whatever address they typed — so pick a name every visitor can resolve, and don't put a port on it unless it is `gateway_PORT_SECURE`. With no usable `gateway_HOST` the redirect fails closed with a 500 rather than following the browser's own `Host` header, which anyone can forge.
 
-`gateway_TRUST_PROXY=true` enables `trust proxy`, so `req.secure` reads `X-Forwarded-Proto` instead. Set it only when something in front terminates TLS (nginx, a CDN, a tunnel); the redirect loops without it. It stays opt-in because anyone who can reach `gateway_PORT` directly can forge that header and skip the redirect.
+`gateway_TRUST_PROXY=true` enables `trust proxy`, and the redirect then also accepts `X-Forwarded-Proto` — the **last** entry, which the front proxy appended, not the first, which a client can prepend. `req.secure` takes the first, so reaching for it here reopens that bypass. Set the flag only when something in front terminates TLS (nginx, a CDN, a tunnel); the redirect loops without it. It stays opt-in because anyone who can reach `gateway_PORT` directly can forge that header and skip the redirect.
 
 ---
 # ACME challenges

--- a/lib/test/certPaths.test.js
+++ b/lib/test/certPaths.test.js
@@ -45,6 +45,14 @@ describe("certPaths", () => {
 		errorSpy.mockRestore()
 	})
 
+	test("empty strings for an IPv4-literal gateway_HOST — an IP gets no certificate either, so the operator needs the same hint", () => {
+		const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+		process.env.gateway_HOST = "https://192.168.1.50"
+		expect(certPaths()).toEqual({ key: "", cert: "" })
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Cannot auto-resolve"), "192.168.1.50", expect.any(String))
+		errorSpy.mockRestore()
+	})
+
 	test("falls back to privateKey_FILEPATH and certificate_FILEPATH if set", () => {
 		process.env.privateKey_FILEPATH = "/custom/key.pem"
 		process.env.certificate_FILEPATH = "/custom/cert.pem"

--- a/lib/test/normalizeHost.test.js
+++ b/lib/test/normalizeHost.test.js
@@ -18,6 +18,11 @@ describe("normalizeHost", () => {
 		expect(parses("2001:db8::1")).toBe("[2001:db8::1]")
 	})
 
+	test("brackets an IPv4-mapped IPv6 literal — the dots do not stop net.isIPv6 recognising it", () => {
+		expect(normalizeHost("::ffff:192.168.1.1")).toBe("https://[::ffff:192.168.1.1]")
+		expect(parses("::ffff:192.168.1.1")).toBe("[::ffff:c0a8:101]")
+	})
+
 	test("leaves an already-bracketed IPv6 host alone", () => {
 		expect(parses("[::1]:8443")).toBe("[::1]:8443")
 	})

--- a/lib/utils/certPaths.js
+++ b/lib/utils/certPaths.js
@@ -1,9 +1,12 @@
+const net = require("net")
 const gatewayHost = require("./gatewayHost.js")
 
 const letsencryptPaths = (hostname) => ({
 	key: `/etc/letsencrypt/live/${hostname}/privkey.pem`,
 	cert: `/etc/letsencrypt/live/${hostname}/fullchain.pem`,
 })
+
+const isIpLiteral = (hostname) => net.isIP((hostname || "").replace(/^\[|\]$/g, "")) !== 0
 
 const certPaths = () => {
 	let hostname = ""
@@ -13,7 +16,7 @@ const certPaths = () => {
 	} catch (e) {
 		console.error("Invalid gateway_HOST:", e.message)
 	}
-	if (hostname.startsWith("[")) {
+	if (isIpLiteral(hostname)) {
 		console.error("Cannot auto-resolve a certificate for the IP literal gateway_HOST:", hostname, "— Let's Encrypt issues for domain names only. Set privateKey_FILEPATH and certificate_FILEPATH instead.")
 		hostname = ""
 	}
@@ -28,4 +31,5 @@ const certPaths = () => {
 }
 
 certPaths.letsencryptPaths = letsencryptPaths
+certPaths.isIpLiteral = isIpLiteral
 module.exports = certPaths

--- a/lib/utils/normalizeHost.js
+++ b/lib/utils/normalizeHost.js
@@ -1,7 +1,9 @@
+const net = require("net")
+
 module.exports = (host) => {
 	const h = (host || "").trim().replace(/\/+$/, "")
 	if (!h) return ""
-	const withScheme = /^https?:\/\//i.test(h) ? h : `https://${h}`
-	try { new URL(withScheme); return withScheme } catch { /* a bare IPv6 literal needs brackets before it parses */ }
-	return withScheme.replace(/^(https?:\/\/)([0-9a-f:]*:[0-9a-f:]*)$/i, "$1[$2]")
+	const scheme = /^https?:\/\//i.exec(h)?.[0]
+	const rest = scheme ? h.slice(scheme.length) : h
+	return `${scheme || "https://"}${net.isIPv6(rest) ? `[${rest}]` : rest}`
 }

--- a/lib/utils/rateLimit.js
+++ b/lib/utils/rateLimit.js
@@ -5,11 +5,11 @@ module.exports = (namespace) => {
 	const memory = require("memory")
 	const sharedAttempts = process.env.memory_ON == "true"
 	const client = sharedAttempts ? memory.client(namespace) : null
+	const local = memory.loginAttempts()
 
 	const defaultKeyFn = (req) => `${req.ip || ""}:${req.path}`
 
 	const makeReserve = ({ windowMs, max, keyFn }) => {
-		const local = memory.loginAttempts()
 		const getKey = keyFn || defaultKeyFn
 		const reserveLocal = (key, cb) =>
 			local.loginReserve(key, max, windowMs, (blocked) => cb(blocked, () => local.loginRelease(key)))
@@ -36,7 +36,6 @@ module.exports = (namespace) => {
 				return next()
 			}
 			if (!throttle) return tooMany(res)
-			// no releaseOnSuccess: a throttled request never charged the budget, so releasing it would refund a guess it never spent
 			throttle(req, (tooSoon) => tooSoon ? tooMany(res) : next())
 		})
 		return skip ? (req, res, next) => skip(req).then((s) => (s ? next() : gate(req, res, next)), () => gate(req, res, next)) : gate


### PR DESCRIPTION
Addresses all 18 open review threads on #490.

## Behaviour fixes

| # | Thread | File | Change |
|---|---|---|---|
| 1 | cert presence probed with `statSync` | `chimera/preflight.js` | `certStatus` opens the file (`openSync` + `fstatSync`) instead of stat'ing it, because `handleSecureServerStart` reads it. A 0640 root key that stats fine but cannot be opened by the reader now counts as unreadable, so the redirect-loop warning is no longer suppressed for the exact deploy it exists to catch. The same one try/catch answers both "present?" and "which errno?", replacing the `isFile(p) \|\| certUnreadable(p) !== null` double stat. |
| 2 | `http://host:PORT` + trusted proxy loses its port | `chimera/preflight.js` | `httpsRedirectPortWarning` now fires on any `http://` `gateway_HOST` while the redirect is on, before the `gateway_TRUST_PROXY` early return. That was the one port combination nothing caught. |
| 3 | unreadable warning contradicted itself on a mixed pair | `chimera/preflight.js` | The "so the redirect-loop warning stays silent" clause is now gated on `certPairMaybePresent`, so it only claims suppression when suppression happened. |
| 4 | IPv4-literal `gateway_HOST` auto-resolved a Let's Encrypt path | `lib/utils/certPaths.js` | `isIpLiteral` uses `net.isIP` and covers v4 and bracketed v6. Exported so `preflight.js` uses the same test instead of its own bracket check. |
| 5 | hand-rolled IPv6 bracketing | `lib/utils/normalizeHost.js` | `net.isIPv6` replaces the `[0-9a-f:]` regex, so `::ffff:192.168.1.1` parses. |
| 6 | eight `loginAttempts()` stores in the AUTH namespace | `lib/utils/rateLimit.js` | `local` is hoisted to the factory closure: one store per namespace, so `MAX_KEYS` and the prune threshold are computed across all its limiters rather than per limiter. Keys are already namespaced (`ip:`, `day:ip:`, `user:`, `throttle:…`), so no collisions. |
| 7 | warning list spelled out three times | `chimera/preflight.js`, `chimera/validateEnvVars.js` | One exported `redirectWarnings(lines)`; all three call sites are a single loop. |

## Message and doc corrections

- `chimera/validateEnvVars.js` — the `gateway_HOST` boot-blocker named a fallback this PR deleted. It now says what actually happens: an unparseable value answers 500.
- `chimera/preflight.js` — `certUnreadableWarning` and `OVERRIDE_PATH_CAVEAT` were written for the host preflight but also run inside the container via the entrypoint. Reworded to hold in both.
- `env.example` — `gateway_TRUST_PROXY` claimed the per-IP login budgets key off the same address either way. It does not: the flag installs `trust proxy 1`, which decides what `req.ip` — and so the `X-Forwarded-For` entry the gateway writes — resolves to. The warning about a reachable `gateway_PORT` now names the login budgets alongside the redirect.
- `command/README.md` — line 47 contradicted line 59. The "one entry, and it is the client" guarantee holds only with `gateway_TRUST_PROXY=true`; the "sole reachable port" precondition is back.
- `gateway/README.md` — same correction for the `X-Forwarded-For` claim, and lines 27/31 no longer attribute the redirect decision to `req.secure`. The code deliberately reads the **last** `X-Forwarded-Proto` element; `req.secure` takes the first, which is the client-prepend bypass `httpsRedirectUntrustedProxy.test.js` guards.

## Explicit decisions

**The four explanatory comments are stripped**, per the repo convention, not kept. Each invariant they carried is now in a test name or a README line instead: the throttle/refund rule at `rateLimit.js:39` is stated in `command/README.md`, and the `configuredCertPair`/`httpsRedirectPortWarning` comments describe behaviour the new tests pin.

**The 10-second account throttle is recorded, not changed.** `9bb7a95` reverted it deliberately — a 15-minute window hands an attacker a permanent lockout of a user with no device token. `command/README.md`'s "What this does not do" now states the cost plainly: roughly 8,600 guesses a day at one username from rotating source addresses. The PR body's fix #1 table row is stale and needs the same correction.

**No test for the shared limiter store.** It is an allocation change with no observable behaviour, and the existing `AUTH` limiter tests cover the paths through it.

## Verification

99 suites, 1277 tests pass. Lint reports 0 errors (4 pre-existing warnings in `object/backend/lib/worker.js`).

New tests: a cert that stats fine but cannot be opened; a mixed readable/missing pair firing both warnings without contradiction; an IPv4-literal `gateway_HOST` in both `certPaths` and the loop warning; `http://` `gateway_HOST` with the redirect on, with and without a trusted proxy; `::ffff:192.168.1.1` normalising. The cert tests now mock the read probe rather than `statSync`.
