### PR TITLE
Allow the language save during a forced password change

### DIFF
--- a/command/backend/routes/authorization.js
+++ b/command/backend/routes/authorization.js
@@ -2,7 +2,7 @@ var express = require("express")
 var { validateBody, auth, password, languages, timingSafeCompare, rateLimiter } = require("lib")
 const { requireAdmin, isCrossSite } = auth
 const { passwordCheck, login, pool, withTransaction, HttpError, COOKIE_SECURE, knownDevice } = require("./lib/auth.js")
-const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout"]
+const forcedChangeAllowed = ["/authorization/password", "/authorization/verify", "/authorization/logout", "/authorization/language"]
 const authorize = auth.createAuthorize(pool, { forcedChangeAllowed })
 const blockCrossSite = (req, res, next) => (isCrossSite(req) ? res.status(403).send({ error: "forbidden" }) : next())
 

--- a/command/test/authorization.test.js
+++ b/command/test/authorization.test.js
@@ -1657,5 +1657,17 @@ describe("Authorization Routes", () => {
 				.send({ password: "replacement-passphrase" })
 			expect(res.status).toBe(200)
 		})
+
+		test("allows the language route through", async () => {
+			mockedPool.query
+				.mockResolvedValueOnce({ rows: [{ role: "user", force_password_change: true, revoked: false }], rowCount: 1 })
+				.mockResolvedValueOnce({ rowCount: 1 })
+			const res = await supertest(app)
+				.put("/authorization/language")
+				.set("Cookie", `bearertoken=Bearer%20${token}`)
+				.send({ language: "fr" })
+			expect(res.status).toBe(200)
+			expect(mockedPool.query).toHaveBeenCalledWith("UPDATE auth SET language = $1 WHERE username = $2", ["fr", "bob"])
+		})
 	})
 })


### PR DESCRIPTION
Addresses the review comment on #520.

`forcedChangeAllowed` did not list `/authorization/language`, so `lib/utils/auth.js:105` answered 401 for the language PUT while `force_password_change` was set.

Failure path:
1. An admin creates a user, so `force_password_change` is TRUE.
2. The user picks a language in the login form picker (`LoginForm.jsx:64`). `picked.current` is set, but `loggedIn` is false, so no save runs.
3. The user signs in. `loggedIn` flips true and the effect in `LanguageContext.jsx:44` re-runs, so `saveLanguage` PUTs `/authorization/language`.
4. The route is not on the allowlist, so the backend answers 401.
5. `rollback()` toasts "could not save language" over the change-password screen, and the choice never reaches the account.

The route is now on the allowlist. It is an authenticated write of an allowlisted value to the caller's own row, so it does not weaken the forced-change gate. `/authorization/theme` is not added, because the theme control lives in `SideMenu`/`MobileMain`, which `AppInner` does not render while `forcePasswordChange` is set.

A regression test covers the language route in the existing forced-password-change block.