### PR TITLE
Make the login-page language selection stick

### DIFF
--- a/command/e2e/language.spec.js
+++ b/command/e2e/language.spec.js
@@ -6,6 +6,8 @@ const pick = async (page, label) => {
 	await page.getByRole("option", { name: label }).click()
 }
 
+const expand = (page) => page.getByRole("button", { name: "Change language" }).click()
+
 const capturePuts = async (page, puts, response = json({ error: false }), hold) =>
 	page.route("**/authorization/language", async (route) => {
 		if (route.request().method() !== "PUT") return route.fallback()
@@ -15,6 +17,18 @@ const capturePuts = async (page, puts, response = json({ error: false }), hold) 
 	})
 
 test.describe("language", () => {
+	test("the login page starts in English with the picker hidden behind Change language", async ({ page }) => {
+		await mockApi(page)
+		await page.addInitScript(() => {
+			Object.defineProperty(navigator, "languages", { value: ["es-ES", "es"], configurable: true })
+		})
+		await page.goto("/")
+
+		await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible()
+		await expect(page.getByRole("combobox")).toBeHidden()
+		await expect(page.getByRole("button", { name: "Change language" })).toBeVisible()
+	})
+
 	test("picking a language before login translates the page and persists it locally", async ({ page }) => {
 		const puts = []
 		await mockApi(page)
@@ -22,12 +36,31 @@ test.describe("language", () => {
 		await page.goto("/")
 		await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible()
 
+		await expand(page)
 		await pick(page, "Español")
 
 		await expect(page.getByRole("button", { name: "Iniciar sesión" })).toBeVisible()
 		await expect.poll(() => page.evaluate(() => localStorage.getItem("language"))).toBe("es")
 		await expect.poll(() => page.evaluate(() => document.documentElement.lang)).toBe("es")
 		expect(puts).toHaveLength(0)
+	})
+
+	test("a language picked on the login page survives the login and is saved to the account", async ({ page }) => {
+		const puts = []
+		await mockApi(page)
+		await capturePuts(page, puts)
+		await page.goto("/")
+		await expand(page)
+		await pick(page, "Español")
+		await expect(page.getByRole("button", { name: "Iniciar sesión" })).toBeVisible()
+
+		await page.getByPlaceholder("nombre de usuario").fill("admin")
+		await page.getByPlaceholder("contraseña").fill("password123")
+		await page.getByRole("button", { name: "Iniciar sesión" }).click()
+
+		await expect(page.getByRole("button", { name: "En vivo" })).toBeVisible()
+		await expect.poll(() => puts.at(-1)).toEqual({ language: "es" })
+		await expect.poll(() => page.evaluate(() => localStorage.getItem("language"))).toBe("es")
 	})
 
 	test("picking a language while signed in translates the app and fires PUT", async ({ page }) => {

--- a/command/frontend/app/LanguageContext.jsx
+++ b/command/frontend/app/LanguageContext.jsx
@@ -3,7 +3,7 @@ import moment from "moment"
 import { request } from "../js/request.js"
 import toast from "../js/toast.js"
 import i18n, { changeLanguage } from "../js/i18n.js"
-import { resolveLanguage, detectLanguage, LANGUAGES } from "../js/languages.js"
+import { resolveLanguage, LANGUAGES } from "../js/languages.js"
 
 const identity = (s) => s
 
@@ -25,18 +25,19 @@ const saveLanguage = (language, onFailure) =>
 		.catch(onFailure))
 
 export const LanguageProvider = ({ serverLanguage, loggedIn, children }) => {
-	const [language, setLanguage] = useState(() => resolveLanguage(localStorage.getItem("language")) ?? detectLanguage())
+	const [language, setLanguage] = useState(() => resolveLanguage(localStorage.getItem("language")) ?? "en")
 	const selected = useRef(language)
 	const loaded = useRef("en")
 	const picked = useRef(null)
 
 	const rollback = (previous, messageKey) => () => {
+		picked.current = null
 		toast(i18n.t(messageKey))
 		setLanguage(previous)
 	}
 
 	useEffect(() => {
-		if (!loggedIn) return
+		if (!loggedIn || picked.current) return
 		setLanguage(resolveLanguage(serverLanguage) ?? "en")
 	}, [serverLanguage, loggedIn])
 
@@ -64,7 +65,7 @@ export const LanguageProvider = ({ serverLanguage, loggedIn, children }) => {
 				if (!stale) rollback(loaded.current, "language.loadFailed")()
 			})
 		return () => { stale = true }
-	}, [language])
+	}, [language, loggedIn])
 
 	const applyLanguage = (next) => {
 		picked.current = next

--- a/command/frontend/app/LanguagePicker.jsx
+++ b/command/frontend/app/LanguagePicker.jsx
@@ -1,14 +1,22 @@
-import React, { useId } from "react"
+import React, { useId, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { Button } from "../components/ui/button"
 import { Label } from "../components/ui/label"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "../components/ui/select"
 import { useLanguage } from "./LanguageContext.jsx"
 import tags, { LANGUAGES } from "../js/languages.js"
 
-const LanguagePicker = () => {
+const LanguagePicker = ({ collapsible = false }) => {
 	const { language, applyLanguage } = useLanguage()
 	const { t } = useTranslation()
 	const uid = useId()
+	const [expanded, setExpanded] = useState(!collapsible)
+
+	if (!expanded) return (
+		<Button type="button" variant="link" size="sm" onClick={() => setExpanded(true)} className="self-center text-muted">
+			{t("language.change")}
+		</Button>
+	)
 
 	return (
 		<div className="flex flex-col gap-1">

--- a/command/frontend/app/LoginForm.jsx
+++ b/command/frontend/app/LoginForm.jsx
@@ -61,7 +61,7 @@ const LoginForm = (props) => {
 					>
 						{t("auth.signIn")}
 					</Button>
-					<LanguagePicker />
+					<LanguagePicker collapsible />
 				</form>
 			</CardContent>
 		</Card>

--- a/command/frontend/js/languages.js
+++ b/command/frontend/js/languages.js
@@ -16,25 +16,15 @@ export const LANGUAGES = {
 
 const VARIANT_SUBTAGS = { "zh-CN": ["hans", "cn", "sg"], "pt-BR": ["br"] }
 
-export const resolveLanguage = (tag, lenient = false) => {
+export const resolveLanguage = (tag) => {
 	if (typeof tag !== "string" || !tag) return null
 	const lower = tag.toLowerCase()
 	const exact = tags.find((t) => t.toLowerCase() === lower)
 	if (exact) return exact
 	const [base, ...subtags] = lower.split("-")
 	const variant = Object.keys(VARIANT_SUBTAGS).find((t) => t.toLowerCase().split("-")[0] === base)
-	if (variant) {
-		if (!subtags.length || subtags.some((s) => VARIANT_SUBTAGS[variant].includes(s))) return variant
-		if (!lenient) return null
-	}
+	if (variant) return !subtags.length || subtags.some((s) => VARIANT_SUBTAGS[variant].includes(s)) ? variant : null
 	return tags.find((t) => t.toLowerCase().split("-")[0] === base) ?? null
-}
-
-export const detectLanguage = () => {
-	const candidates = navigator.languages?.length ? navigator.languages : [navigator.language]
-	return candidates.map((tag) => resolveLanguage(tag)).find(Boolean)
-		?? candidates.map((tag) => resolveLanguage(tag, true)).find(Boolean)
-		?? "en"
 }
 
 export default tags

--- a/command/frontend/locales/de.json
+++ b/command/frontend/locales/de.json
@@ -163,6 +163,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} gelöscht"
 	},
 	"language": {
+		"change": "Sprache ändern",
 		"label": "Sprache",
 		"loadFailed": "Sprache konnte nicht geladen werden",
 		"preferences": "Einstellungen",

--- a/command/frontend/locales/en.json
+++ b/command/frontend/locales/en.json
@@ -163,6 +163,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} Deleted"
 	},
 	"language": {
+		"change": "Change language",
 		"label": "Language",
 		"loadFailed": "Couldn't load language",
 		"preferences": "Preferences",

--- a/command/frontend/locales/es.json
+++ b/command/frontend/locales/es.json
@@ -164,6 +164,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} eliminados"
 	},
 	"language": {
+		"change": "Cambiar idioma",
 		"label": "Idioma",
 		"loadFailed": "No se pudo cargar el idioma",
 		"preferences": "Preferencias",

--- a/command/frontend/locales/fr.json
+++ b/command/frontend/locales/fr.json
@@ -164,6 +164,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} supprimés"
 	},
 	"language": {
+		"change": "Changer de langue",
 		"label": "Langue",
 		"loadFailed": "Impossible de charger la langue",
 		"preferences": "Préférences",

--- a/command/frontend/locales/gu.json
+++ b/command/frontend/locales/gu.json
@@ -163,6 +163,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} કાઢી નાખવામાં આવી"
 	},
 	"language": {
+		"change": "ભાષા બદલો",
 		"label": "ભાષા",
 		"loadFailed": "ભાષા લોડ કરી શકાઈ નહીં",
 		"preferences": "પસંદગીઓ",

--- a/command/frontend/locales/hi.json
+++ b/command/frontend/locales/hi.json
@@ -163,6 +163,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} हटाई गईं"
 	},
 	"language": {
+		"change": "भाषा बदलें",
 		"label": "भाषा",
 		"loadFailed": "भाषा लोड नहीं की जा सकी",
 		"preferences": "प्राथमिकताएं",

--- a/command/frontend/locales/ja.json
+++ b/command/frontend/locales/ja.json
@@ -162,6 +162,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} 件削除済み"
 	},
 	"language": {
+		"change": "言語を変更",
 		"label": "言語",
 		"loadFailed": "言語を読み込めませんでした",
 		"preferences": "環境設定",

--- a/command/frontend/locales/ko.json
+++ b/command/frontend/locales/ko.json
@@ -162,6 +162,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} 삭제됨"
 	},
 	"language": {
+		"change": "언어 변경",
 		"label": "언어",
 		"loadFailed": "언어를 불러오지 못했습니다",
 		"preferences": "환경설정",

--- a/command/frontend/locales/pt-BR.json
+++ b/command/frontend/locales/pt-BR.json
@@ -164,6 +164,7 @@
 		"partialDeleted": "{{deleted}}/{{total}} Excluídos"
 	},
 	"language": {
+		"change": "Alterar idioma",
 		"label": "Idioma",
 		"loadFailed": "Não foi possível carregar o idioma",
 		"preferences": "Preferências",

--- a/command/frontend/locales/ru.json
+++ b/command/frontend/locales/ru.json
@@ -165,6 +165,7 @@
 		"partialDeleted": "Удалено {{deleted}}/{{total}}"
 	},
 	"language": {
+		"change": "Изменить язык",
 		"label": "Язык",
 		"loadFailed": "Не удалось загрузить язык",
 		"preferences": "Настройки",

--- a/command/frontend/locales/zh-CN.json
+++ b/command/frontend/locales/zh-CN.json
@@ -162,6 +162,7 @@
 		"partialDeleted": "已删除 {{deleted}}/{{total}}"
 	},
 	"language": {
+		"change": "更改语言",
 		"label": "语言",
 		"loadFailed": "无法加载语言设置",
 		"preferences": "偏好设置",

--- a/command/test/languageContext.test.jsx
+++ b/command/test/languageContext.test.jsx
@@ -66,33 +66,38 @@ test("a fresh login with no server language lands on en rather than a stale loca
 	expect(screen.getByTestId("language").textContent).toBe("en")
 })
 
-test("a logged-out render falls back to navigator.language on the base tag", () => {
+test("a logged-out render starts on en rather than the browser's language", () => {
 	Object.defineProperty(navigator, "languages", { value: ["es-MX"], configurable: true })
 
 	renderWithProvider({ serverLanguage: "ko", loggedIn: false })
 
-	expect(screen.getByTestId("language").textContent).toBe("es")
+	expect(screen.getByTestId("language").textContent).toBe("en")
+})
+
+test("a logged-out render restores the language the user last chose", () => {
+	localStorage.setItem("language", "ja")
+
+	renderWithProvider({ serverLanguage: null, loggedIn: false })
+
+	expect(screen.getByTestId("language").textContent).toBe("ja")
 })
 
 test.each([
-	[["pt-PT", "fr"], "fr"],
-	[["zh-TW", "ja"], "ja"],
-	[["zh-Hant", "ja"], "ja"],
-	[["zh-HK", "ja"], "ja"],
-	[["zh-Hans"], "zh-CN"],
-	[["zh-SG"], "zh-CN"],
-	[["zh"], "zh-CN"],
-	[["pt"], "pt-BR"]
-])("%s resolves to %s", (languages, expected) => {
-	Object.defineProperty(navigator, "languages", { value: languages, configurable: true })
+	["es-MX", "es"],
+	["zh-Hans", "zh-CN"],
+	["zh-SG", "zh-CN"],
+	["zh", "zh-CN"],
+	["pt", "pt-BR"]
+])("a stored %s resolves to %s", (stored, expected) => {
+	localStorage.setItem("language", stored)
 
 	renderWithProvider({ serverLanguage: null, loggedIn: false })
 
 	expect(screen.getByTestId("language").textContent).toBe(expected)
 })
 
-test("an unsupported navigator language falls back to en", () => {
-	Object.defineProperty(navigator, "languages", { value: ["is-IS"], configurable: true })
+test.each(["pt-PT", "zh-TW", "zh-Hant", "zh-HK", "is-IS"])("a stored %s falls back to en", (stored) => {
+	localStorage.setItem("language", stored)
 
 	renderWithProvider({ serverLanguage: null, loggedIn: false })
 
@@ -117,6 +122,52 @@ test("picking a language while logged in saves it to the server once its bundle 
 	await waitFor(() => expect(requests).toHaveLength(1))
 	expect(requests[0][0]).toBe("/authorization/language")
 	expect(JSON.parse(requests[0][1].body)).toEqual({ language: "ja" })
+})
+
+test("a language picked on the login page survives the login instead of snapping back to the server's", async () => {
+	const { rerender } = renderWithProvider({ serverLanguage: null, loggedIn: false })
+	fireEvent.click(screen.getByTestId("language"))
+	await waitFor(() => expect(localStorage.getItem("language")).toBe("ja"))
+	expect(requests).toHaveLength(0)
+
+	rerender(React.createElement(LanguageProvider, { serverLanguage: "en", loggedIn: true },
+		React.createElement(Consumer)))
+
+	await waitFor(() => expect(requests).toHaveLength(1))
+	expect(JSON.parse(requests[0][1].body)).toEqual({ language: "ja" })
+	expect(screen.getByTestId("language").textContent).toBe("ja")
+	expect(localStorage.getItem("language")).toBe("ja")
+})
+
+test("a login-page pick is saved only once, so a later sign-out and sign-in does not resend it", async () => {
+	const { rerender } = renderWithProvider({ serverLanguage: null, loggedIn: false })
+	fireEvent.click(screen.getByTestId("language"))
+	const login = (loggedIn) => rerender(React.createElement(LanguageProvider,
+		{ serverLanguage: "ja", loggedIn }, React.createElement(Consumer)))
+
+	login(true)
+	await waitFor(() => expect(requests).toHaveLength(1))
+	login(false)
+	login(true)
+
+	await waitFor(() => expect(screen.getByTestId("language").textContent).toBe("ja"))
+	expect(requests).toHaveLength(1)
+})
+
+test("a login-page pick whose bundle fails to load does not block the server language", async () => {
+	const rejected = Promise.reject(new Error("chunk 404"))
+	rejected.catch(() => {})
+	loads["ru"] = rejected
+	picked = "ru"
+	const { rerender } = renderWithProvider({ serverLanguage: null, loggedIn: false })
+	fireEvent.click(screen.getByTestId("language"))
+	await waitFor(() => expect(screen.getByTestId("language").textContent).toBe("en"))
+
+	rerender(React.createElement(LanguageProvider, { serverLanguage: "ko", loggedIn: true },
+		React.createElement(Consumer)))
+
+	await waitFor(() => expect(screen.getByTestId("language").textContent).toBe("ko"))
+	expect(requests).toHaveLength(0)
 })
 
 test("logging in does not write the language the server just supplied back to it", async () => {
@@ -159,7 +210,7 @@ test("a locale chunk that lands after a newer language change leaves moment on t
 	let landHindi
 	loads["hi"] = new Promise((resolve) => { landHindi = resolve })
 		.then(() => { require("moment/locale/hi"); moment.locale("hi"); return [] })
-	Object.defineProperty(navigator, "languages", { value: ["hi"], configurable: true })
+	localStorage.setItem("language", "hi")
 
 	const { rerender } = renderWithProvider({ serverLanguage: null, loggedIn: false })
 	rerender(React.createElement(LanguageProvider, { serverLanguage: "en", loggedIn: true },

--- a/command/test/languagePicker.test.jsx
+++ b/command/test/languagePicker.test.jsx
@@ -35,8 +35,8 @@ beforeEach(() => {
 
 const flush = () => act(async () => {})
 
-const renderPicker = async (props) => {
-	const view = render(React.createElement(LanguageProvider, props, React.createElement(LanguagePicker)))
+const renderPicker = async (props, pickerProps) => {
+	const view = render(React.createElement(LanguageProvider, props, React.createElement(LanguagePicker, pickerProps)))
 	await flush()
 	return view
 }
@@ -80,4 +80,21 @@ test("picking an option pre-login applies it without calling the server", async 
 
 	expect(screen.getByRole("combobox").textContent).toBe(LANGUAGES["de"].label)
 	expect(requests).toHaveLength(0)
+})
+
+test("a collapsible picker hides the select behind Change language", async () => {
+	await renderPicker({ serverLanguage: null, loggedIn: false }, { collapsible: true })
+
+	expect(screen.queryByRole("combobox")).toBeNull()
+	expect(screen.getByRole("button", { name: "Change language" })).toBeTruthy()
+})
+
+test("Change language reveals the select, still on the default language", async () => {
+	await renderPicker({ serverLanguage: null, loggedIn: false }, { collapsible: true })
+
+	fireEvent.click(screen.getByRole("button", { name: "Change language" }))
+	await flush()
+
+	expect(screen.getByRole("combobox").textContent).toBe(LANGUAGES["en"].label)
+	expect(screen.queryByRole("button", { name: "Change language" })).toBeNull()
 })

--- a/command/test/loginForm.test.jsx
+++ b/command/test/loginForm.test.jsx
@@ -55,6 +55,17 @@ test("a server error code is resolved to its English wording", () => {
 	expect(screen.getByRole("alert").textContent).toBe("Too many attempts")
 })
 
+test("the language picker stays collapsed until Change language is clicked, which must not submit the form", () => {
+	const tryLogin = jest.fn()
+	render(React.createElement(LoginForm, { tryLogin }))
+	expect(screen.queryByRole("combobox")).toBeNull()
+
+	fireEvent.click(screen.getByText("Change language"))
+
+	expect(screen.getByRole("combobox")).toBeTruthy()
+	expect(tryLogin).not.toHaveBeenCalled()
+})
+
 test("submit does not trigger native page navigation", () => {
 	const tryLogin = jest.fn()
 	render(React.createElement(LoginForm, { tryLogin }))


### PR DESCRIPTION
Addresses https://github.com/jjjpanda/Chimera/pull/520#issuecomment-5260973571.

### 2. Language lost on login

A pre-login pick was applied locally, but never sent to the server: the `PUT /authorization/language` is gated on `loggedIn`. On login, this effect then overwrote the pick with the account's stored language — `'en'` for anyone who never opened Account Settings.

```js
useEffect(() => {
    if (!loggedIn) return
    setLanguage(resolveLanguage(serverLanguage) ?? "en")
}, [serverLanguage, loggedIn])
```

The value was destroyed, not stale, so a refresh could not recover it.

The `picked` ref now means "explicit choice, not yet saved". Two changes follow:

- the login effect does not overwrite an unsaved pick
- the apply effect re-runs on `loggedIn`, so the pick is saved when the session starts

The pick now survives login and persists to the account. With no pick, the server language still wins.

`rollback` also clears `picked`. If not, a locale chunk that fails pre-login blocks the server language on the next login.

### 1. Hidden behind a click, defaulted to English

`LanguagePicker` takes a `collapsible` prop. The login page shows a `Change language` link that reveals the select. Account Settings is unchanged. The link is `type="button"`, so it cannot submit the form.

`language.change` is added to all 11 locales.

**Browser detection is removed.** `detectLanguage()` read `navigator.languages`, so a Spanish browser got a Spanish login page. The login page is now always English. A prior choice in `localStorage` is still used — that is a choice, not a guess. This is the only change outside the login page; say so if you meant something narrower.

### Tests

Unit: the pick survives login and is saved; it is sent once only; a failed pre-login chunk does not block the server language; the picker stays collapsed; the link does not submit the form.

E2E: the login page starts in English with the picker hidden, even in an `es-ES` browser; a pre-login pick survives sign-in.

Full suite green — 1474 unit, 40 e2e, lint clean.
