### PR TITLE
Let a correct password through a throttled login

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -40,7 +40,7 @@ Three access levels: public, session (`authorize`), admin (`requireAdmin`). Auth
 | daily | IP address | yes |
 | account | username | yes |
 
-No limit ends in a hard block. Once a limit is used up, the route runs one password check per window and answers 429 to every other request at once. Nothing waits in a queue, so a flood cannot build latency. That one check also answers 429 when the password is wrong, so a 429 does not prove the password went unchecked.
+No limit ends in a hard block. Once a limit is used up, the route runs one password check per window and answers 429 to every other request at once. Nothing waits in a queue, so a flood cannot build latency. That one check decides the request: a correct password logs in, a wrong one answers 429, so a 429 does not prove the password went unchecked.
 
 | response | the slot is |
 |---|---|

--- a/command/backend/routes/lib/auth.js
+++ b/command/backend/routes/lib/auth.js
@@ -56,7 +56,7 @@ module.exports = {
 			const row = values.rows[0]
 			bcrypt.compare(password === undefined ? "" : password, row && row.hash ? row.hash : DUMMY_HASH, (err, success) => {
 				if (err) return serverError()
-				if (req.throttled || !success || !row || !row.hash) return deny()
+				if (!success || !row || !row.hash) return deny()
 				req.userRole = row.role
 				req.deviceKey = deviceKey(row.hash)
 				req.forcePasswordChange = row.force_password_change

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -1111,18 +1111,20 @@ describe("Authorization Routes", () => {
 				.post("/authorization/login")
 				.set("X-Forwarded-For", "192.0.2.99")
 				.send({ username: "dosvictim", password: "mockedPassword" })
-			expect(res.status).toBe(429)
-			expect(res.body.errors).toBe("TOO_MANY_ATTEMPTS")
+			expect(res.status).toBe(200)
+			expect(res.body.error).toBe(false)
 		})
 
 		test("only one credential check runs per throttle window once the budget is spent", async () => {
+			const now = Date.now()
+			jest.spyOn(Date, "now").mockImplementation(() => now)
 			for (let i = 0; i < 10; i++) {
 				await supertest(app)
 					.post("/authorization/login")
 					.set("X-Forwarded-For", `192.0.2.${160 + i}`)
 					.send({ username: "floodvictim", password: "wrongpassword" })
 			}
-			const start = Date.now()
+			const start = process.hrtime.bigint()
 			const first = await supertest(app)
 				.post("/authorization/login")
 				.set("X-Forwarded-For", "192.0.2.180")
@@ -1131,9 +1133,9 @@ describe("Authorization Routes", () => {
 				.post("/authorization/login")
 				.set("X-Forwarded-For", "192.0.2.181")
 				.send({ username: "floodvictim", password: "mockedPassword" })
-			expect(first.status).toBe(429)
+			expect(first.status).toBe(200)
 			expect(second.status).toBe(429)
-			expect(Date.now() - start).toBeLessThan(1000)
+			expect(Number(process.hrtime.bigint() - start) / 1e6).toBeLessThan(1000)
 		})
 
 		// the throttle slot is one per username and anyone can take it, so a long window would hand an
@@ -1167,7 +1169,7 @@ describe("Authorization Routes", () => {
 				.post("/authorization/login")
 				.set("X-Forwarded-For", "192.0.2.52")
 				.send({ username, password: "mockedPassword" })
-			expect(tenSecondsLater.status).toBe(429)
+			expect(tenSecondsLater.status).toBe(200)
 		})
 
 		test("a throttled request is refused immediately instead of being queued", async () => {
@@ -1200,12 +1202,14 @@ describe("Authorization Routes", () => {
 				.post("/authorization/login")
 				.set("X-Forwarded-For", shared)
 				.send({ username: "sharedvictim", password: "mockedPassword" })
-			expect(res.status).toBe(429)
+			expect(res.status).toBe(200)
 		})
 
 		// one username for the whole spray, so the per-username throttle refuses most
 		// of it before passwordCheck and the loop costs ~11 bcrypt compares, not 20
 		test("a spent per-IP budget throttles instead of blocking, and a device token does not skip it", async () => {
+			const now = Date.now()
+			jest.spyOn(Date, "now").mockImplementation(() => now)
 			const ip = "198.18.3.3"
 			const agent = supertest.agent(app)
 			const enrol = await agent
@@ -1225,7 +1229,7 @@ describe("Authorization Routes", () => {
 				.post("/authorization/login")
 				.set("X-Forwarded-For", ip)
 				.send({ username: "sprayvictim", password: "mockedPassword" })
-			expect(first.status).toBe(429)
+			expect(first.status).toBe(200)
 
 			const second = await supertest(app)
 				.post("/authorization/login")
@@ -1309,7 +1313,7 @@ describe("Authorization Routes", () => {
 				.post("/authorization/login")
 				.set("X-Forwarded-For", ip)
 				.send({ username: "daytokenuser", password: "mockedPassword" })
-			expect(stranger.status).toBe(429)
+			expect(stranger.status).toBe(200)
 
 			const throttled = await supertest(app)
 				.post("/authorization/login")
@@ -1393,6 +1397,8 @@ describe("Authorization Routes", () => {
 		})
 
 		test("a device token for another username does not skip the throttle", async () => {
+			const now = Date.now()
+			jest.spyOn(Date, "now").mockImplementation(() => now)
 			const agent = supertest.agent(app)
 			await agent
 				.post("/authorization/login")
@@ -1418,6 +1424,8 @@ describe("Authorization Routes", () => {
 		})
 
 		test("a password change voids the device token", async () => {
+			const now = Date.now()
+			jest.spyOn(Date, "now").mockImplementation(() => now)
 			const agent = supertest.agent(app)
 			const enrol = await agent
 				.post("/authorization/login")
@@ -1441,6 +1449,8 @@ describe("Authorization Routes", () => {
 		})
 
 		test("a deleted account voids the device token", async () => {
+			const now = Date.now()
+			jest.spyOn(Date, "now").mockImplementation(() => now)
 			const agent = supertest.agent(app)
 			await agent
 				.post("/authorization/login")


### PR DESCRIPTION
Restores the deny condition that `77b4b54` changed.

```diff
-if (req.throttled || !success || !row || !row.hash) return deny()
+if (!success || !row || !row.hash) return deny()
```

With the flag in the condition, the one request a spent budget lets through per window answers 429 **whatever the password is**. A spent burst budget becomes a hard 15-minute block, and the burst limit takes no device-token skip — so everyone behind a shared exit address is locked out, including daily users of the same browser. `command/README.md:43` says the opposite: "No limit ends in a hard block."

The `bcrypt.compare` above it still ran at cost 10 and its result was thrown away — the same event-loop cost the README names as a DoS vector, on the one path meant to absorb a flood.

## Why this keeps flipping

`auth.js:59` has changed four times since #487, twice inside #518 alone, and has never been reviewed on its own merits — `77b4b54` was a direct commit to `develop` with no PR.

Two rules meet on this line and no PR ever ranked them:

| rule | wants the throttled-through check to |
|---|---|
| a real user with the right password is never locked out (#487, `README.md:43`) | decide the request |
| a spent budget costs the attacker guesses (`README.md:70`) | be refused anyway |

This PR ranks the first above the second and records it in `command/README.md`, so the next round has something to disagree with.

## The throughput objection is already measured

#518's revert was driven by two review comments about **`rateLimit.js`**, not this line — `auth.js` appeared in them only as a premise. That comment measured:

> 195 password checks on `39f2d597` vs 475 on this head; **reverting only this file returns it to 195**

"This file" is `rateLimit.js`. So dropping `req.throttled ||` on its own measures **195 checks per 24 h from one address — the same as today**. The 475 came from the `releaseFrom(i + 1)` change, which #518 correctly reverted and which this PR does not touch.

## Tests

Six assertions restored to 200 — their names already described this behaviour and contradicted their own expectations, e.g. *"a correct password still logs in after wrong attempts exhaust the per-username budget"* asserted 429.

Five tests also made deterministic. They passed before only *because* the flag forced a 429 regardless of limiter state; without it they depend on the real 10-second throttle window, which a loaded run can exceed. `Date.now()` is frozen in each, matching the neighbouring throttle-window test. `only one credential check runs per throttle window` keeps a real-clock latency check via `process.hrtime.bigint()`.

Lint clean. `command/test/authorization.test.js` alone: 26 runs clean, 15 of them under synthetic CPU load.

## Not changed

`lib/utils/rateLimit.js` and `memory/lib/loginAttempts.js`. `releaseFrom(0)` stays.

## Suite flakiness — pre-existing, not from this change

The full 9-project run is flaky under parallel load on both sides. Interleaved A/B against `origin/develop`, 8 runs each:

| arm | failed runs | failures inside the tests this PR touches |
|---|---|---|
| `origin/develop` | 1 | 1 — `a known device still has to pass the password check` |
| this branch | 3 | 0 — 2× Livestream, 1× `DELETE /users` (runs before the changed tests) |

The baseline flakes inside the rateLimit block too, so the sensitivity is in the suite rather than in this change. None of it reproduces in isolation: `command/test/authorization.test.js` alone is clean over 26 runs, 15 of them under synthetic CPU load.

Worth a separate look, not a blocker here. The likeliest candidate is `loginReserve` checking `count >= max` before incrementing, so one late `releaseOnSuccess` re-opens a spent budget by a slot.

## Note on the record

#518's description lists three fixes. Only the third (`loginAttempts.js`) merged — `fed37613` reverted the other two before the squash, and the body was never updated.
