### PR TITLE
Add widget title bars and expand arrows

### DIFF
--- a/command/e2e/nav.spec.js
+++ b/command/e2e/nav.spec.js
@@ -24,7 +24,7 @@ test.describe("navigation", () => {
 	test("opens the objects page", async ({ page }) => {
 		await page.getByRole("button", { name: "Objects" }).click()
 		await expect(page).toHaveURL(/\/objects$/)
-		await expect(page.getByText("object detection")).toBeVisible()
+		await expect(page.getByText("Object Detection")).toBeVisible()
 	})
 
 	test("admin can open the user management page", async ({ page }) => {

--- a/command/frontend/app/ClipMaker.jsx
+++ b/command/frontend/app/ClipMaker.jsx
@@ -270,6 +270,7 @@ const ClipMakerMini = () => {
 
 	return (
 		<CameraGridMini
+			title={t("clip.title")}
 			slots={slots}
 			onActivate={() => navigate("/clip")}
 			activateLabel={t("clip.openClipMaker")}

--- a/command/frontend/app/ObjectDetections.jsx
+++ b/command/frontend/app/ObjectDetections.jsx
@@ -102,6 +102,7 @@ const ObjectDetectionsMini = () => {
 
 	return (
 		<CameraGridMini
+			title={t("detections.title")}
 			slots={slots}
 			onActivate={() => navigate("/objects")}
 			activateLabel={t("detections.openObjectDetections")}

--- a/command/frontend/app/StorageWidget.jsx
+++ b/command/frontend/app/StorageWidget.jsx
@@ -5,6 +5,7 @@ import useStorageUsage from "../hooks/useStorageUsage.js"
 import StorageBreakdown from "./StorageBreakdown.jsx"
 import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card"
 import { Button } from "../components/ui/button"
+import NavigateToRoute from "./NavigateToRoute.jsx"
 import formatBytes from "../js/formatBytes.js"
 import colors, { CHART_ACCENT } from "../js/colors.js"
 import { useRole } from "./AuthContext"
@@ -25,6 +26,7 @@ const StorageWidget = () => {
 		<Card className="h-full">
 			<CardHeader className="flex flex-row items-center justify-between pb-2">
 				<CardTitle className="text-sm font-medium">{t("storage.usageTitle")}</CardTitle>
+				<NavigateToRoute to="/stats" />
 			</CardHeader>
 			<CardContent className="flex flex-col gap-3">
 				{usage.cameras.length > 0 ? (

--- a/command/frontend/components/CameraGridMini.jsx
+++ b/command/frontend/components/CameraGridMini.jsx
@@ -1,13 +1,25 @@
 import React from "react"
-import { ImageOff } from "lucide-react"
+import { ImageOff, Maximize2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Card } from "./ui/card"
 
-const CameraGridMini = ({ slots, renderCell, cellLabel, onCellClick, centerIcon, onActivate, activateLabel }) => {
+const CameraGridMini = ({ slots, renderCell, cellLabel, onCellClick, centerIcon, onActivate, activateLabel, title }) => {
 	const { t } = useTranslation()
 
 	return (
 		<Card className="h-full overflow-hidden cursor-pointer select-none transition-shadow" onClick={onActivate}>
+			{title && (
+				<div className="flex h-9 items-center justify-between bg-surface-raised px-3">
+					<span className="text-sm font-medium text-primary">{title}</span>
+					<button
+						type="button"
+						onClick={(e) => { e.stopPropagation(); onActivate() }}
+						className="flex items-center justify-center size-7 rounded-md text-muted transition-colors hover:text-primary hover:bg-surface"
+					>
+						<Maximize2 className="size-4" />
+					</button>
+				</div>
+			)}
 			<div className="relative flex-1 grid grid-cols-2 grid-rows-2 gap-px bg-border min-h-0 h-full">
 				{slots.map((slot, i) => (
 					<div

--- a/command/frontend/locales/de.json
+++ b/command/frontend/locales/de.json
@@ -120,7 +120,7 @@
 		"switchToSingleCamera": "Zu Einzelkamera wechseln",
 		"timeRange": "Zeitraum",
 		"timeZoom": "Zeit-Zoom",
-		"title": "clip-ersteller",
+		"title": "Clip-Ersteller",
 		"trimEnd": "Ende zuschneiden",
 		"trimEndValue": "Ende {{value}}%",
 		"trimStart": "Start zuschneiden",
@@ -161,7 +161,7 @@
 		"scanResultFound_other": "Kamera {{camera}}: {{count}} Erkennungen",
 		"scanningCamera": "Kamera {{camera}} wird gescannt…",
 		"scrubDetections": "Erkennungen durchsuchen",
-		"title": "objekterkennung"
+		"title": "Objekterkennung"
 	},
 	"errors": {
 		"cannotDeleteLastAdmin": "Der letzte Administrator kann nicht gelöscht werden",

--- a/command/frontend/locales/en.json
+++ b/command/frontend/locales/en.json
@@ -120,7 +120,7 @@
 		"switchToSingleCamera": "Switch to single camera",
 		"timeRange": "Time Range",
 		"timeZoom": "Time Zoom",
-		"title": "clip maker",
+		"title": "Clip Maker",
 		"trimEnd": "Trim end",
 		"trimEndValue": "End {{value}}%",
 		"trimStart": "Trim start",
@@ -161,7 +161,7 @@
 		"scanResultFound_other": "Camera {{camera}}: {{count}} detections",
 		"scanningCamera": "Scanning camera {{camera}}…",
 		"scrubDetections": "Scrub detections",
-		"title": "object detection"
+		"title": "Object Detection"
 	},
 	"errors": {
 		"cannotDeleteLastAdmin": "Cannot delete the last admin",

--- a/command/frontend/locales/es.json
+++ b/command/frontend/locales/es.json
@@ -120,7 +120,7 @@
 		"switchToSingleCamera": "Cambiar a cámara única",
 		"timeRange": "Rango de tiempo",
 		"timeZoom": "Zoom de tiempo",
-		"title": "creador de clips",
+		"title": "Creador de Clips",
 		"trimEnd": "Recortar fin",
 		"trimEndValue": "Fin {{value}}%",
 		"trimStart": "Recortar inicio",
@@ -162,7 +162,7 @@
 		"scanResultFound_other": "Cámara {{camera}}: {{count}} detecciones",
 		"scanningCamera": "Escaneando cámara {{camera}}…",
 		"scrubDetections": "Desplazar detecciones",
-		"title": "detección de objetos"
+		"title": "Detección de Objetos"
 	},
 	"errors": {
 		"cannotDeleteLastAdmin": "No se puede eliminar el último administrador",

--- a/command/frontend/locales/fr.json
+++ b/command/frontend/locales/fr.json
@@ -120,7 +120,7 @@
 		"switchToSingleCamera": "Passer en mode caméra unique",
 		"timeRange": "Plage horaire",
 		"timeZoom": "Zoom temporel",
-		"title": "créateur de clips",
+		"title": "Créateur de Clips",
 		"trimEnd": "Rogner la fin",
 		"trimEndValue": "Fin {{value}} %",
 		"trimStart": "Rogner le début",
@@ -162,7 +162,7 @@
 		"scanResultFound_other": "Caméra {{camera}} : {{count}} détections",
 		"scanningCamera": "Analyse de la caméra {{camera}}…",
 		"scrubDetections": "Parcourir les détections",
-		"title": "détection d'objets"
+		"title": "Détection d'Objets"
 	},
 	"errors": {
 		"cannotDeleteLastAdmin": "Impossible de supprimer le dernier administrateur",

--- a/command/frontend/locales/pt-BR.json
+++ b/command/frontend/locales/pt-BR.json
@@ -120,7 +120,7 @@
 		"switchToSingleCamera": "Mudar para câmera única",
 		"timeRange": "Intervalo de Tempo",
 		"timeZoom": "Zoom de Tempo",
-		"title": "criador de clipes",
+		"title": "Criador de Clipes",
 		"trimEnd": "Aparar fim",
 		"trimEndValue": "Fim {{value}}%",
 		"trimStart": "Aparar início",
@@ -162,7 +162,7 @@
 		"scanResultFound_other": "Câmera {{camera}}: {{count}} detecções",
 		"scanningCamera": "Escaneando câmera {{camera}}…",
 		"scrubDetections": "Arrastar detecções",
-		"title": "detecção de objetos"
+		"title": "Detecção de Objetos"
 	},
 	"errors": {
 		"cannotDeleteLastAdmin": "Não é possível excluir o último admin",

--- a/command/frontend/locales/ru.json
+++ b/command/frontend/locales/ru.json
@@ -120,7 +120,7 @@
 		"switchToSingleCamera": "Переключиться на одну камеру",
 		"timeRange": "Диапазон времени",
 		"timeZoom": "Масштаб времени",
-		"title": "создание клипов",
+		"title": "Создание Клипов",
 		"trimEnd": "Обрезать конец",
 		"trimEndValue": "Конец {{value}}%",
 		"trimStart": "Обрезать начало",
@@ -163,7 +163,7 @@
 		"scanResultFound_other": "Камера {{camera}}: {{count}} обнаружения",
 		"scanningCamera": "Сканирование камеры {{camera}}…",
 		"scrubDetections": "Прокрутка обнаружений",
-		"title": "обнаружение объектов"
+		"title": "Обнаружение Объектов"
 	},
 	"errors": {
 		"cannotDeleteLastAdmin": "Невозможно удалить последнего администратора",


### PR DESCRIPTION
## Summary
- Add title bars with expand arrows (Maximize2 icon) to Object Detection and Clip Maker mini-mode widgets via CameraGridMini `title` prop
- Add expand arrow to Storage Usage widget header via NavigateToRoute
- Fix title casing across all locale files (en, de, es, fr, pt-BR, ru): "object detection" → "Object Detection", "clip maker" → "Clip Maker"
- Update e2e test assertion to match new casing

Before:

<img width="1280" height="839" alt="image" src="https://github.com/user-attachments/assets/ee1d5adf-8447-4e01-8be0-eb502d23b7f9" />

After:

<img width="1280" height="842" alt="image" src="https://github.com/user-attachments/assets/25588432-ba4a-4311-a97a-64b40b2278e6" />