### PR TITLE
Address the 8 open review threads on #490

### DIFF
--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -22,7 +22,8 @@ try {
 const { parseConf, buildFullUrl, urlProblem } = loadCameras
 const { multiInstance, validInstances } = multiInstanceLib
 const { validTrustedSources } = trustedSourcesLib
-const { letsencryptPaths, isIpLiteral } = certPaths
+const { letsencryptPaths, isIpLiteral, isFile } = certPaths
+const { validTrustProxy } = trustProxyHops
 
 const ROOT = path.join(__dirname, "..")
 const ENV = path.join(ROOT, ".env")
@@ -123,7 +124,7 @@ const varProblem = (v, val) => {
 	if (v.key === "storage_HOST" && !/^https?:\/\//i.test(val)) return `must start with http:// or https:// (got "${val}")`
 	if (v.key === "gateway_HOST" && normalizeHost.bareIPv6(val)) return `must bracket an IPv6 literal, or the port cannot be told apart from the address — write https://[${val.replace(/^https?:\/\//i, "")}] (got "${val}")`
 	if (v.key === "gateway_HOST" && !urlPart(normalizeHost(val), "hostname")) return `must be a valid URL (got "${val}")`
-	if (v.key === "gateway_TRUST_PROXY" && val !== "true" && val !== "false" && !/^\d+$/.test(val)) return `must be true, false, or the number of proxies in front (got "${val}")`
+	if (v.key === "gateway_TRUST_PROXY" && !validTrustProxy(val)) return `must be true, false, or the number of proxies in front (got "${val}")`
 	if (v.key === "object_ALERT_ON" && !["true", "text", "false"].includes(val)) return `must be true, text, or false (got "${val}")`
 	if (isSecret(v.key) && val.length < 32) return `must be at least 32 characters (got ${val.length})`
 	const t = typeOf(v.key, v.placeholder)
@@ -131,8 +132,6 @@ const varProblem = (v, val) => {
 	if (t === "port" && !(/^\d+$/.test(val) && Number(val) >= 1 && Number(val) <= 65535)) return `must be a port from 1 to 65535 (got "${val}")`
 	return null
 }
-
-const isFile = (p) => { try { return fs.statSync(p).isFile() } catch { return false } }
 
 const ABSENT = "ENOENT"
 const certStatus = (p) => {
@@ -268,12 +267,10 @@ const configuredCertPair = (lines) => {
 	return { paths: [auto.key, auto.cert], source: "auto" }
 }
 
-// Every warning below needs the same two files. Open them once: six syscall sets per path on a
-// slow bind mount is wasteful, and a renewal landing mid-run made the answers contradict.
 const certPairStatus = (lines) => {
 	const { paths, source } = configuredCertPair(lines)
 	const statuses = paths.map(p => [p, certStatus(p)])
-	return { paths, source, statuses, maybePresent: statuses.length > 0 && statuses.every(([, code]) => code !== ABSENT) }
+	return { source, statuses, maybePresent: statuses.length > 0 && statuses.every(([, code]) => code !== ABSENT) }
 }
 
 const trustsProxy = (lines) => trustProxyHops(getVal(lines, "gateway_TRUST_PROXY") || "") > 0
@@ -297,15 +294,13 @@ const OVERRIDE_PATH_CAVEAT = "\n  Already mounted your own pair? privateKey_FILE
 
 const httpsRedirectLoopWarning = (lines, pair = certPairStatus(lines)) => {
 	if (!redirectNeedsLocalCert(lines) || pair.maybePresent) return null
-	const { paths, source } = pair
+	const { statuses, source } = pair
 	return "WARNING: gateway_HTTPS_Redirect=true, but nothing here serves https:// and gateway_TRUST_PROXY is not true. Every page redirects to itself (ERR_TOO_MANY_REDIRECTS).\n  Who holds the certificate?\n  this machine — set certbot_ON=true, or give privateKey_FILEPATH and certificate_FILEPATH absolute paths to your cert pair\n  a proxy or tunnel — set gateway_TRUST_PROXY=true, and make the proxy send X-Forwarded-Proto (nginx: proxy_set_header X-Forwarded-Proto $scheme)"
-		+ (source === "override" && paths.length ? OVERRIDE_PATH_CAVEAT : "")
+		+ (source === "override" && statuses.length ? OVERRIDE_PATH_CAVEAT : "")
 }
 
 const GATEWAY_PORT_SECURE_DEFAULT = redirectTarget.DEFAULT_SECURE_PORT
 
-// Asks gateway.js where it would send the visitor rather than restating its rules, so the two
-// cannot drift, and compares that against the gateway_HOST share links and certbot use.
 const httpsRedirectPortWarning = (lines) => {
 	if (getVal(lines, "gateway_HTTPS_Redirect") !== "true") return null
 	const url = gatewayUrl(lines)
@@ -316,8 +311,8 @@ const httpsRedirectPortWarning = (lines) => {
 	if (trustsProxy(lines)) return null
 	const securePort = getVal(lines, "gateway_PORT_SECURE") || GATEWAY_PORT_SECURE_DEFAULT
 	const target = redirectTarget({ host: url, securePort, trustProxy: false })
-	const targetPort = urlPart(`https://${target}`, "port") || GATEWAY_PORT_SECURE_DEFAULT
-	if (targetPort !== securePort) return `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${targetPort} (gateway_HOST), but this deploy terminates TLS on port ${securePort} (gateway_PORT_SECURE). The redirect lands on a port that serves no TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
+	const hostPort = urlPart(url, "port")
+	if (hostPort && hostPort !== securePort) return `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${hostPort} (gateway_HOST), but this deploy terminates TLS on port ${securePort} (gateway_PORT_SECURE). The redirect lands on a port that serves no TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
 	return target === urlPart(url, "host")
 		? null
 		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to https://${target}, but gateway_HOST is ${url}. Storage share links and certbot use gateway_HOST, so they name a port nothing listens on. Write the TLS port into gateway_HOST: https://${target}`

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -3,13 +3,15 @@ const path = require("path")
 const readline = require("readline")
 const crypto = require("crypto")
 
-let loadCameras, multiInstanceLib, trustedSourcesLib, normalizeHost, certPaths
+let loadCameras, multiInstanceLib, trustedSourcesLib, normalizeHost, certPaths, redirectTarget, trustProxyHops
 try {
 	loadCameras = require("../lib/utils/loadCameras.js")
 	multiInstanceLib = require("../lib/utils/multiInstance.js")
 	trustedSourcesLib = require("../lib/utils/trustedSources.js")
 	normalizeHost = require("../lib/utils/normalizeHost.js")
 	certPaths = require("../lib/utils/certPaths.js")
+	redirectTarget = require("../lib/utils/redirectTarget.js")
+	trustProxyHops = require("../lib/utils/trustProxyHops.js")
 } catch (e) {
 	if (e.code === "MODULE_NOT_FOUND") {
 		console.error("Missing dependencies — run `npm install` first.")
@@ -119,7 +121,9 @@ const varProblem = (v, val) => {
 	if (v.key === "chimeraInstances" && !validInstances(val)) return `must be "max", -1, or an integer >= 0 (got "${val}")`
 	if (v.key === "scheduler_TRUSTED_SOURCES" && !validTrustedSources(val)) return `must be comma-separated IPs/CIDRs or proxy-addr names like "loopback" (got "${val}")`
 	if (v.key === "storage_HOST" && !/^https?:\/\//i.test(val)) return `must start with http:// or https:// (got "${val}")`
+	if (v.key === "gateway_HOST" && normalizeHost.bareIPv6(val)) return `must bracket an IPv6 literal, or the port cannot be told apart from the address — write https://[${val.replace(/^https?:\/\//i, "")}] (got "${val}")`
 	if (v.key === "gateway_HOST" && !urlPart(normalizeHost(val), "hostname")) return `must be a valid URL (got "${val}")`
+	if (v.key === "gateway_TRUST_PROXY" && val !== "true" && val !== "false" && !/^\d+$/.test(val)) return `must be true, false, or the number of proxies in front (got "${val}")`
 	if (v.key === "object_ALERT_ON" && !["true", "text", "false"].includes(val)) return `must be true, text, or false (got "${val}")`
 	if (isSecret(v.key) && val.length < 32) return `must be at least 32 characters (got ${val.length})`
 	const t = typeOf(v.key, v.placeholder)
@@ -144,8 +148,6 @@ const certStatus = (p) => {
 		if (fd !== undefined) fs.closeSync(fd)
 	}
 }
-const certUnreadable = (p) => { const code = certStatus(p); return code === ABSENT ? null : code }
-const certMaybePresent = (p) => certStatus(p) !== ABSENT
 
 const motionDirProblem = () => !isFile(MOTION) && fs.existsSync(MOTION)
 	? "is a directory — Docker creates one when the bind-mounted file is missing; run `rm -rf motion.conf && cp motion.conf.example motion.conf`"
@@ -266,21 +268,26 @@ const configuredCertPair = (lines) => {
 	return { paths: [auto.key, auto.cert], source: "auto" }
 }
 
-const certPairMaybePresent = (lines) => {
-	const { paths } = configuredCertPair(lines)
-	return paths.length > 0 && paths.every(certMaybePresent)
+// Every warning below needs the same two files. Open them once: six syscall sets per path on a
+// slow bind mount is wasteful, and a renewal landing mid-run made the answers contradict.
+const certPairStatus = (lines) => {
+	const { paths, source } = configuredCertPair(lines)
+	const statuses = paths.map(p => [p, certStatus(p)])
+	return { paths, source, statuses, maybePresent: statuses.length > 0 && statuses.every(([, code]) => code !== ABSENT) }
 }
 
+const trustsProxy = (lines) => trustProxyHops(getVal(lines, "gateway_TRUST_PROXY") || "") > 0
+
 const redirectNeedsLocalCert = (lines) =>
-	getVal(lines, "gateway_HTTPS_Redirect") === "true" && getVal(lines, "gateway_TRUST_PROXY") !== "true"
+	getVal(lines, "gateway_HTTPS_Redirect") === "true" && !trustsProxy(lines)
 		&& getVal(lines, "certbot_ON") !== "true"
 
-const certUnreadableWarning = (lines) => {
+const certUnreadableWarning = (lines, pair = certPairStatus(lines)) => {
 	if (!redirectNeedsLocalCert(lines)) return null
-	const unreadable = configuredCertPair(lines).paths.map(p => [p, certUnreadable(p)]).filter(([, code]) => code)
+	const unreadable = pair.statuses.filter(([, code]) => code && code !== ABSENT)
 	if (!unreadable.length) return null
 	const named = unreadable.map(([p, code]) => `${p} (${code})`).join(", ")
-	const blind = certPairMaybePresent(lines) ? "\n  A path this user cannot read is not proof the certificate is absent, so the redirect-loop warning stays silent." : ""
+	const blind = pair.maybePresent ? "\n  A path this user cannot read is not proof the certificate is absent, so the redirect-loop warning stays silent." : ""
 	return `WARNING: this user cannot read ${named}.${blind}`
 		+ "\n  The gateway opens the same paths as uid 1000. If it cannot open them, the secure listener stays down."
 		+ "\n  /etc/letsencrypt is mode 0700 root. A FILEPATH names a path inside the container, so docker-compose.yml must mount it, and uid 1000 must be able to read it."
@@ -288,15 +295,17 @@ const certUnreadableWarning = (lines) => {
 
 const OVERRIDE_PATH_CAVEAT = "\n  Already mounted your own pair? privateKey_FILEPATH and certificate_FILEPATH name paths inside the container. This check can only look at the filesystem it runs on. From the host, that is the mount source, not the container path."
 
-const httpsRedirectLoopWarning = (lines) => {
-	if (!redirectNeedsLocalCert(lines) || certPairMaybePresent(lines)) return null
-	const { paths, source } = configuredCertPair(lines)
+const httpsRedirectLoopWarning = (lines, pair = certPairStatus(lines)) => {
+	if (!redirectNeedsLocalCert(lines) || pair.maybePresent) return null
+	const { paths, source } = pair
 	return "WARNING: gateway_HTTPS_Redirect=true, but nothing here serves https:// and gateway_TRUST_PROXY is not true. Every page redirects to itself (ERR_TOO_MANY_REDIRECTS).\n  Who holds the certificate?\n  this machine — set certbot_ON=true, or give privateKey_FILEPATH and certificate_FILEPATH absolute paths to your cert pair\n  a proxy or tunnel — set gateway_TRUST_PROXY=true, and make the proxy send X-Forwarded-Proto (nginx: proxy_set_header X-Forwarded-Proto $scheme)"
 		+ (source === "override" && paths.length ? OVERRIDE_PATH_CAVEAT : "")
 }
 
-const GATEWAY_PORT_SECURE_DEFAULT = "443"
+const GATEWAY_PORT_SECURE_DEFAULT = redirectTarget.DEFAULT_SECURE_PORT
 
+// Asks gateway.js where it would send the visitor rather than restating its rules, so the two
+// cannot drift, and compares that against the gateway_HOST share links and certbot use.
 const httpsRedirectPortWarning = (lines) => {
 	if (getVal(lines, "gateway_HTTPS_Redirect") !== "true") return null
 	const url = gatewayUrl(lines)
@@ -304,17 +313,20 @@ const httpsRedirectPortWarning = (lines) => {
 	if (urlPart(url, "protocol") !== "https:") {
 		return "WARNING: gateway_HTTPS_Redirect=true but gateway_HOST is http://. The redirect always sends visitors to https://, so it ignores the scheme. With gateway_TRUST_PROXY=true it also drops any port gateway_HOST names and lands visitors on 443. Write gateway_HOST as https:// with the port browsers reach, or turn the redirect off"
 	}
-	if (getVal(lines, "gateway_TRUST_PROXY") === "true") return null
-	const hostPort = urlPart(url, "port")
-	if (!hostPort) return null
+	if (trustsProxy(lines)) return null
 	const securePort = getVal(lines, "gateway_PORT_SECURE") || GATEWAY_PORT_SECURE_DEFAULT
-	return hostPort === securePort
+	const target = redirectTarget({ host: url, securePort, trustProxy: false })
+	const targetPort = urlPart(`https://${target}`, "port") || GATEWAY_PORT_SECURE_DEFAULT
+	if (targetPort !== securePort) return `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${targetPort} (gateway_HOST), but this deploy terminates TLS on port ${securePort} (gateway_PORT_SECURE). The redirect lands on a port that serves no TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
+	return target === urlPart(url, "host")
 		? null
-		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to port ${hostPort} (gateway_HOST), but this deploy terminates TLS on port ${securePort} (gateway_PORT_SECURE). The redirect lands on a port that serves no TLS (ERR_SSL_PROTOCOL_ERROR). Give gateway_HOST and gateway_PORT_SECURE the same port`
+		: `WARNING: gateway_HTTPS_Redirect=true sends http:// visitors to https://${target}, but gateway_HOST is ${url}. Storage share links and certbot use gateway_HOST, so they name a port nothing listens on. Write the TLS port into gateway_HOST: https://${target}`
 }
 
-const redirectWarnings = (lines) =>
-	[httpsRedirectLoopWarning(lines), certUnreadableWarning(lines), httpsRedirectPortWarning(lines)].filter(Boolean)
+const redirectWarnings = (lines) => {
+	const pair = certPairStatus(lines)
+	return [httpsRedirectLoopWarning(lines, pair), certUnreadableWarning(lines, pair), httpsRedirectPortWarning(lines)].filter(Boolean)
+}
 
 const certbotPortProblem = (lines) =>
 	getVal(lines, "certbot_ON") === "true" && getVal(lines, "gateway_PORT") !== "80"

--- a/chimera/preflight.js
+++ b/chimera/preflight.js
@@ -122,7 +122,7 @@ const varProblem = (v, val) => {
 	if (v.key === "chimeraInstances" && !validInstances(val)) return `must be "max", -1, or an integer >= 0 (got "${val}")`
 	if (v.key === "scheduler_TRUSTED_SOURCES" && !validTrustedSources(val)) return `must be comma-separated IPs/CIDRs or proxy-addr names like "loopback" (got "${val}")`
 	if (v.key === "storage_HOST" && !/^https?:\/\//i.test(val)) return `must start with http:// or https:// (got "${val}")`
-	if (v.key === "gateway_HOST" && normalizeHost.bareIPv6(val)) return `must bracket an IPv6 literal, or the port cannot be told apart from the address — write https://[${val.replace(/^https?:\/\//i, "")}] (got "${val}")`
+	if (v.key === "gateway_HOST" && normalizeHost.bareIPv6(val)) return `must bracket an IPv6 literal, or the port cannot be told apart from the address — write https://[address] or https://[address]:port (got "${val}")`
 	if (v.key === "gateway_HOST" && !urlPart(normalizeHost(val), "hostname")) return `must be a valid URL (got "${val}")`
 	if (v.key === "gateway_TRUST_PROXY" && !validTrustProxy(val)) return `must be true, false, or the number of proxies in front (got "${val}")`
 	if (v.key === "object_ALERT_ON" && !["true", "text", "false"].includes(val)) return `must be true, text, or false (got "${val}")`

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -172,8 +172,6 @@ describe("varProblem", () => {
 		expect(varProblem(gatewayHostVar, "http://127.0.0.1:8080")).toBeNull()
 	})
 
-	// an unbracketed "::1:8443" is a valid address as well as a port, and reading it the wrong
-	// way redirects every visitor somewhere nobody serves, so preflight asks for the brackets
 	test("gateway_HOST: a bare IPv6 literal → asks for brackets; a bracketed one → null", () => {
 		expect(varProblem(gatewayHostVar, "::1")).toMatch(/must bracket an IPv6 literal/)
 		expect(varProblem(gatewayHostVar, "http://::1")).toMatch(/must bracket an IPv6 literal/)
@@ -538,8 +536,6 @@ describe("certUnreadableWarning", () => {
 describe("httpsRedirectPortWarning", () => {
 	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
 
-	// the redirect reaches the listener, but gateway_HOST no longer names the address browsers
-	// use, and that is the address storage share links and certbot hand out
 	test("fires when gateway_HOST names no port but gateway.js appends one — the two disagree on the public address", () => {
 		const w = httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50" }))
 		expect(w).toMatch(/visitors to https:\/\/192\.168\.1\.50:8443/)

--- a/chimera/test/preflight.test.js
+++ b/chimera/test/preflight.test.js
@@ -172,11 +172,22 @@ describe("varProblem", () => {
 		expect(varProblem(gatewayHostVar, "http://127.0.0.1:8080")).toBeNull()
 	})
 
-	test("gateway_HOST: a bare IPv6 literal → null, bracketed or not — new URL() only takes the bracketed form", () => {
-		expect(varProblem(gatewayHostVar, "::1")).toBeNull()
+	// an unbracketed "::1:8443" is a valid address as well as a port, and reading it the wrong
+	// way redirects every visitor somewhere nobody serves, so preflight asks for the brackets
+	test("gateway_HOST: a bare IPv6 literal → asks for brackets; a bracketed one → null", () => {
+		expect(varProblem(gatewayHostVar, "::1")).toMatch(/must bracket an IPv6 literal/)
+		expect(varProblem(gatewayHostVar, "http://::1")).toMatch(/must bracket an IPv6 literal/)
+		expect(varProblem(gatewayHostVar, "https://::1:8443")).toMatch(/must bracket an IPv6 literal/)
 		expect(varProblem(gatewayHostVar, "[::1]")).toBeNull()
-		expect(varProblem(gatewayHostVar, "http://::1")).toBeNull()
 		expect(varProblem(gatewayHostVar, "https://[2001:db8::5]:8443")).toBeNull()
+	})
+
+	test("gateway_TRUST_PROXY: true, false or a hop count → null; anything else → error", () => {
+		const v = { key: "gateway_TRUST_PROXY", placeholder: "(false | true | how many proxies)", optional: true }
+		expect(varProblem(v, "true")).toBeNull()
+		expect(varProblem(v, "false")).toBeNull()
+		expect(varProblem(v, "2")).toBeNull()
+		expect(varProblem(v, "yes")).toMatch(/must be true, false, or the number of proxies/)
 	})
 
 	test("setup_TOKEN: under 32 characters → error, so preflight blocks what validateEnvVars would crash-loop on", () => {
@@ -527,8 +538,12 @@ describe("certUnreadableWarning", () => {
 describe("httpsRedirectPortWarning", () => {
 	const lines = (o) => Object.entries(o).map(([k, v]) => `${k} = ${v}`)
 
-	test("stays quiet when gateway_HOST names no port — gateway.js appends gateway_PORT_SECURE itself, so the redirect reaches the listener", () => {
-		expect(httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50" }))).toBeNull()
+	// the redirect reaches the listener, but gateway_HOST no longer names the address browsers
+	// use, and that is the address storage share links and certbot hand out
+	test("fires when gateway_HOST names no port but gateway.js appends one — the two disagree on the public address", () => {
+		const w = httpsRedirectPortWarning(lines({ gateway_HTTPS_Redirect: "true", gateway_PORT: "8080", gateway_PORT_SECURE: "8443", gateway_HOST: "https://192.168.1.50" }))
+		expect(w).toMatch(/visitors to https:\/\/192\.168\.1\.50:8443/)
+		expect(w).toMatch(/gateway_HOST is https:\/\/192\.168\.1\.50\./)
 	})
 
 	test("fires when the TLS listener is on a port gateway_HOST names differently — the redirect lands where nothing serves TLS", () => {

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -33,12 +33,12 @@ const assertNotLastAdmin = async (client, message) => {
 	if (admins.rows.length <= 1) throw new HttpError(400, message)
 }
 
-const { rateLimit: baseRateLimit, rateLimitChain: baseRateLimitChain, client: memoryClient } = rateLimiter("AUTH")
+const { rateLimitChain: baseRateLimitChain, client: memoryClient } = rateLimiter("AUTH")
 if (memoryClient) auth.connectSessionSync(memoryClient)
 
 const releasing = (opts) => ({ ...opts, releaseOnSuccess: true })
-const rateLimit = (opts) => baseRateLimit(releasing(opts))
 const rateLimitChain = (optsList) => baseRateLimitChain(optsList.map(releasing))
+const rateLimit = (opts) => rateLimitChain([opts])
 
 const setupLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10 })
 
@@ -51,8 +51,6 @@ const ipKeyFn = (req) => `ip:${req.ip || ""}`
 
 const deviceKnown = (req) => (req.deviceKnown ??= knownDevice(req))
 
-// One middleware, not three chained ones: the three budgets reserve together, so a shared-memory
-// deploy pays one round-trip per login instead of three in a row.
 const loginLimiter = rateLimitChain([
 	{ windowMs: 15 * 60 * 1000, max: 20, throttleMs: THROTTLE_WINDOW_MS, keyFn: ipKeyFn },
 	{ windowMs: 24 * 60 * 60 * 1000, max: 100, throttleMs: 15 * 60 * 1000, keyFn: (req) => `day:${ipKeyFn(req)}`, skip: deviceKnown },

--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -33,10 +33,12 @@ const assertNotLastAdmin = async (client, message) => {
 	if (admins.rows.length <= 1) throw new HttpError(400, message)
 }
 
-const { rateLimit: baseRateLimit, client: memoryClient } = rateLimiter("AUTH")
+const { rateLimit: baseRateLimit, rateLimitChain: baseRateLimitChain, client: memoryClient } = rateLimiter("AUTH")
 if (memoryClient) auth.connectSessionSync(memoryClient)
 
-const rateLimit = (opts) => baseRateLimit({ ...opts, releaseOnSuccess: true })
+const releasing = (opts) => ({ ...opts, releaseOnSuccess: true })
+const rateLimit = (opts) => baseRateLimit(releasing(opts))
+const rateLimitChain = (optsList) => baseRateLimitChain(optsList.map(releasing))
 
 const setupLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10 })
 
@@ -49,9 +51,13 @@ const ipKeyFn = (req) => `ip:${req.ip || ""}`
 
 const deviceKnown = (req) => (req.deviceKnown ??= knownDevice(req))
 
-const ipLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 20, throttleMs: THROTTLE_WINDOW_MS, keyFn: ipKeyFn })
-const ipDayLimiter = rateLimit({ windowMs: 24 * 60 * 60 * 1000, max: 100, throttleMs: 15 * 60 * 1000, keyFn: (req) => `day:${ipKeyFn(req)}`, skip: deviceKnown })
-const accountLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10, throttleMs: THROTTLE_WINDOW_MS, keyFn: accountKeyFn, skip: deviceKnown })
+// One middleware, not three chained ones: the three budgets reserve together, so a shared-memory
+// deploy pays one round-trip per login instead of three in a row.
+const loginLimiter = rateLimitChain([
+	{ windowMs: 15 * 60 * 1000, max: 20, throttleMs: THROTTLE_WINDOW_MS, keyFn: ipKeyFn },
+	{ windowMs: 24 * 60 * 60 * 1000, max: 100, throttleMs: 15 * 60 * 1000, keyFn: (req) => `day:${ipKeyFn(req)}`, skip: deviceKnown },
+	{ windowMs: 15 * 60 * 1000, max: 10, throttleMs: THROTTLE_WINDOW_MS, keyFn: accountKeyFn, skip: deviceKnown },
+])
 
 app.get("/status", async (req, res) => {
 	try {
@@ -92,7 +98,7 @@ app.post("/setup", blockCrossSite, validateBody, setupLimiter, async (req, res) 
 	}
 })
 
-app.post("/login", blockCrossSite, validateBody, ipLimiter, ipDayLimiter, accountLimiter, passwordCheck, login)
+app.post("/login", blockCrossSite, validateBody, loginLimiter, passwordCheck, login)
 app.post("/verify", authorize, async (req, res) => {
 	try {
 		const result = await pool.query("SELECT force_password_change, theme FROM auth WHERE username = $1", [req.decoded.username])
@@ -252,4 +258,5 @@ app.post("/logout", authorize, async (req, res) => {
 })
 
 app.rateLimit = rateLimit
+app.rateLimitChain = rateLimitChain
 module.exports = app

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -899,6 +899,10 @@ describe("Authorization Routes", () => {
 	describe("rateLimit", () => {
 		const { rateLimit } = require("../backend/routes/authorization.js")
 
+		// the limiters resolve their skips together before reserving, so a skip decision costs
+		// more than one microtask tick — drain the queue rather than counting ticks
+		const flush = () => new Promise(setImmediate)
+
 		const run = (mw, ip, statusCode = 400) => {
 			const req = { headers: {}, ip, path: "/login" }
 			let onFinish
@@ -965,13 +969,13 @@ describe("Authorization Routes", () => {
 
 			const next1 = jest.fn()
 			mw(makeReq("16.16.16.16"), makeRes(), next1)
-			await Promise.resolve()
+			await flush()
 			expect(next1).toHaveBeenCalled()
 
 			const res2 = makeRes()
 			const next2 = jest.fn()
 			mw(makeReq("16.16.16.16"), res2, next2)
-			await Promise.resolve()
+			await flush()
 			expect(next2).toHaveBeenCalled()
 			expect(res2.status).not.toHaveBeenCalled()
 		})
@@ -983,15 +987,41 @@ describe("Authorization Routes", () => {
 
 			const next1 = jest.fn()
 			mw(makeReq("17.17.17.17"), makeRes(), next1)
-			await Promise.resolve()
+			await flush()
 			expect(next1).toHaveBeenCalled()
 
 			const res2 = makeRes()
 			const next2 = jest.fn()
 			mw(makeReq("17.17.17.17"), res2, next2)
-			await Promise.resolve()
+			await flush()
 			expect(next2).not.toHaveBeenCalled()
 			expect(res2.status).toHaveBeenCalledWith(429)
+		})
+
+		test("a chain refuses on the first spent budget, and hands back what the later ones reserved", () => {
+			const { rateLimitChain } = require("../backend/routes/authorization.js")
+			const mw = rateLimitChain([
+				{ windowMs: 60000, max: 1, keyFn: (req) => `chain:ip:${req.ip}` },
+				{ windowMs: 60000, max: 3, keyFn: () => "chain:shared" },
+			])
+			expect(run(mw, "9.9.9.1").next).toHaveBeenCalled()
+			expect(run(mw, "9.9.9.1").res.status).toHaveBeenCalledWith(429)
+			expect(run(mw, "9.9.9.1").res.status).toHaveBeenCalledWith(429)
+			// the two refusals reserved the shared budget together with the per-IP one, so
+			// without the release these two would already be refused
+			expect(run(mw, "9.9.9.2").next).toHaveBeenCalled()
+			expect(run(mw, "9.9.9.3").next).toHaveBeenCalled()
+			expect(run(mw, "9.9.9.4").res.status).toHaveBeenCalledWith(429)
+		})
+
+		test("a throttled-through budget still lets the later ones decide", () => {
+			const { rateLimitChain } = require("../backend/routes/authorization.js")
+			const mw = rateLimitChain([
+				{ windowMs: 60000, max: 1, throttleMs: 60000, keyFn: (req) => `throttled:ip:${req.ip}` },
+				{ windowMs: 60000, max: 1, keyFn: () => "throttled:account" },
+			])
+			expect(run(mw, "9.9.8.1").next).toHaveBeenCalled()
+			expect(run(mw, "9.9.8.1").res.status).toHaveBeenCalledWith(429)
 		})
 
 		test("is wired onto POST /setup and returns 429 once exhausted", async () => {

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -899,8 +899,6 @@ describe("Authorization Routes", () => {
 	describe("rateLimit", () => {
 		const { rateLimit } = require("../backend/routes/authorization.js")
 
-		// the limiters resolve their skips together before reserving, so a skip decision costs
-		// more than one microtask tick — drain the queue rather than counting ticks
 		const flush = () => new Promise(setImmediate)
 
 		const run = (mw, ip, statusCode = 400) => {
@@ -1007,8 +1005,6 @@ describe("Authorization Routes", () => {
 			expect(run(mw, "9.9.9.1").next).toHaveBeenCalled()
 			expect(run(mw, "9.9.9.1").res.status).toHaveBeenCalledWith(429)
 			expect(run(mw, "9.9.9.1").res.status).toHaveBeenCalledWith(429)
-			// the two refusals reserved the shared budget together with the per-IP one, so
-			// without the release these two would already be refused
 			expect(run(mw, "9.9.9.2").next).toHaveBeenCalled()
 			expect(run(mw, "9.9.9.3").next).toHaveBeenCalled()
 			expect(run(mw, "9.9.9.4").res.status).toHaveBeenCalledWith(429)

--- a/env.example
+++ b/env.example
@@ -33,9 +33,10 @@ certbot_ON = (true | false) Get and renew Let's Encrypt certs automatically. Nee
 privateKey_FILEPATH = Custom TLS private key path (set both FILEPATHs, or neither) ***
 certificate_FILEPATH = Custom TLS certificate path (set both FILEPATHs, or neither) ***
 gateway_HTTPS_Redirect = (true | false) Send http:// visitors to https://. Behind a proxy, also set gateway_TRUST_PROXY=true, or every page redirects to itself. ***
-gateway_TRUST_PROXY = (true | false) Trust X-Forwarded-For and X-Forwarded-Proto from the proxy in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). ***
+gateway_TRUST_PROXY = (false | true | how many proxies) Trust X-Forwarded-For and X-Forwarded-Proto from the proxy in front (nginx: proxy_set_header X-Forwarded-Proto $scheme). ***
 # false: the gateway sees every visitor behind that proxy as one address. They share one per-IP login limit, and the redirect cannot tell that the visit was already https.
-# true: each visitor gets their own address and their own limit, and the redirect works. Set true only when nothing but the proxy can reach gateway_PORT, because anyone who reaches it directly can forge both headers.
+# true: one proxy in front. Each visitor gets their own address and their own limit, and the redirect works. Set this only when nothing but the proxy can reach gateway_PORT, because anyone who reaches it directly can forge both headers.
+# a number: that many proxies in front, counted from the visitor. Use 2 for a CDN in front of your own nginx — with 1 the gateway reads nginx's entry, which says http, and redirects an https visit back to itself.
 
 ##################################################################
 # Command

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -28,6 +28,7 @@ The gateway writes `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Forwarded-Host`
 |---|---|
 | `false` | the address the gateway sees. This is your own proxy, if you run one in front. |
 | `true` | the client address that your own proxy reports |
+| a number | the address reported that many hops out, for a CDN in front of your own proxy |
 
 The gateway deletes any `Authorization` header before it forwards the request. The gateway runs no authentication of its own. Each service runs its own after the proxy hop.
 
@@ -71,10 +72,13 @@ If `gateway_HOST` is not usable, the redirect answers 500. It does not fall back
 |---|---|
 | `false` | its own TLS socket. Nobody can forge this. |
 | `true` | its own TLS socket, or `X-Forwarded-Proto` |
+| a number | the same, counting that many proxies |
 
-With `true`, the gateway reads the **last** value in `X-Forwarded-Proto`. Each proxy adds its value at the end, so the last value comes from the proxy directly in front. A client can only add a value at the start, so the gateway ignores it. Express `req.secure` reads the first value, and this is why the code does not use `req.secure`.
+The gateway counts back from the end of `X-Forwarded-Proto` by the number of trusted hops. Each proxy adds its value at the end, so with `true` — one hop — the gateway reads the last value, the one written by the proxy directly in front. A client can only add a value at the start, so the gateway ignores it. Express `req.secure` reads the first value, which a client can forge, and this is why the code does not use `req.secure`.
 
-Set `gateway_TRUST_PROXY=true` only when both of these are true:
+Set `gateway_TRUST_PROXY=2` when a CDN sits in front of your own proxy and that proxy adds to the header instead of replacing it. The header arrives as `https,http`: the CDN saw https, your proxy saw the plain hop to the gateway. With `1` the gateway reads `http` and redirects an https visit back to itself, which the CDN sends round again (`ERR_TOO_MANY_REDIRECTS`). Count the proxies between the visitor and the gateway.
+
+Set `gateway_TRUST_PROXY` above `false` only when both of these are true:
 
 1. Something in front of the gateway terminates TLS (nginx, a CDN, a tunnel).
 2. Nothing but that proxy can reach `gateway_PORT`.

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -4,12 +4,13 @@ const helmet = require("helmet")
 var {
 	createProxyMiddleware
 }              = require("http-proxy-middleware")
-const { helmetOptions, gatewayHost } = require("lib")
+const { helmetOptions, redirectTarget, trustProxyHops } = require("lib")
 
 var app = express()
-const trustProxy = process.env.gateway_TRUST_PROXY == "true"
+const trustHops = trustProxyHops()
+const trustProxy = trustHops > 0
 if(trustProxy){
-	app.set("trust proxy", 1)
+	app.set("trust proxy", trustHops)
 }
 
 app.use("/.well-known/", express.static(path.join(__dirname, "../.well-known/"), {
@@ -18,27 +19,25 @@ app.use("/.well-known/", express.static(path.join(__dirname, "../.well-known/"),
 
 app.use(helmet(helmetOptions))
 
-const forwardedProto = (req) => (req.headers["x-forwarded-proto"] || "").split(",").pop().trim().toLowerCase()
+// Read the entry the outermost trusted hop wrote: count back from the end by the number of hops,
+// the same way req.ip picks the client out of X-Forwarded-For. With one hop that is the last
+// entry, so a client prepending its own "https" cannot skip the redirect. With a CDN in front of
+// nginx, gateway_TRUST_PROXY=2 reads the CDN's entry instead of nginx's view of the local hop —
+// express's req.secure always takes the first entry, which is why this does not use it.
+const forwardedProto = (req) => {
+	const values = (req.headers["x-forwarded-proto"] || "").split(",")
+	return (values[values.length - trustHops] ?? values[0]).trim().toLowerCase()
+}
 const isSecure = (req) => !!req.socket.encrypted || (trustProxy && forwardedProto(req) == "https")
 
 if(process.env.gateway_HTTPS_Redirect == "true"){
-	const securePort = process.env.gateway_PORT_SECURE || 443
-	const portSuffix = trustProxy || String(securePort) == "443" ? "" : `:${securePort}`
-	const redirectTarget = (() => {
-		try{
-			const url = new URL(gatewayHost())
-			return url.protocol == "https:" && url.port ? url.host : `${url.hostname}${portSuffix}`
-		}
-		catch{
-			return ""
-		}
-	})()
+	const target = redirectTarget({ trustProxy })
 	app.use((req, res, next) => {
 		if(isSecure(req) || req.path.split("/")[1] == ".well-known"){
 			next()
 		}
-		else if(redirectTarget){
-			res.redirect(`https://${redirectTarget}${req.url}`)
+		else if(target){
+			res.redirect(`https://${target}${req.url}`)
 		}
 		else{
 			res.status(500).send("gateway_HOST is missing or unparseable, so there is no HTTPS redirect target")

--- a/gateway/gateway.js
+++ b/gateway/gateway.js
@@ -19,11 +19,6 @@ app.use("/.well-known/", express.static(path.join(__dirname, "../.well-known/"),
 
 app.use(helmet(helmetOptions))
 
-// Read the entry the outermost trusted hop wrote: count back from the end by the number of hops,
-// the same way req.ip picks the client out of X-Forwarded-For. With one hop that is the last
-// entry, so a client prepending its own "https" cannot skip the redirect. With a CDN in front of
-// nginx, gateway_TRUST_PROXY=2 reads the CDN's entry instead of nginx's view of the local hop —
-// express's req.secure always takes the first entry, which is why this does not use it.
 const forwardedProto = (req) => {
 	const values = (req.headers["x-forwarded-proto"] || "").split(",")
 	return (values[values.length - trustHops] ?? values[0]).trim().toLowerCase()

--- a/gateway/test/httpsRedirect.test.js
+++ b/gateway/test/httpsRedirect.test.js
@@ -144,14 +144,26 @@ describe("the redirect target comes from config, not from the request", () => {
 			.expect("location", "https://cam.example.com:8443/command/health", done)
 	})
 
-	test("a bare IPv6 gateway_HOST is bracketed, not dropped as unparseable", (done) => {
+	test("a bracketed IPv6 gateway_HOST takes gateway_PORT_SECURE", (done) => {
+		process.env.gateway_TRUST_PROXY = "false"
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_HOST = "https://[::1]"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("Host", "[::1]:8080")
+			.expect("location", "https://[::1]:8443/command/health", done)
+	})
+
+	// "::1:8443" is a valid address as well as one way of writing [::1] port 8443, so the
+	// gateway refuses rather than sending every visitor to whichever reading it guessed
+	test("an unbracketed IPv6 gateway_HOST answers 500 instead of redirecting to a guess", (done) => {
 		process.env.gateway_TRUST_PROXY = "false"
 		process.env.gateway_PORT_SECURE = "8443"
 		process.env.gateway_HOST = "::1"
 		supertest(freshGateway())
 			.get("/command/health")
 			.set("Host", "[::1]:8080")
-			.expect("location", "https://[::1]:8443/command/health", done)
+			.expect(500, done)
 	})
 
 	test("an http:// gateway_HOST behind a proxy keeps the proxy's port, not the container's TLS port", (done) => {

--- a/gateway/test/httpsRedirect.test.js
+++ b/gateway/test/httpsRedirect.test.js
@@ -154,8 +154,6 @@ describe("the redirect target comes from config, not from the request", () => {
 			.expect("location", "https://[::1]:8443/command/health", done)
 	})
 
-	// "::1:8443" is a valid address as well as one way of writing [::1] port 8443, so the
-	// gateway refuses rather than sending every visitor to whichever reading it guessed
 	test("an unbracketed IPv6 gateway_HOST answers 500 instead of redirecting to a guess", (done) => {
 		process.env.gateway_TRUST_PROXY = "false"
 		process.env.gateway_PORT_SECURE = "8443"

--- a/gateway/test/httpsRedirectUntrustedProxy.test.js
+++ b/gateway/test/httpsRedirectUntrustedProxy.test.js
@@ -53,8 +53,6 @@ describe("gateway_HTTPS_Redirect without gateway_TRUST_PROXY", () => {
 			.expect(302, done)
 	})
 
-	// a CDN in front of an nginx that appends sends "https,http": the CDN saw https, nginx saw
-	// the plain hop to the gateway. Reading nginx's entry redirects an https visit back to itself
 	test("gateway_TRUST_PROXY=2 reads the hop two out, so a CDN in front of a proxy does not loop", (done) => {
 		process.env.gateway_TRUST_PROXY = "2"
 		supertest(freshGateway())
@@ -66,8 +64,6 @@ describe("gateway_HTTPS_Redirect without gateway_TRUST_PROXY", () => {
 			.end(done)
 	})
 
-	// nginx configured the standard way replaces the header, so two hops leave one value —
-	// the count is clamped to the frontmost entry, the same way express indexes X-Forwarded-For
 	test("gateway_TRUST_PROXY=2 clamps to the only value when a proxy replaces the header", (done) => {
 		process.env.gateway_TRUST_PROXY = "2"
 		supertest(freshGateway())

--- a/gateway/test/httpsRedirectUntrustedProxy.test.js
+++ b/gateway/test/httpsRedirectUntrustedProxy.test.js
@@ -52,4 +52,38 @@ describe("gateway_HTTPS_Redirect without gateway_TRUST_PROXY", () => {
 			.set("X-Forwarded-Proto", "https,http")
 			.expect(302, done)
 	})
+
+	// a CDN in front of an nginx that appends sends "https,http": the CDN saw https, nginx saw
+	// the plain hop to the gateway. Reading nginx's entry redirects an https visit back to itself
+	test("gateway_TRUST_PROXY=2 reads the hop two out, so a CDN in front of a proxy does not loop", (done) => {
+		process.env.gateway_TRUST_PROXY = "2"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("X-Forwarded-Proto", "https,http")
+			.expect((res) => {
+				if (res.status === 302) throw new Error("redirected despite the CDN reporting https")
+			})
+			.end(done)
+	})
+
+	// nginx configured the standard way replaces the header, so two hops leave one value —
+	// the count is clamped to the frontmost entry, the same way express indexes X-Forwarded-For
+	test("gateway_TRUST_PROXY=2 clamps to the only value when a proxy replaces the header", (done) => {
+		process.env.gateway_TRUST_PROXY = "2"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("X-Forwarded-Proto", "https")
+			.expect((res) => {
+				if (res.status === 302) throw new Error("redirected despite the proxy reporting https")
+			})
+			.end(done)
+	})
+
+	test("a value that is neither true, false nor a number trusts nothing", (done) => {
+		process.env.gateway_TRUST_PROXY = "yes"
+		supertest(freshGateway())
+			.get("/command/health")
+			.set("X-Forwarded-Proto", "https")
+			.expect(302, done)
+	})
 })

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,8 @@ module.exports = {
 	withTransaction: require("./utils/withTransaction.js"),
 	schedulableUrls: require("./utils/schedulableUrls.js"),
 	gatewayHost: require("./utils/gatewayHost.js"),
+	redirectTarget: require("./utils/redirectTarget.js"),
+	trustProxyHops: require("./utils/trustProxyHops.js"),
 	storageHost: require("./utils/storageHost.js"),
 	rateLimiter: require("./utils/rateLimit.js"),
 	isPrimeInstance: !("NODE_APP_INSTANCE" in process.env) || process.env.NODE_APP_INSTANCE === "0"

--- a/lib/test/certPaths.test.js
+++ b/lib/test/certPaths.test.js
@@ -1,3 +1,4 @@
+const fs = require("fs")
 const certPaths = require("../utils/certPaths.js")
 
 describe("certPaths", () => {
@@ -39,7 +40,7 @@ describe("certPaths", () => {
 
 	test("empty strings for an IP-literal gateway_HOST — Let's Encrypt has no path to derive", () => {
 		const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
-		process.env.gateway_HOST = "::1"
+		process.env.gateway_HOST = "https://[::1]"
 		expect(certPaths()).toEqual({ key: "", cert: "" })
 		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Cannot auto-resolve"), "[::1]", expect.any(String))
 		errorSpy.mockRestore()
@@ -60,6 +61,27 @@ describe("certPaths", () => {
 			key: "/custom/key.pem",
 			cert: "/custom/cert.pem",
 		})
+	})
+
+	test("an IP-literal gateway_HOST with both overrides set says nothing — the operator already did what the message asks", () => {
+		const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+		process.env.gateway_HOST = "https://192.168.1.50"
+		process.env.privateKey_FILEPATH = "/custom/key.pem"
+		process.env.certificate_FILEPATH = "/custom/cert.pem"
+		expect(certPaths()).toEqual({ key: "/custom/key.pem", cert: "/custom/cert.pem" })
+		expect(errorSpy).not.toHaveBeenCalled()
+		errorSpy.mockRestore()
+	})
+
+	test("an IP-literal gateway_HOST keeps a hand-placed pair that is actually there", () => {
+		const auto = certPaths.letsencryptPaths("192.168.1.50")
+		const statSpy = jest.spyOn(fs, "statSync").mockImplementation((p) => {
+			if (p !== auto.key && p !== auto.cert) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+			return { isFile: () => true }
+		})
+		process.env.gateway_HOST = "https://192.168.1.50"
+		expect(certPaths()).toEqual(auto)
+		statSpy.mockRestore()
 	})
 
 	test("fails closed when only one of privateKey_FILEPATH/certificate_FILEPATH is set alongside a resolvable gateway_HOST", () => {

--- a/lib/test/normalizeHost.test.js
+++ b/lib/test/normalizeHost.test.js
@@ -13,14 +13,20 @@ describe("normalizeHost", () => {
 		expect(normalizeHost(undefined)).toBe("")
 	})
 
-	test("brackets a bare IPv6 literal so it parses", () => {
-		expect(parses("::1")).toBe("[::1]")
-		expect(parses("2001:db8::1")).toBe("[2001:db8::1]")
+	// "::1:8443" is a valid address and also someone's [::1]:8443, and bracketing it picked the
+	// reading that redirects every visitor to a host nobody serves
+	test("refuses a bare IPv6 literal instead of guessing where the address ends", () => {
+		expect(normalizeHost("::1")).toBe("")
+		expect(normalizeHost("2001:db8::1")).toBe("")
+		expect(normalizeHost("https://::1:8443")).toBe("")
+		expect(normalizeHost("::ffff:192.168.1.1")).toBe("")
 	})
 
-	test("brackets an IPv4-mapped IPv6 literal — the dots do not stop net.isIPv6 recognising it", () => {
-		expect(normalizeHost("::ffff:192.168.1.1")).toBe("https://[::ffff:192.168.1.1]")
-		expect(parses("::ffff:192.168.1.1")).toBe("[::ffff:c0a8:101]")
+	test("bareIPv6 flags exactly what normalizeHost refuses", () => {
+		expect(normalizeHost.bareIPv6("::1")).toBe(true)
+		expect(normalizeHost.bareIPv6("https://::1:8443")).toBe(true)
+		expect(normalizeHost.bareIPv6("[::1]:8443")).toBe(false)
+		expect(normalizeHost.bareIPv6("cam.example.com")).toBe(false)
 	})
 
 	test("leaves an already-bracketed IPv6 host alone", () => {

--- a/lib/test/normalizeHost.test.js
+++ b/lib/test/normalizeHost.test.js
@@ -13,8 +13,6 @@ describe("normalizeHost", () => {
 		expect(normalizeHost(undefined)).toBe("")
 	})
 
-	// "::1:8443" is a valid address and also someone's [::1]:8443, and bracketing it picked the
-	// reading that redirects every visitor to a host nobody serves
 	test("refuses a bare IPv6 literal instead of guessing where the address ends", () => {
 		expect(normalizeHost("::1")).toBe("")
 		expect(normalizeHost("2001:db8::1")).toBe("")

--- a/lib/test/redirectTarget.test.js
+++ b/lib/test/redirectTarget.test.js
@@ -1,0 +1,38 @@
+const redirectTarget = require("../utils/redirectTarget.js")
+
+describe("redirectTarget", () => {
+	test("appends gateway_PORT_SECURE when gateway_HOST names no port", () => {
+		expect(redirectTarget({ host: "https://cam.example.com", securePort: "8443", trustProxy: false })).toBe("cam.example.com:8443")
+	})
+
+	test("443 needs no suffix — browsers drop it", () => {
+		expect(redirectTarget({ host: "https://cam.example.com", securePort: "443", trustProxy: false })).toBe("cam.example.com")
+	})
+
+	test("a port on an https gateway_HOST wins, because that is the port browsers reach", () => {
+		expect(redirectTarget({ host: "https://cam.example.com:9443", securePort: "8443", trustProxy: false })).toBe("cam.example.com:9443")
+	})
+
+	test("behind a trusted proxy the container's TLS port is not the browser-facing one, so it is dropped", () => {
+		expect(redirectTarget({ host: "https://cam.example.com", securePort: "8443", trustProxy: true })).toBe("cam.example.com")
+	})
+
+	test("an IPv6 literal keeps its brackets", () => {
+		expect(redirectTarget({ host: "https://[2001:db8::5]", securePort: "8443", trustProxy: false })).toBe("[2001:db8::5]:8443")
+	})
+
+	test("an unusable host gives no target, so the gateway can answer 500 instead of guessing", () => {
+		expect(redirectTarget({ host: "", securePort: "8443", trustProxy: false })).toBe("")
+		expect(redirectTarget({ host: "not a host", securePort: "8443", trustProxy: false })).toBe("")
+	})
+
+	test("reads gateway_HOST, gateway_PORT_SECURE and gateway_TRUST_PROXY when called with nothing", () => {
+		process.env.gateway_HOST = "https://cam.example.com"
+		process.env.gateway_PORT_SECURE = "8443"
+		process.env.gateway_TRUST_PROXY = "false"
+		expect(redirectTarget()).toBe("cam.example.com:8443")
+		delete process.env.gateway_HOST
+		delete process.env.gateway_PORT_SECURE
+		delete process.env.gateway_TRUST_PROXY
+	})
+})

--- a/lib/test/trustProxyHops.test.js
+++ b/lib/test/trustProxyHops.test.js
@@ -1,0 +1,28 @@
+const trustProxyHops = require("../utils/trustProxyHops.js")
+
+describe("trustProxyHops", () => {
+	test("true is one hop, false and blank are none", () => {
+		expect(trustProxyHops("true")).toBe(1)
+		expect(trustProxyHops("false")).toBe(0)
+		expect(trustProxyHops("")).toBe(0)
+	})
+
+	test("a number is that many hops", () => {
+		expect(trustProxyHops("2")).toBe(2)
+		expect(trustProxyHops(" 3 ")).toBe(3)
+		expect(trustProxyHops("0")).toBe(0)
+	})
+
+	test("anything unrecognised trusts nothing, which is the safe reading", () => {
+		expect(trustProxyHops("yes")).toBe(0)
+		expect(trustProxyHops("-1")).toBe(0)
+		expect(trustProxyHops("1.5")).toBe(0)
+	})
+
+	test("falls back to gateway_TRUST_PROXY", () => {
+		process.env.gateway_TRUST_PROXY = "2"
+		expect(trustProxyHops()).toBe(2)
+		delete process.env.gateway_TRUST_PROXY
+		expect(trustProxyHops()).toBe(0)
+	})
+})

--- a/lib/utils/certPaths.js
+++ b/lib/utils/certPaths.js
@@ -1,3 +1,4 @@
+const fs = require("fs")
 const net = require("net")
 const gatewayHost = require("./gatewayHost.js")
 
@@ -8,6 +9,8 @@ const letsencryptPaths = (hostname) => ({
 
 const isIpLiteral = (hostname) => net.isIP((hostname || "").replace(/^\[|\]$/g, "")) !== 0
 
+const isFile = (p) => { try { return fs.statSync(p).isFile() } catch { return false } }
+
 const certPaths = () => {
 	let hostname = ""
 	try {
@@ -16,18 +19,24 @@ const certPaths = () => {
 	} catch (e) {
 		console.error("Invalid gateway_HOST:", e.message)
 	}
-	if (isIpLiteral(hostname)) {
-		console.error("Cannot auto-resolve a certificate for the IP literal gateway_HOST:", hostname, "— Let's Encrypt issues for domain names only. Set privateKey_FILEPATH and certificate_FILEPATH instead.")
-		hostname = ""
-	}
 	const keyOverride = process.env.privateKey_FILEPATH
 	const certOverride = process.env.certificate_FILEPATH
 	if ((keyOverride && !certOverride) || (!keyOverride && certOverride)) {
 		console.error("⚠️ HTTPS misconfigured: privateKey_FILEPATH and certificate_FILEPATH must both be set, or neither.")
 		return { key: "", cert: "" }
 	}
-	const auto = hostname ? letsencryptPaths(hostname) : { key: "", cert: "" }
-	return { key: keyOverride || auto.key, cert: certOverride || auto.cert }
+	// The overrides answer the question, so the IP-literal complaint below must not run first —
+	// an operator who has already set both was told to set them on every gateway start.
+	if (keyOverride && certOverride) return { key: keyOverride, cert: certOverride }
+	if (!hostname) return { key: "", cert: "" }
+	const auto = letsencryptPaths(hostname)
+	// A hand-placed pair under the Let's Encrypt directory still works for an IP host. Only
+	// complain when there is nothing there, because then the path really is unusable.
+	if (isIpLiteral(hostname) && !(isFile(auto.key) && isFile(auto.cert))) {
+		console.error("Cannot auto-resolve a certificate for the IP literal gateway_HOST:", hostname, "— Let's Encrypt issues for domain names only. Set privateKey_FILEPATH and certificate_FILEPATH instead.")
+		return { key: "", cert: "" }
+	}
+	return auto
 }
 
 certPaths.letsencryptPaths = letsencryptPaths

--- a/lib/utils/certPaths.js
+++ b/lib/utils/certPaths.js
@@ -30,8 +30,6 @@ const certPaths = () => {
 	if (keyOverride && certOverride) return { key: keyOverride, cert: certOverride }
 	if (!hostname) return { key: "", cert: "" }
 	const auto = letsencryptPaths(hostname)
-	// A hand-placed pair under the Let's Encrypt directory still works for an IP host. Only
-	// complain when there is nothing there, because then the path really is unusable.
 	if (isIpLiteral(hostname) && !(isFile(auto.key) && isFile(auto.cert))) {
 		console.error("Cannot auto-resolve a certificate for the IP literal gateway_HOST:", hostname, "— Let's Encrypt issues for domain names only. Set privateKey_FILEPATH and certificate_FILEPATH instead.")
 		return { key: "", cert: "" }
@@ -41,4 +39,5 @@ const certPaths = () => {
 
 certPaths.letsencryptPaths = letsencryptPaths
 certPaths.isIpLiteral = isIpLiteral
+certPaths.isFile = isFile
 module.exports = certPaths

--- a/lib/utils/certPaths.js
+++ b/lib/utils/certPaths.js
@@ -25,8 +25,6 @@ const certPaths = () => {
 		console.error("⚠️ HTTPS misconfigured: privateKey_FILEPATH and certificate_FILEPATH must both be set, or neither.")
 		return { key: "", cert: "" }
 	}
-	// The overrides answer the question, so the IP-literal complaint below must not run first —
-	// an operator who has already set both was told to set them on every gateway start.
 	if (keyOverride && certOverride) return { key: keyOverride, cert: certOverride }
 	if (!hostname) return { key: "", cert: "" }
 	const auto = letsencryptPaths(hostname)

--- a/lib/utils/normalizeHost.js
+++ b/lib/utils/normalizeHost.js
@@ -6,9 +6,6 @@ const split = (host) => {
 	return { scheme, rest: scheme ? h.slice(scheme.length) : h }
 }
 
-// "::1:8443" is a valid eight-group address and it is also how someone writes [::1] port 8443.
-// Bracketing it picked one reading and sent every visitor to an address nobody serves. There is
-// no way to tell the two apart, so an unbracketed IPv6 is refused and new URL() fails loudly.
 const bareIPv6 = (host) => net.isIPv6(split(host).rest)
 
 const normalizeHost = (host) => {

--- a/lib/utils/normalizeHost.js
+++ b/lib/utils/normalizeHost.js
@@ -1,9 +1,21 @@
 const net = require("net")
 
-module.exports = (host) => {
+const split = (host) => {
 	const h = (host || "").trim().replace(/\/+$/, "")
-	if (!h) return ""
 	const scheme = /^https?:\/\//i.exec(h)?.[0]
-	const rest = scheme ? h.slice(scheme.length) : h
-	return `${scheme || "https://"}${net.isIPv6(rest) ? `[${rest}]` : rest}`
+	return { scheme, rest: scheme ? h.slice(scheme.length) : h }
 }
+
+// "::1:8443" is a valid eight-group address and it is also how someone writes [::1] port 8443.
+// Bracketing it picked one reading and sent every visitor to an address nobody serves. There is
+// no way to tell the two apart, so an unbracketed IPv6 is refused and new URL() fails loudly.
+const bareIPv6 = (host) => net.isIPv6(split(host).rest)
+
+const normalizeHost = (host) => {
+	const { scheme, rest } = split(host)
+	if (!rest || net.isIPv6(rest)) return ""
+	return `${scheme || "https://"}${rest}`
+}
+
+normalizeHost.bareIPv6 = bareIPv6
+module.exports = normalizeHost

--- a/lib/utils/rateLimit.js
+++ b/lib/utils/rateLimit.js
@@ -8,8 +8,6 @@ module.exports = (namespace) => {
 
 	const defaultKeyFn = (req) => `${req.ip || ""}:${req.path}`
 
-	// One store per limiter. A shared store lets the buckets evict each other: a flood of
-	// per-account keys would drop the flooder's own per-IP counter and hand them a fresh budget.
 	const makeReserve = ({ windowMs, max, keyFn }) => {
 		const local = memory.loginAttempts()
 		const getKey = keyFn || defaultKeyFn
@@ -27,10 +25,6 @@ module.exports = (namespace) => {
 
 	const tooMany = (res) => res.status(429).json({ error: true, errors: "Too many attempts" })
 
-	// Chained limiters, one round-trip. Every budget is reserved at once instead of one after
-	// the other, so a shared-memory deploy waits on one timeout rather than three stacked ones.
-	// The decision still walks the list in order, and a refusal releases the reservations the
-	// serial version would never have made.
 	const rateLimitChain = (optsList) => {
 		const parts = optsList.map((opts) => {
 			const getKey = opts.keyFn || defaultKeyFn
@@ -44,20 +38,15 @@ module.exports = (namespace) => {
 
 		const reserveAll = (req, skips, done) => {
 			const results = []
-			let pending = 0
-			let issued = false
-			const settle = () => { if (issued && pending === 0) done(results) }
-			parts.forEach((part, i) => {
-				if (skips[i]) return
-				pending++
-				part.budget(req, (blocked, release) => {
+			const live = parts.map((_, i) => i).filter((i) => !skips[i])
+			let pending = live.length
+			if (!pending) return done(results)
+			live.forEach((i) => {
+				parts[i].budget(req, (blocked, release) => {
 					results[i] = { blocked, release }
-					pending--
-					settle()
+					if (--pending === 0) done(results)
 				})
 			})
-			issued = true
-			settle()
 		}
 
 		const decide = (req, res, next, results) => {
@@ -84,13 +73,8 @@ module.exports = (namespace) => {
 
 		return (req, res, next) => {
 			if (!anySkip) return run(req, res, next, [])
-			const skips = []
-			let pending = parts.length
-			const settle = () => { if (--pending === 0) run(req, res, next, skips) }
-			parts.forEach((part, i) => {
-				if (!part.opts.skip) return settle()
-				part.opts.skip(req).then((s) => { skips[i] = !!s }, () => {}).then(settle)
-			})
+			Promise.all(parts.map((p) => (p.opts.skip ? p.opts.skip(req).then(Boolean, () => false) : false)))
+				.then((skips) => run(req, res, next, skips))
 		}
 	}
 

--- a/lib/utils/rateLimit.js
+++ b/lib/utils/rateLimit.js
@@ -5,11 +5,13 @@ module.exports = (namespace) => {
 	const memory = require("memory")
 	const sharedAttempts = process.env.memory_ON == "true"
 	const client = sharedAttempts ? memory.client(namespace) : null
-	const local = memory.loginAttempts()
 
 	const defaultKeyFn = (req) => `${req.ip || ""}:${req.path}`
 
+	// One store per limiter. A shared store lets the buckets evict each other: a flood of
+	// per-account keys would drop the flooder's own per-IP counter and hand them a fresh budget.
 	const makeReserve = ({ windowMs, max, keyFn }) => {
+		const local = memory.loginAttempts()
 		const getKey = keyFn || defaultKeyFn
 		const reserveLocal = (key, cb) =>
 			local.loginReserve(key, max, windowMs, (blocked) => cb(blocked, () => local.loginRelease(key)))
@@ -23,23 +25,74 @@ module.exports = (namespace) => {
 		return (req, cb) => reserve(getKey(req), cb)
 	}
 
-	const rateLimit = (opts) => {
-		const { throttleMs, skip, keyFn } = opts
-		const getKey = keyFn || defaultKeyFn
-		const budget = makeReserve(opts)
-		const throttle = throttleMs && makeReserve({ windowMs: throttleMs, max: 1, keyFn: (req) => `throttle:${getKey(req)}` })
-		const tooMany = (res) => res.status(429).json({ error: true, errors: "Too many attempts" })
-		const gate = (req, res, next) => budget(req, (blocked, release) => {
-			req.throttled ||= blocked
-			if (!blocked) {
-				if (opts.releaseOnSuccess) releaseOnSuccess(res, release)
-				return next()
+	const tooMany = (res) => res.status(429).json({ error: true, errors: "Too many attempts" })
+
+	// Chained limiters, one round-trip. Every budget is reserved at once instead of one after
+	// the other, so a shared-memory deploy waits on one timeout rather than three stacked ones.
+	// The decision still walks the list in order, and a refusal releases the reservations the
+	// serial version would never have made.
+	const rateLimitChain = (optsList) => {
+		const parts = optsList.map((opts) => {
+			const getKey = opts.keyFn || defaultKeyFn
+			return {
+				opts,
+				budget: makeReserve(opts),
+				throttle: opts.throttleMs && makeReserve({ windowMs: opts.throttleMs, max: 1, keyFn: (req) => `throttle:${getKey(req)}` }),
 			}
-			if (!throttle) return tooMany(res)
-			throttle(req, (tooSoon) => tooSoon ? tooMany(res) : next())
 		})
-		return skip ? (req, res, next) => skip(req).then((s) => (s ? next() : gate(req, res, next)), () => gate(req, res, next)) : gate
+		const anySkip = parts.some((p) => p.opts.skip)
+
+		const reserveAll = (req, skips, done) => {
+			const results = []
+			let pending = 0
+			let issued = false
+			const settle = () => { if (issued && pending === 0) done(results) }
+			parts.forEach((part, i) => {
+				if (skips[i]) return
+				pending++
+				part.budget(req, (blocked, release) => {
+					results[i] = { blocked, release }
+					pending--
+					settle()
+				})
+			})
+			issued = true
+			settle()
+		}
+
+		const decide = (req, res, next, results) => {
+			const releaseFrom = (from) => {
+				for (let i = from; i < results.length; i++) if (results[i] && !results[i].blocked) results[i].release()
+			}
+			const step = (i) => {
+				if (i >= parts.length) return next()
+				const result = results[i]
+				if (!result) return step(i + 1)
+				req.throttled ||= result.blocked
+				if (!result.blocked) {
+					if (parts[i].opts.releaseOnSuccess) releaseOnSuccess(res, result.release)
+					return step(i + 1)
+				}
+				const refuse = () => { releaseFrom(i + 1); tooMany(res) }
+				if (!parts[i].throttle) return refuse()
+				parts[i].throttle(req, (tooSoon) => tooSoon ? refuse() : step(i + 1))
+			}
+			step(0)
+		}
+
+		const run = (req, res, next, skips) => reserveAll(req, skips, (results) => decide(req, res, next, results))
+
+		return (req, res, next) => {
+			if (!anySkip) return run(req, res, next, [])
+			const skips = []
+			let pending = parts.length
+			const settle = () => { if (--pending === 0) run(req, res, next, skips) }
+			parts.forEach((part, i) => {
+				if (!part.opts.skip) return settle()
+				part.opts.skip(req).then((s) => { skips[i] = !!s }, () => {}).then(settle)
+			})
+		}
 	}
 
-	return { rateLimit, client }
+	return { rateLimit: (opts) => rateLimitChain([opts]), rateLimitChain, client }
 }

--- a/lib/utils/redirectTarget.js
+++ b/lib/utils/redirectTarget.js
@@ -1,0 +1,25 @@
+const gatewayHost = require("./gatewayHost.js")
+const trustProxyHops = require("./trustProxyHops.js")
+
+const DEFAULT_SECURE_PORT = "443"
+
+// Where the HTTPS redirect sends an http:// visitor, in one place. gateway.js redirects here and
+// preflight checks the same value against gateway_HOST, so the two cannot drift apart.
+const redirectTarget = ({
+	host = gatewayHost(),
+	securePort = process.env.gateway_PORT_SECURE || DEFAULT_SECURE_PORT,
+	trustProxy = trustProxyHops() > 0,
+} = {}) => {
+	try {
+		const url = new URL(host)
+		if (url.protocol == "https:" && url.port) return url.host
+		const suffix = trustProxy || String(securePort) == DEFAULT_SECURE_PORT ? "" : `:${securePort}`
+		return `${url.hostname}${suffix}`
+	}
+	catch {
+		return ""
+	}
+}
+
+redirectTarget.DEFAULT_SECURE_PORT = DEFAULT_SECURE_PORT
+module.exports = redirectTarget

--- a/lib/utils/redirectTarget.js
+++ b/lib/utils/redirectTarget.js
@@ -3,8 +3,6 @@ const trustProxyHops = require("./trustProxyHops.js")
 
 const DEFAULT_SECURE_PORT = "443"
 
-// Where the HTTPS redirect sends an http:// visitor, in one place. gateway.js redirects here and
-// preflight checks the same value against gateway_HOST, so the two cannot drift apart.
 const redirectTarget = ({
 	host = gatewayHost(),
 	securePort = process.env.gateway_PORT_SECURE || DEFAULT_SECURE_PORT,

--- a/lib/utils/trustProxyHops.js
+++ b/lib/utils/trustProxyHops.js
@@ -1,0 +1,8 @@
+// gateway_TRUST_PROXY says how many proxies sit in front: "true" is one, "false" or unset is
+// none, a number is that many. The count picks which X-Forwarded-* entry to believe — the one
+// the outermost trusted hop wrote. Anything unrecognised reads as none, which trusts nothing.
+module.exports = (val = process.env.gateway_TRUST_PROXY) => {
+	const v = (val || "").trim()
+	if (v === "true") return 1
+	return /^\d+$/.test(v) ? Number(v) : 0
+}

--- a/lib/utils/trustProxyHops.js
+++ b/lib/utils/trustProxyHops.js
@@ -1,8 +1,13 @@
-// gateway_TRUST_PROXY says how many proxies sit in front: "true" is one, "false" or unset is
-// none, a number is that many. The count picks which X-Forwarded-* entry to believe — the one
-// the outermost trusted hop wrote. Anything unrecognised reads as none, which trusts nothing.
-module.exports = (val = process.env.gateway_TRUST_PROXY) => {
-	const v = (val || "").trim()
+const clean = (val) => (val || "").trim()
+
+const trustProxyHops = (val = process.env.gateway_TRUST_PROXY) => {
+	const v = clean(val)
 	if (v === "true") return 1
 	return /^\d+$/.test(v) ? Number(v) : 0
 }
+
+trustProxyHops.validTrustProxy = (val) => {
+	const v = clean(val)
+	return v === "true" || v === "false" || /^\d+$/.test(v)
+}
+module.exports = trustProxyHops

--- a/memory/lib/loginAttempts.js
+++ b/memory/lib/loginAttempts.js
@@ -1,16 +1,24 @@
 module.exports = () => {
 	const hits = new Map()
 	const MAX_KEYS = 20000
+	// Eviction order decides who wins a flood. Sorting by reset dropped every short-window key
+	// first, which is exactly the 15-minute per-account counter sitting at its max, while the
+	// 24h day counters were never touched. Order by what an eviction gives back instead: a
+	// counter at its max is the one doing the blocking, so it goes last. Three passes over the
+	// map, no copy and no sort, because this runs inside the login request.
 	const prune = (now) => {
 		if(hits.size > 5000) for(const [k, v] of hits) if(now > v.reset) hits.delete(k)
-		if(hits.size > MAX_KEYS){
-			const target = MAX_KEYS - (MAX_KEYS >> 3)
-			const soonestFirst = [...hits.entries()].sort((a, b) => a[1].reset - b[1].reset)
-			for(const [k] of soonestFirst){
-				if(hits.size <= target) break
-				hits.delete(k)
+		if(hits.size <= MAX_KEYS) return
+		const target = MAX_KEYS - (MAX_KEYS >> 3)
+		const sweep = (evictable) => {
+			for(const [k, v] of hits){
+				if(hits.size <= target) return
+				if(evictable(v)) hits.delete(k)
 			}
 		}
+		sweep((v) => v.count <= 1 && v.count < v.max)
+		sweep((v) => v.count < v.max)
+		sweep(() => true)
 	}
 	return {
 		loginReserve: (key, max, windowMs, callback=()=>{}) => {

--- a/memory/lib/loginAttempts.js
+++ b/memory/lib/loginAttempts.js
@@ -1,11 +1,6 @@
 module.exports = () => {
 	const hits = new Map()
 	const MAX_KEYS = 20000
-	// Eviction order decides who wins a flood. Sorting by reset dropped every short-window key
-	// first, which is exactly the 15-minute per-account counter sitting at its max, while the
-	// 24h day counters were never touched. Order by what an eviction gives back instead: a
-	// counter at its max is the one doing the blocking, so it goes last. Three passes over the
-	// map, no copy and no sort, because this runs inside the login request.
 	const prune = (now) => {
 		if(hits.size > 5000) for(const [k, v] of hits) if(now > v.reset) hits.delete(k)
 		if(hits.size <= MAX_KEYS) return

--- a/memory/test/loginAttempts.test.js
+++ b/memory/test/loginAttempts.test.js
@@ -38,8 +38,6 @@ describe("loginAttempts", () => {
 		expect(blocked).toBe(true)
 	})
 
-	// the account counter is the shortest-lived key in the map, so evicting by expiry dropped
-	// exactly the counter that was blocking and handed the attacker a fresh 10 guesses
 	test("a per-account counter at its max survives a flood, even though it expires first", () => {
 		const { loginReserve } = makeLoginAttempts()
 		for (let i = 0; i < 10; i++) loginReserve("user:victim", 10, 15 * 60 * 1000, () => {})

--- a/memory/test/loginAttempts.test.js
+++ b/memory/test/loginAttempts.test.js
@@ -29,7 +29,7 @@ describe("loginAttempts", () => {
 		expect(blocked).toBe(false)
 	})
 
-	test("eviction drops the soonest-to-expire keys first, so a spent daily budget outlives a flood of short-window ones", () => {
+	test("a spent daily budget outlives a flood of fresh short-window keys", () => {
 		const { loginReserve } = makeLoginAttempts()
 		loginReserve("day:ip:attacker", 1, 24 * 60 * 60 * 1000, () => {})
 		for (let i = 0; i < 21000; i++) loginReserve(`flood-${i}`, 100, 15 * 60 * 1000, () => {})
@@ -38,15 +38,23 @@ describe("loginAttempts", () => {
 		expect(blocked).toBe(true)
 	})
 
-	test("eviction past MAX_KEYS is age-based, not preferential to non-saturated victim counters", () => {
+	// the account counter is the shortest-lived key in the map, so evicting by expiry dropped
+	// exactly the counter that was blocking and handed the attacker a fresh 10 guesses
+	test("a per-account counter at its max survives a flood, even though it expires first", () => {
 		const { loginReserve } = makeLoginAttempts()
-		loginReserve("saturated-old", 1, 60000, () => {})
-		loginReserve("victim", 10, 60000, () => {})
-		for (let i = 0; i < 20000; i++) loginReserve(`flood-${i}`, 100, 60000, () => {})
-		let victimBlocked
-		loginReserve("victim", 10, 60000, (b) => { victimBlocked = b })
-		let saturatedBlocked
-		loginReserve("saturated-old", 1, 60000, (b) => { saturatedBlocked = b })
-		expect(victimBlocked).toBe(saturatedBlocked)
+		for (let i = 0; i < 10; i++) loginReserve("user:victim", 10, 15 * 60 * 1000, () => {})
+		for (let i = 0; i < 21000; i++) loginReserve(`day:ip:flood-${i}`, 100, 24 * 60 * 60 * 1000, () => {})
+		let blocked
+		loginReserve("user:victim", 10, 15 * 60 * 1000, (b) => { blocked = b })
+		expect(blocked).toBe(true)
+	})
+
+	test("a saturated counter outlives a flood of same-window keys that are still under their max", () => {
+		const { loginReserve } = makeLoginAttempts()
+		loginReserve("saturated", 1, 60000, () => {})
+		for (let i = 0; i < 21000; i++) loginReserve(`flood-${i}`, 100, 60000, () => {})
+		let blocked
+		loginReserve("saturated", 1, 60000, (b) => { blocked = b })
+		expect(blocked).toBe(true)
 	})
 })


### PR DESCRIPTION
Closes the 8 open review threads on #490. Two blockers, six follow-ups.

## Blockers

### 1. Eviction order defeated the per-account limit — `memory/lib/loginAttempts.js`

`prune` sorted by `reset` and dropped the soonest-to-expire keys. The 15-minute `user:<account>` counter is always the soonest, so a spray past 20,000 keys evicted the very counter sitting at its max of 10 and left the 24h `day:ip:*` keys untouched.

Eviction now orders by how close a counter is to its max, because that is what an eviction gives back:

| pass | evicts |
|---|---|
| 1 | `count <= 1` and under max — one request to rebuild |
| 2 | anything under its max |
| 3 | anything |

Three O(n) passes over the map, no copy and no sort. The old path allocated a 20,000-element array and sorted it inside the login request.

### 2. One store for the whole AUTH namespace — `lib/utils/rateLimit.js`

Hoisting `memory.loginAttempts()` out of `makeReserve` put `ip:`, `day:ip:`, `user:` and `throttle:` keys in one 20,000-key map, where they evicted each other. An attacker posting 20,000 usernames dropped their own `ip:<addr>` entry and resumed with a fresh budget. Each limiter holds its own store again.

## Follow-ups

| # | File | Fix |
|---|---|---|
| 3 | `lib/utils/certPaths.js` | Read the FILEPATH overrides before the IP-literal check. An operator who had set both was told to set them on every gateway start. A hand-placed pair under `/etc/letsencrypt/live/<ip>/` is also kept now when the files are there, instead of turning off a working TLS listener. |
| 4 | `lib/utils/normalizeHost.js` | Refuse an unbracketed IPv6. `net.isIPv6("::1:8443")` is true, so bracketing produced `[::1:8443]` — a valid address nobody serves. It parsed, preflight passed it, and every http:// visitor was redirected there. preflight now names the fix: write `https://[::1]:8443`. |
| 5 | `gateway/gateway.js` | `gateway_TRUST_PROXY` takes a hop count. See below. |
| 6 | `lib/utils/redirectTarget.js` (new) | `gateway.js` and `preflight.js` built the redirect target independently. preflight already had the gap: with `gateway_HOST=https://example.com` and `gateway_PORT_SECURE=8443` it stayed silent while `gateway.js` appended `:8443`, so share links and certbot named a port nothing listens on. One function now, both callers. |
| 7 | `chimera/preflight.js` | `configuredCertPair(lines).paths.map(certStatus)` runs once per run and is passed to the three warnings. It was about six `openSync`/`fstatSync`/`closeSync` sets per path, and a renewal landing mid-run could make the "unreadable" list and the "maybe present" verdict contradict each other. |
| 8 | `command/backend/routes/authorization.js` | The three login budgets reserve together instead of one after the other. With `memory_ON=true` that is one round-trip per login, not three — up to six once the throttles engaged. |

### On `X-Forwarded-Proto` — hop count instead of `[0]`

The comment asked for `.split(",")[0]`, to match the `req.secure` this replaced.

`.pop()` is not an accident: #493 added it, `gateway/README.md` documents it, and a test covers it. Express reads the **first** entry, which a client can forge whenever the adjacent proxy appends rather than replaces — `X-Forwarded-Proto: https` from the client, `http` appended by nginx, and express reads the client's value. Switching to `[0]` reintroduces that.

Both readings are right for a different number of hops, so the hop count is now explicit:

```
gateway_TRUST_PROXY = false | true | <how many proxies>
```

The gateway counts back from the end of the header by that number, the same way `req.ip` picks the client out of `X-Forwarded-For`, and clamps to the first entry when there are fewer values than hops. `true` is one hop and behaves exactly as before. The comment's CDN → nginx → gateway deploy sets `2` and reads the CDN's `https`. `app.set("trust proxy", trustHops)` follows, which also narrows the client-IP limitation noted in #490 for that deploy.

## Not changed

`gateway.js` still answers 500 when `gateway_HOST` is unusable rather than falling back to the browser's `Host` header — forgeable, and preflight refuses the config first.

## Verification

101 test suites, 1298 tests pass. Lint: 0 errors, 122 warnings (cap 150).

New tests: eviction keeps a saturated account counter through a flood; a chain refusal hands back the later reservations; a chain lets a throttled-through budget reach the later ones; `redirectTarget` and `trustProxyHops` in full; `gateway_TRUST_PROXY=2` against an appending proxy, its clamp, and an unrecognised value; an unbracketed IPv6 `gateway_HOST` answering 500; an IP-literal host with overrides staying quiet, and with a real pair on disk being kept; preflight's port warning firing on the drift gap; `gateway_TRUST_PROXY` validation.
